### PR TITLE
feat: expand template system with backend layer, design principles, and style guides

### DIFF
--- a/INTERVIEW.md
+++ b/INTERVIEW.md
@@ -27,9 +27,11 @@ Which stack template applies to this project?
 
 - `stack/static-site.md` — generic static site (any framework)
 - `stack/astro.md` — Astro static site
-- `stack/python-lib.md` — Python library or CLI tool *(coming soon)*
-- `stack/react-spa.md` — React single-page application *(coming soon)*
-- `stack/fastapi.md` — FastAPI backend *(coming soon)*
+- `stack/python-lib.md` — Python library or CLI tool
+- `stack/flask.md` — Flask web application or API
+- `stack/fastapi.md` — FastAPI backend
+- `stack/react-spa.md` — React single-page application (TypeScript)
+- `stack/go-service.md` — Go service, API server, or CLI tool
 
 ---
 
@@ -109,8 +111,18 @@ Any deviations?
 
 ## Step 10 — Output format [REQUIRED]
 
-Which context file format should be generated?
+Which AI tool will use this context file?
 
-- `CLAUDE.md` — Claude / Claude Code
-- `.cursorrules` — Cursor
-- `AI_CONTEXT.md` — generic / other agent
+| Choice | Output file | Location | Format guide |
+|--------|-------------|----------|--------------|
+| Claude Code | `CLAUDE.md` | project root | `output/claude.md` |
+| Cursor | `.cursor/rules/project.mdc` | `.cursor/rules/` | `output/cursorrules.md` |
+| GitHub Copilot | `copilot-instructions.md` | `.github/` | `output/copilot.md` |
+| OpenAI Codex CLI | `AGENTS.md` | project root | `output/codex.md` |
+| Other / generic | `AI_CONTEXT.md` | project root | `output/generic.md` |
+
+Interop: `AGENTS.md` (Codex) is also read by Claude Code as a fallback.
+If the project uses both, generating `AGENTS.md` alone may be sufficient.
+
+Load the corresponding file in `output/` and apply its structure and
+formatting rules when rendering the final context file.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,10 @@
 
 SOLID-inspired composable project templates for LLM agents.
 
-Generate a `CLAUDE.md`, `.cursorrules`, or `AI_CONTEXT.md` for any project
-by combining reusable base templates with framework-specific stack templates —
-structured like object-oriented design, built for AI-augmented engineering.
-
----
-
-## Status
-
-Early design phase. Specification in progress.
+Generate a context file (`CLAUDE.md`, `AGENTS.md`, `.cursor/rules/project.mdc`,
+`copilot-instructions.md`, or `AI_CONTEXT.md`) for any project by combining
+reusable base templates with framework-specific stack templates — structured
+like object-oriented design, built for AI-augmented engineering.
 
 ---
 
@@ -27,12 +22,48 @@ repository provides a composable system inspired by SOLID principles:
 
 ---
 
+## Structure
+
+```
+base/          # cross-cutting — git, docs, quality (all projects)
+frontend/      # frontend layer — UX, CSS, SEO (UI projects only)
+backend/       # backend layer — config, HTTP, database, observability
+stack/         # concrete stacks — extend base + frontend or backend
+output/        # rendering rules per AI tool
+INTERVIEW.md   # agent-driven project setup interview
+SPEC.md        # design decisions and system architecture
+ROADMAP.md     # project status and planned work
+```
+
+---
+
+## Supported stacks
+
+| Template | Extends |
+|----------|---------|
+| `stack/static-site.md` | base |
+| `stack/astro.md` | static-site |
+| `stack/python-lib.md` | base |
+| `stack/flask.md` | python-lib |
+| `stack/fastapi.md` | python-lib |
+| `stack/react-spa.md` | base |
+| `stack/go-service.md` | base |
+
+## Supported agents
+
+| Agent | Output file | Format guide |
+|-------|-------------|--------------|
+| Claude Code | `CLAUDE.md` | `output/claude.md` |
+| Cursor | `.cursor/rules/project.mdc` | `output/cursorrules.md` |
+| GitHub Copilot | `.github/copilot-instructions.md` | `output/copilot.md` |
+| OpenAI Codex CLI | `AGENTS.md` | `output/codex.md` |
+| Generic / other | `AI_CONTEXT.md` | `output/generic.md` |
+
+---
+
 ## Roadmap
 
-- [ ] Base templates (git, ux, docs, quality)
-- [ ] Stack templates (static-site, astro, python-lib, react-spa)
-- [ ] Interview template (agent-driven project setup)
-- [ ] Agent output mapping (CLAUDE.md, .cursorrules, AI_CONTEXT.md)
+See `ROADMAP.md`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,82 @@
+# Roadmap
+
+Single source of truth for project status and planned work.
+See `SPEC.md` for design decisions and `README.md` for an overview.
+
+---
+
+## Phase 1 — Foundation
+
+- [x] `base/git.md` — committer identity, commits, branching, PR workflow, versioning
+- [x] `base/docs.md` — rule language, documentation standards, ADR, diagrams, docs-as-code
+- [x] `base/quality.md` — architecture, code style, security, testing
+- [x] `base/review.md` — peer review priority, MUST/SHOULD checklists
+- [x] `base/devsecops.md` — SAST, SCA, SBOM, secret detection, license compliance
+- [x] `base/release.md` — semver, version bump propagation, backward compat, cut-over
+- [x] `base/testing.md` — test pyramid, coverage thresholds, naming conventions
+- [x] `base/cicd.md` — pipeline stages, triggers, environments, IaC, deployment
+- [x] `base/containers.md` — Dockerfile, runtime security, resource limits, Kubernetes
+- [x] `frontend/ux.md` — UX principles, WCAG 2.1 AA, responsive breakpoints
+- [x] `frontend/quality.md` — CSS conventions, performance, SEO
+- [x] `stack/static-site.md` — generic static site (any generator)
+- [x] `stack/astro.md` — Astro islands, client directives (extends static-site)
+- [x] `INTERVIEW.md` — agent-driven project setup interview
+
+---
+
+## Phase 2 — Backend layer (from SE handbook)
+
+- [x] `backend/http.md` — enriched: URI design, headers, HATEOAS, auth, RFC 9457 errors
+- [x] `backend/observability.md` — enriched: log levels with examples, JSON format, rules
+- [x] `backend/api.md` — new: API-first, OpenAPI, versioning, deprecation headers, pagination
+- [x] `backend/monitoring.md` — new: key metrics, thresholds, alerts, dashboards, incidents
+- [x] `backend/caching.md` — new: cache-aside, keys, TTL, invalidation, resilience, stampede
+- [x] `backend/auth.md` — new: authn/authz, JWT, RBAC, sessions, API keys, token transport
+- [x] `backend/jobs.md` — new: idempotency, retry/backoff, DLQ, scheduling-as-code, observability
+- [x] `backend/concurrency.md` — new: when-to-use table, shared state, structured concurrency, pitfalls
+- [x] `backend/microservices.md` — new: boundaries, inter-service comms, saga, contract testing, observability
+
+---
+
+## Phase 3 — Frontend layer (from SE handbook)
+
+- [x] `frontend/ux.md` — enriched: design system principle, component-driven development
+- [x] `frontend/quality.md` — enriched: linting/formatting on save, no console warnings, Core Web Vitals
+
+---
+
+## Phase 4 — Stack expansion
+
+- [x] `stack/python-lib.md` — Python library / CLI (packaging, mypy, ruff, pytest, test naming)
+- [x] `stack/flask.md` — Flask web app (factory pattern, blueprints, migrations, test naming)
+- [x] `stack/fastapi.md` — FastAPI (async, Pydantic v2, DI, OpenAPI, test naming)
+- [x] `stack/react-spa.md` — React + TypeScript (components, state, RTL, a11y, Gherkin naming, E2E)
+- [x] `stack/go-service.md` — Go service / CLI (packages, interfaces, concurrency, test naming, k6)
+
+---
+
+## Phase 3 — Agent output coverage
+
+- [x] `output/claude.md` — Claude Code → `CLAUDE.md`
+- [x] `output/cursorrules.md` — Cursor → `.cursor/rules/project.mdc`
+- [x] `output/copilot.md` — GitHub Copilot → `.github/copilot-instructions.md`
+- [x] `output/codex.md` — OpenAI Codex CLI → `AGENTS.md`
+- [x] `output/generic.md` — fallback → `AI_CONTEXT.md`
+
+---
+
+## Phase 4 — Testing
+
+- [ ] Test end-to-end with Claude Code (`CLAUDE.md` output)
+- [ ] Test end-to-end with Cursor (`.mdc` output)
+- [ ] Test end-to-end with GitHub Copilot
+- [ ] Test end-to-end with OpenAI Codex CLI
+- [ ] Document agent-specific quirks and workarounds
+
+---
+
+## Phase 5 — Validation
+
+- [ ] Use the system on a real new project end-to-end
+- [ ] Use the system on a real refactoring project end-to-end
+- [ ] Refine templates based on gaps found during real use

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,13 +3,13 @@
 ## Goal
 
 A composable, inheritance-based template system that any LLM agent can use
-to generate a project context file (`CLAUDE.md`, `PROJECT.md`, `AI_CONTEXT.md`,
+to generate a project context file (`CLAUDE.md`, `AGENTS.md`, `AI_CONTEXT.md`,
 or equivalent) for any type of project — from a static portfolio to a Python
 SDK to a React SPA.
 
-Designed to be agent-agnostic: works with Claude, Cursor, Copilot Workspace,
-Gemini, or any agent that accepts a Markdown context file. Claude-specific
-conventions (e.g. `CLAUDE.md` naming) are configurable, not hardcoded.
+Designed to be agent-agnostic: works with Claude Code, Cursor, GitHub Copilot,
+OpenAI Codex CLI, or any agent that accepts a Markdown context file. The
+output filename is configurable, not hardcoded.
 
 Inspired by SOLID principles: each template has a single responsibility,
 is open for extension, and can be composed without modification.
@@ -18,80 +18,139 @@ is open for extension, and can be composed without modification.
 
 ## Core concepts
 
-### 1. Base templates (abstract)
+### 1. Base templates (abstract, cross-cutting)
 
-Reusable building blocks covering one concern each. Framework-agnostic.
-Never used directly — always composed into a profile.
-
-```
-templates/base/
-├── git.md         # Conventional commits, branching, PR workflow, versioning
-├── ux.md          # UX principles, WCAG 2.1 AA, browser support
-├── docs.md        # Documentation rule, README, PLAYBOOK, ONBOARDING
-└── quality.md     # CSS conventions, performance, SEO, architecture rules
-```
-
-### 2. Stack templates (concrete, extend base)
-
-Technology-specific rules that extend one or more base templates.
-Cover the stack, component model, and tooling for a specific framework.
+Reusable building blocks covering one concern each. Apply to every project
+regardless of stack. Never used directly — always composed into a higher layer.
 
 ```
-templates/stack/
-├── static-site.md    # extends base — generic static site concepts
-├── astro.md          # extends static-site — Astro islands, client directives
-├── react-spa.md      # extends base — React-specific rules
-└── python-lib.md     # extends base — Python packaging, testing, typing
+base/
+├── git.md         # Committer identity, commits, branching, PR workflow, versioning
+├── docs.md        # Rule language, documentation standards, ADR, diagrams, docs-as-code
+├── quality.md     # Architecture, code style, security, testing
+├── review.md      # Peer review priority, MUST/SHOULD checklists, deviation rules
+├── devsecops.md   # SAST, SCA, SBOM, secret detection, license compliance
+├── release.md     # Semver, version bump propagation, backward compat, cut-over
+├── testing.md     # Test pyramid, coverage thresholds, naming conventions
+├── cicd.md        # Pipeline stages, triggers, environments, IaC, deployment
+└── containers.md  # Dockerfile, runtime security, resource limits, Kubernetes
+```
+
+### 2. Frontend templates (abstract, frontend layer)
+
+Concerns that apply to all frontend projects but not to backend or library
+projects. Extend base templates. Never used directly by a project.
+
+```
+frontend/
+├── ux.md          # UX principles, WCAG 2.1 AA, responsive breakpoints
+└── quality.md     # CSS conventions, performance, SEO & analytics
+```
+
+### 3. Backend templates (abstract, backend layer)
+
+Concerns shared by all backend services but not by frontend or pure libraries.
+Extend base templates. Never used directly by a project.
+
+```
+backend/
+├── config.md        # env vars, secrets, fail-fast validation
+├── http.md          # URI design, methods, headers, HATEOAS, auth, errors
+├── api.md           # API-first, OpenAPI, versioning, deprecation, pagination
+├── database.md      # migrations, transactions, no raw SQL, connection pooling
+├── caching.md       # cache-aside, TTL, invalidation, resilience, stampede
+├── auth.md           # authn/authz, JWT, RBAC, sessions, API keys
+├── jobs.md           # background jobs, idempotency, retry, DLQ, scheduling
+├── concurrency.md    # threads vs. processes vs. async, shared state, structured concurrency
+├── microservices.md  # service boundaries, inter-service comms, saga, contract testing
+├── observability.md # log levels, log format, health check, error visibility
+├── monitoring.md    # key metrics, thresholds, alerts, dashboards, incidents
+└── quality.md       # layered architecture, security, performance, API stability
+```
+
+### 4. Stack templates (concrete)
+
+Technology-specific rules. Each stack declares which layers it depends on.
+
+```
+stack/
+├── static-site.md    # extends base + frontend — generic static site
+├── astro.md          # extends base + frontend + static-site
+├── react-spa.md      # extends base + frontend — React + TypeScript
+├── python-lib.md     # extends base — Python packaging, mypy, ruff, pytest
+├── flask.md          # extends base + backend + python-lib
+├── fastapi.md        # extends base + backend + python-lib
+└── go-service.md     # extends base + backend
 ```
 
 ### 3. Interview template (orchestrator)
 
-A single file Claude uses to ask the user the REQUIRED questions before
-generating `CLAUDE.md`. Questions are grouped by concern and reference
-the relevant base/stack templates.
+A single file any agent uses to ask the user the required questions before
+generating the output context file. Questions are grouped by concern and
+reference the relevant base/stack templates.
 
 ```
-templates/interview.md
+INTERVIEW.md
 ```
 
-### 4. Profile (output)
+### 4. Output format templates
 
-The generated context file for a specific project. The output filename
-depends on the target agent:
+Rendering rules for each supported AI tool. Describe structure, formatting
+constraints, and tone for that tool's context file format.
 
-| Agent             | Output file       |
-|-------------------|-------------------|
-| Claude / Claude Code | `CLAUDE.md`    |
-| Cursor            | `.cursorrules`    |
-| Generic / other   | `AI_CONTEXT.md`   |
+```
+output/
+├── claude.md         # Claude Code → CLAUDE.md
+├── cursorrules.md    # Cursor → .cursor/rules/project.mdc
+├── copilot.md        # GitHub Copilot → .github/copilot-instructions.md
+├── codex.md          # OpenAI Codex CLI → AGENTS.md
+└── generic.md        # fallback → AI_CONTEXT.md
+```
 
-Produced by the agent by combining interview answers + selected base
-templates + selected stack template.
+### 5. Profile (generated output)
+
+The context file generated for a specific project by combining interview
+answers + base templates + stack template + output format template.
+
+| Agent            | Output file                  | Location        |
+|------------------|------------------------------|-----------------|
+| Claude Code      | `CLAUDE.md`                  | project root    |
+| Cursor           | `.cursor/rules/project.mdc`  | `.cursor/rules/`|
+| GitHub Copilot   | `copilot-instructions.md`    | `.github/`      |
+| OpenAI Codex CLI | `AGENTS.md`                  | project root    |
+| Generic / other  | `AI_CONTEXT.md`              | project root    |
+
+Interop: `AGENTS.md` is also read by Claude Code as a fallback when no
+`CLAUDE.md` is present.
 
 ---
 
 ## Inheritance model
 
 ```
-base/git.md ─────────────────────────────┐
-base/ux.md ──────────────────────────────┤
-base/docs.md ────────────────────────────┤──► stack/static-site.md
-base/quality.md ─────────────────────────┘         │
-                                                    ▼
-                                         stack/astro.md
-                                                    │
-                                         + interview answers
-                                                    │
-                                                    ▼
-                                              CLAUDE.md
+base/git.md ────────────────────────────────────────────┐
+base/docs.md ───────────────────────────────────────────┤
+base/quality.md ────────────────────────────────────────┤
+                                                        ▼
+frontend/ux.md ─────────────────────────────► stack/static-site.md
+frontend/quality.md ────────────────────────►          │
+                                                        ▼
+                                             stack/astro.md
+                                                        │
+                                             + INTERVIEW.md answers
+                                                        │
+                                             + output/claude.md rules
+                                                        │
+                                                        ▼
+                                                   CLAUDE.md
 ```
 
 Rules:
 - A stack template MUST reference which base templates it depends on
 - A stack template MAY override a base rule — overrides must be explicit
 - A stack template MAY add new rules not present in the base
-- Claude assembles the final `CLAUDE.md` by merging base + stack +
-  interview answers, with stack overrides taking precedence
+- The agent assembles the final output by merging base defaults + stack
+  overrides + interview answers, then applies the output format template
 
 ---
 
@@ -100,21 +159,21 @@ Rules:
 Each base template section is tagged with a unique ID:
 
 ```markdown
-## Git conventions [ID: git-conventions]
+## Git conventions [ID: base-git]
 ...
 ```
 
 A stack template overrides a section by referencing its ID:
 
 ```markdown
-## Git conventions [OVERRIDE: git-conventions]
+## Git conventions [OVERRIDE: base-git]
 - Always test with `npm run dev` before committing  ← replaces base rule
 ```
 
 A stack template extends a section by referencing its ID:
 
 ```markdown
-## Git conventions [EXTEND: git-conventions]
+## Git conventions [EXTEND: base-git]
 - Do not commit `dist/` or `node_modules/`  ← added on top of base rules
 ```
 
@@ -135,61 +194,45 @@ The interview template groups questions by concern:
 [SERVICES]     Analytics, forms, third-party integrations
 [BROWSERS]     Supported browsers and versions
 [OVERRIDES]    Any base rules the user wants to change
+[OUTPUT]       Target AI tool and output file format
 ```
 
-Claude asks all REQUIRED questions before generating anything.
+The agent asks all REQUIRED questions before generating anything.
 DEFAULTED sections are pre-filled from the selected base + stack templates.
 
 ---
 
 ## How an agent uses the system
 
-1. User provides a stack template (e.g. `templates/stack/astro.md`)
+1. User provides `INTERVIEW.md` and a stack template (e.g. `stack/fastapi.md`)
 2. Agent reads the stack template, identifies its base dependencies
 3. Agent loads the referenced base templates
 4. Agent runs the interview (REQUIRED questions only)
 5. Agent merges: base defaults + stack overrides + interview answers
-6. Agent outputs a complete context file (`CLAUDE.md`, `.cursorrules`, etc.)
+6. Agent loads the output format template for the chosen AI tool
+7. Agent renders and outputs the final context file
 
 The interview instructions use neutral language ("ask the user") so any
-agent can follow them without Claude-specific interpretation.
+agent can follow them without tool-specific interpretation.
 
 ---
 
 ## File naming conventions
 
 ```
-base/[concern].md               # single responsibility
-stack/[framework].md            # concrete, extends one or more base templates
+base/[concern].md               # cross-cutting — applies to all projects
+frontend/[concern].md           # frontend layer — UI projects only
+backend/[concern].md            # backend layer — services and APIs only
+stack/[framework].md            # concrete — extends base + frontend or backend
 stack/[framework]-[variant].md  # variant of a framework (e.g. astro-ssr.md)
-interview.md                    # orchestrator — always one file
+output/[agent].md               # rendering rules for a specific AI tool
+INTERVIEW.md                    # orchestrator — always one file
 SPEC.md                         # this file
+ROADMAP.md                      # project status and planned work
 ```
 
 ---
 
 ## Roadmap
 
-### Phase 1 — Foundation (current)
-- [ ] Write `base/git.md`
-- [ ] Write `base/ux.md`
-- [ ] Write `base/docs.md`
-- [ ] Write `base/quality.md`
-- [ ] Write `stack/static-site.md`
-- [ ] Write `stack/astro.md`
-- [ ] Write `interview.md`
-- [ ] Delete `static-site.md` and `static-site-astro.md` (superseded)
-
-### Phase 2 — Expansion
-- [ ] `stack/python-lib.md`
-- [ ] `stack/react-spa.md`
-- [ ] `stack/fastapi.md`
-
-### Phase 3 — Agent coverage
-- [ ] Test with Cursor (`.cursorrules` output)
-- [ ] Test with a generic agent (`AI_CONTEXT.md` output)
-- [ ] Document agent-specific quirks and workarounds
-
-### Phase 4 — Validation
-- [ ] Use the system on a new project end-to-end
-- [ ] Refine based on gaps found during real use
+See `ROADMAP.md`.

--- a/backend/api.md
+++ b/backend/api.md
@@ -1,0 +1,74 @@
+# Backend — API Design
+[ID: backend-api]
+
+## API-first
+- Software MUST be designed API-first — define the contract before writing
+  implementation
+- Exceptions require a documented Architecture Decision Record (ADR)
+- API-first enables: multiple clients (web, mobile) sharing one contract,
+  headless testing, and API-as-a-product exposure
+
+## API types
+- REST — SHOULD be the default choice
+- gRPC — SHOULD be used for internal service-to-service communication where
+  performance is critical
+- GraphQL — COULD be used for frontend-facing APIs where flexible querying
+  is needed
+- Other types (SOAP, WebSockets) require a per-case ADR
+
+## OpenAPI specification
+- Every API MUST have an OpenAPI specification
+- The spec MUST be kept up to date — a stale spec is worse than no spec
+- Include: all resources, methods, parameters, response schemas, error responses,
+  and authentication requirements
+- Provide a changelog documenting API changes across versions
+
+## Versioning
+- APIs in a given version MUST maintain backward compatibility
+- Version the API in the URI path prefix: `/v1/`, `/v2/`
+- Start versioning from `v1`; introduce `v2` only when breaking changes are
+  unavoidable
+- Alternatively, use a custom request header: `Api-Version: 2`
+- MUST NOT use media type to control API versions
+
+## Backward compatibility
+Breaking changes require a new major version. A change is breaking when:
+- A field or object is removed or renamed in the response
+- A field type is changed
+- The authentication type changes
+- An HTTP verb or URI path changes
+- The protocol or Content-Type changes
+- Business logic or flow changes in a way that alters observable behaviour
+
+A change is **not** breaking when:
+- A new field or object is added to the response
+- A new path or HTTP verb is added
+- Additional optional query parameters are added
+
+## Deprecation strategy
+When a breaking change is introduced:
+
+1. Deploy the new version alongside the old one
+2. Add the `Deprecation` header to all responses from the old version:
+   `Deprecation: @1688169599` (Unix timestamp of when it became deprecated)
+3. Optionally add the `Sunset` header with the removal date:
+   `Sunset: Sat, 31 Dec 2025 23:59:59 GMT`
+4. Notify all consumers and agree on a migration timeline
+5. Remove the old version only after the sunset date has passed
+
+```
+Deprecation: @1688169599
+Sunset: Sat, 31 Dec 2025 23:59:59 GMT
+```
+
+## Statelessness
+- APIs MUST be stateless — no client context stored on the server between requests
+- All information needed to process a request MUST be in the request itself
+- Session state belongs in the client or a dedicated session store, not in the
+  API service
+
+## Pagination
+- Collection endpoints MUST be paginated — never return unbounded lists
+- Use `limit` and `offset` (or cursor-based) pagination
+- Include navigation links (`next`, `prev`) in the response per HATEOAS
+  (see `backend/http.md`)

--- a/backend/auth.md
+++ b/backend/auth.md
@@ -1,0 +1,96 @@
+# Backend — Authentication and Authorization
+[ID: backend-auth]
+
+Rules for identity verification (authn) and access control (authz).
+Applies to any backend service that has protected resources.
+
+---
+
+## General principles
+
+- Authentication (who are you?) and authorization (what can you do?) are
+  separate concerns — keep them in separate layers
+- Never implement your own cryptographic primitives — use well-audited libraries
+- Fail closed: deny access by default; grant explicitly
+- Centralise auth logic — no scattered permission checks across route handlers
+
+---
+
+## Authentication
+
+- Prefer delegating authentication to an identity provider (IdP) via
+  OAuth 2.0 / OIDC (e.g. Auth0, Keycloak, Cognito) over rolling your own
+- If issuing tokens directly, use short-lived JWTs (access token ≤ 15 minutes)
+  with a separate refresh token (≤ 7 days, rotated on use)
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens missing
+  any required claim
+- Store refresh tokens server-side (database or cache) so they can be revoked —
+  stateless refresh tokens cannot be invalidated before expiry
+- Never store passwords in plaintext — hash with bcrypt, scrypt, or Argon2id;
+  never MD5 or SHA-1
+- Enforce account lockout or exponential backoff after repeated failed logins
+
+---
+
+## Token transport
+
+- Access tokens MUST be sent in the `Authorization: Bearer <token>` header
+- Do NOT accept tokens in query parameters — they appear in server logs and
+  browser history
+- Refresh tokens MUST be stored in `httpOnly`, `Secure`, `SameSite=Strict`
+  cookies — never in `localStorage` or JavaScript-accessible memory
+- HTTPS required for all authenticated endpoints — no exceptions
+
+---
+
+## Authorization
+
+- Use role-based access control (RBAC) as the baseline:
+  assign permissions to roles, assign roles to users
+- For fine-grained needs, layer attribute-based access control (ABAC) on top
+  of RBAC — do not replace RBAC entirely
+- Authorise at the service layer, not only at the route layer:
+  a route that passes auth may call a service that operates on another user's data
+- Never trust client-supplied IDs for ownership checks — always verify that
+  the authenticated user owns or has access to the requested resource
+
+---
+
+## Session management (if using sessions instead of tokens)
+
+- Use cryptographically random session IDs (≥ 128 bits)
+- Regenerate session ID on privilege escalation (login, sudo-style elevation)
+- Set `httpOnly`, `Secure`, `SameSite=Strict` on session cookies
+- Expire idle sessions — do not keep sessions alive indefinitely
+
+---
+
+## API keys (service-to-service)
+
+- Issue API keys with the minimum required scope
+- Hash API keys before storing — treat them like passwords
+- Rotate API keys on a schedule and immediately on suspected compromise
+- Log every API key usage with the key ID (not the key value) and the
+  calling service identity
+
+---
+
+## Observability
+
+- Log authentication failures at WARN with IP, user agent, and username
+  (never the attempted password)
+- Log authorization failures at WARN with user ID, resource, and action
+- Alert on a spike in auth failures — may indicate a credential stuffing attack
+- Never log tokens, passwords, or secrets — even at DEBUG level
+
+---
+
+## Testing
+
+- Unit test permission logic with all role combinations including edge cases
+  (no role, multiple roles, deprecated role)
+- Integration test that protected endpoints return 401 for unauthenticated
+  requests and 403 for authenticated requests with insufficient permissions
+- Test token expiry: assert that an expired token is rejected
+- Test token revocation: assert that a revoked refresh token cannot obtain
+  a new access token

--- a/backend/caching.md
+++ b/backend/caching.md
@@ -1,0 +1,91 @@
+# Backend — Caching
+[ID: backend-caching]
+
+Cross-cutting caching rules for any backend service. Applies regardless of
+cache technology (Redis, Memcached, in-process).
+
+---
+
+## When to cache
+
+- Cache data that is expensive to compute or retrieve and changes infrequently
+- Do NOT cache data that MUST be real-time (e.g. account balances, stock levels)
+- Do NOT cache secrets, credentials, tokens, or PII — even temporarily
+- Prefer no cache over a stale cache for safety-critical or financial data
+
+---
+
+## Patterns
+
+- **Cache-aside (lazy loading)**: read from cache first; on miss, load from source,
+  populate cache, return result — default pattern for read-heavy workloads
+- **Write-through**: write to cache and source together on every update —
+  use when stale reads are unacceptable and write latency is acceptable
+- **Write-behind**: write to cache immediately, persist to source asynchronously —
+  avoid unless throughput requirements justify the added complexity and risk
+- Never cache at more than one layer for the same data — multiple caches
+  create inconsistency and make invalidation impossible to reason about
+
+---
+
+## Keys
+
+- Namespaced keys: `<service>:<entity>:<id>` — e.g. `users:profile:42`
+- Include a version segment when the cached schema changes:
+  `users:v2:profile:42`
+- Document the key schema — undocumented keys become orphaned entries
+- Never construct keys from unvalidated user input — risk of cache poisoning
+
+---
+
+## TTL and expiry
+
+- Every cached entry MUST have a TTL — no indefinite caching
+- Set TTL based on acceptable staleness, not convenience
+- Use shorter TTLs (seconds–minutes) for frequently changing data;
+  longer TTLs (hours–days) for reference data
+- Use cache tags or explicit invalidation for data that must expire on write,
+  not just on timeout
+
+---
+
+## Invalidation
+
+- Invalidate cache entries on write, not only on TTL expiry
+- Invalidation MUST be atomic with the write where consistency matters —
+  use transactional outbox or pub/sub if cache and DB are separate systems
+- Prefer targeted invalidation (`DEL users:profile:42`) over broad flush
+  (`FLUSHDB`) — a cache flush is an outage in disguise
+- Document which code path owns invalidation for each cache key
+
+---
+
+## Resilience
+
+- Cache failures MUST NOT crash the application — treat the cache as
+  an optional acceleration layer, not a required dependency
+- On cache miss or error, fall through to the source of truth
+- Use circuit breakers or timeouts on cache calls — a slow cache is
+  worse than no cache
+- Protect against cache stampede (thundering herd): use probabilistic early
+  expiry, a mutex/lock on population, or a background refresh
+
+---
+
+## Observability
+
+- Instrument cache hit rate, miss rate, and eviction rate
+- Alert if hit rate drops significantly below baseline — indicates
+  misconfigured TTL or an invalidation bug
+- Log cache errors at WARN level; log stampede events at INFO
+
+---
+
+## Testing
+
+- Integration tests MUST run against a real cache instance (e.g. Redis
+  in Docker) — do not mock the cache client in integration tests
+- Unit tests for cache key construction and TTL logic may use an in-memory
+  fake or mock
+- Test the fallback path: assert that a cache miss or error still returns
+  correct data from the source

--- a/backend/concurrency.md
+++ b/backend/concurrency.md
@@ -1,0 +1,81 @@
+# Backend — Concurrency
+[ID: backend-concurrency]
+
+Universal rules for multi-threading, multi-processing, and async I/O.
+Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+
+---
+
+## When to use what
+
+| Workload | Recommended model | Avoid |
+|---|---|---|
+| I/O-bound (network, disk, DB) | Async / non-blocking I/O or thread pool | Blocking the main thread |
+| CPU-bound (compute, encoding) | Separate processes | Threads in runtimes with a GIL |
+| Mixed I/O + CPU | Async for I/O, process pool for CPU | Single-threaded blocking |
+| True parallelism required | Language with native threading (e.g. Go) or multiprocessing | Green threads for CPU work |
+
+Default to async for I/O-bound services. Reach for processes only when
+CPU-bound work cannot be offloaded to a background job or worker process.
+
+---
+
+## Shared state
+
+- Avoid shared mutable state — prefer immutable data structures or
+  message passing (queues, channels)
+- If shared state is unavoidable, protect every access with a lock;
+  document which lock guards which data
+- Never hold a lock while performing I/O — risk of deadlock and contention
+- Prefer fine-grained locks over a single global lock
+
+---
+
+## Structured concurrency
+
+- Never start a thread, goroutine, or async task without a clear owner
+  and a clear shutdown path
+- Use structured concurrency primitives (e.g. `errgroup`, `asyncio.TaskGroup`,
+  `ExecutorService`) over fire-and-forget
+- Propagate cancellation explicitly — pass a cancellation token or context
+  as the first argument to any function that may block
+- On shutdown, cancel all in-flight work and wait for it to finish before
+  the process exits — do not rely on OS cleanup
+
+---
+
+## Pitfalls
+
+- **Deadlock**: two threads each waiting for a lock the other holds —
+  always acquire locks in a consistent order
+- **Livelock**: threads repeatedly yielding to each other without making
+  progress — add backoff or a tiebreaker
+- **Race condition**: outcome depends on scheduling order —
+  use a race detector during testing (e.g. `go test -race`, ThreadSanitizer)
+- **Starvation**: low-priority work never gets scheduled —
+  bound queue sizes and use fair scheduling where possible
+- **Thread-local state leakage**: in thread-pool or async contexts,
+  context (e.g. request ID, user identity) must be explicitly passed,
+  not stored in thread-locals
+
+---
+
+## Observability
+
+- Log the concurrency model in use at service startup (thread pool size,
+  event loop policy, worker count)
+- Track thread/goroutine/task count as a metric — an unbounded growth
+  indicates a leak
+- Alert on deadlock symptoms: requests timing out uniformly across all
+  endpoints with no error in logs
+
+---
+
+## Testing
+
+- Run tests with the race detector enabled in CI — do not rely on
+  code review alone to catch data races
+- Write stress tests for any code that shares state: run N goroutines /
+  threads concurrently and assert invariants hold
+- Test cancellation paths: assert that cancelling a context or token
+  terminates the operation promptly and cleans up resources

--- a/backend/config.md
+++ b/backend/config.md
@@ -1,0 +1,11 @@
+# Backend — Configuration
+[ID: backend-config]
+
+## Rules
+- All configuration from environment variables — no hardcoded values in source
+- Validate all required config at startup — fail fast if anything is missing
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in `.gitignore`
+- Separate configuration per environment (development, testing, production)
+- Pass config explicitly to components — no global config objects accessed
+  from arbitrary locations

--- a/backend/database.md
+++ b/backend/database.md
@@ -1,0 +1,21 @@
+# Backend — Database Conventions
+[ID: backend-database]
+
+## Schema changes
+- All schema changes via migrations — never edit the database manually
+- Migrations are committed to source control
+- Never regenerate or modify a migration that is already merged
+- One migration per logical change — do not batch unrelated schema changes
+
+## Queries
+- No raw SQL strings — use an ORM or query builder
+- Use parameterised queries if raw SQL is unavoidable — never string interpolation
+- No unbounded queries — always apply a limit or filter
+
+## Transactions
+- Wrap multi-step writes in a transaction — commit only after all writes succeed
+- Never leave a transaction open across an HTTP request boundary
+
+## Connections
+- Use a connection pool — never open a new connection per request
+- Inject the database session/connection as a dependency — no global DB handles

--- a/backend/http.md
+++ b/backend/http.md
@@ -1,0 +1,75 @@
+# Backend — HTTP Conventions
+[ID: backend-http]
+
+## Handler design
+- Handlers are thin: decode request → call service → encode response
+- No business logic in handlers — delegate to a service layer
+- Validate all incoming request data before processing
+
+## URI design
+- Use lowercase letters and hyphens to separate words — never underscores or camelCase
+- Use nouns, not verbs: `/orders`, not `/getOrders`
+- Use plural nouns for collections: `/orders`, `/products`
+- Use singular for individual resources beneath a collection: `/orders/{orderId}`
+- Use hierarchical paths for related resources: `/customers/{id}/orders`
+- A URI MUST NOT end with a trailing slash
+- Use American English — no abbreviations or acronyms in URIs
+
+## Query parameters
+- Use camelCase for query parameter names
+- Use query parameters for filtering, sorting, and pagination
+- Reserved names — do not use these for other purposes:
+  `limit`, `skip`, `offset`, `expand`, `sortedBy`
+
+## Request headers
+- Use Hyphenated-Pascal-Case for all HTTP headers: `Order-Metadata-Header`
+- Custom headers SHOULD NOT use the `X-` prefix (deprecated per RFC 6648)
+
+## HTTP methods
+| Method | Use for | Idempotent |
+|--------|---------|-----------|
+| GET | Retrieve a resource or collection — no side effects | Yes |
+| POST | Create a new resource — server assigns URI | No |
+| PUT | Replace a resource entirely | Yes |
+| PATCH | Partially update a resource | No |
+| DELETE | Remove a resource | Yes |
+
+## Resource representation
+- Use JSON as the default format; XML where explicitly required
+- Use ISO standards for field types:
+  - Dates/times: ISO 8601
+  - Languages: ISO 639
+  - Countries: ISO 3166-1 alpha-2
+  - Currencies: ISO 4217
+- Integers larger than 9007199254740992 (2^53) MUST be represented as strings
+  to avoid JavaScript floating-point precision loss
+- Include only necessary fields — keep response payloads small
+
+## HATEOAS
+- Embed hyperlinks in responses to enable resource discovery
+- Use a `links` array with `href`, `rel`, `type`, and `media` fields:
+  ```json
+  "links": [
+    {
+      "href": "documents/a12231e4-46ef-4adf-82e2-8a74fc017447",
+      "rel": "documents",
+      "type": "deliveryNote",
+      "media": "application/pdf"
+    }
+  ]
+  ```
+- Support at minimum: `self`, `next`, `prev` relations on paginated collections
+
+## Error responses
+- Use consistent error response shape across all endpoints
+- Follow RFC 9457 (`application/problem+json`) for error format
+- Use 4xx for client errors, 5xx for server errors — never use 200 for errors
+- Never return stack traces, internal paths, or implementation details to the client
+- Set explicit `Content-Type: application/json` on all JSON responses
+
+## Authentication and authorisation
+- MUST use HTTPS — never serve APIs over plain HTTP
+- Use token-based authentication with expiring access tokens (JWT)
+- External APIs MUST have both authentication and authorisation
+- Internal APIs SHOULD have at least authentication
+- Never expose unauthenticated write endpoints

--- a/backend/jobs.md
+++ b/backend/jobs.md
@@ -1,0 +1,80 @@
+# Backend — Background Jobs
+[ID: backend-jobs]
+
+Rules for background job processing, task queues, and scheduled work.
+Applies regardless of technology (Celery, asynq, Sidekiq, BullMQ, etc.).
+
+---
+
+## When to use background jobs
+
+- Offload any work that does not need to complete within the HTTP request cycle
+- Use jobs for: email delivery, report generation, image processing,
+  webhook fanout, long-running data imports
+- Do NOT use jobs for work that the caller needs the result of immediately —
+  use async/await or streaming instead
+- Do NOT use jobs to paper over a slow synchronous path — fix the root cause first
+
+---
+
+## Idempotency
+
+- Every job MUST be idempotent — safe to execute more than once with the
+  same input and produce the same outcome
+- Use a deduplication key (e.g. `job_id`, `event_id`) to detect and skip
+  duplicate executions
+- Design for at-least-once delivery — the queue may deliver a message more
+  than once, especially after a worker crash
+
+---
+
+## Retry and failure handling
+
+- All jobs MUST have a retry limit — infinite retries will fill the queue
+- Use exponential backoff with jitter between retries
+- After the retry limit is exhausted, move the job to a dead-letter queue (DLQ)
+  — never silently drop failed jobs
+- Alert on DLQ depth — a growing DLQ is a silent production incident
+- Log the job ID, attempt number, and error on every failure
+
+---
+
+## Separation of concerns
+
+- Job handlers MUST be thin — delegate all business logic to service functions
+- Service functions used by jobs SHOULD be the same ones used by HTTP handlers —
+  no parallel logic paths
+- No direct database access in job handlers — go through the service layer
+- No HTTP calls in job handlers unless the job's explicit purpose is an
+  outbound webhook
+
+---
+
+## Scheduling
+
+- Scheduled jobs (cron-style) MUST be defined in code, not configured manually
+  in the infrastructure — schedule-as-code
+- Document the expected frequency and maximum acceptable latency for each
+  scheduled job
+- Ensure only one instance of a scheduled job runs at a time —
+  use a distributed lock or a leader-election mechanism
+
+---
+
+## Observability
+
+- Emit a structured log entry at job start (INFO) and job completion (INFO)
+- Log failures at ERROR with full context (job type, ID, payload summary,
+  error message, stack trace)
+- Track job duration, queue depth, and failure rate as metrics
+- Alert if queue depth exceeds a threshold that indicates worker starvation
+
+---
+
+## Testing
+
+- Unit test the service function the job delegates to — not the job handler itself
+- Integration test at least the happy path end-to-end: enqueue → execute →
+  assert side effect
+- Test the retry path: assert that a transient failure triggers a retry
+- Test the DLQ path: assert that a permanent failure ends up in the DLQ

--- a/backend/microservices.md
+++ b/backend/microservices.md
@@ -1,0 +1,141 @@
+# Backend — Microservices
+[ID: backend-microservices]
+
+Rules for projects explicitly built as a microservices architecture.
+Do not apply this template to a monolith or a single-service project.
+
+---
+
+## When to use microservices
+
+- Start with a **modular monolith** — well-separated modules within a single
+  deployable unit; extract services only when you have a clear, proven reason
+- Valid reasons to extract a service: independent scaling requirement,
+  independent deployment cadence, different technology requirement,
+  organisational team boundary (Conway's Law)
+- Invalid reasons: "it feels cleaner", "microservices are modern",
+  premature optimisation — the operational cost is real and front-loaded
+- A system of two or three services is not microservices — it is a
+  distributed monolith waiting to happen; apply these rules only when
+  the architecture is intentionally service-oriented
+
+---
+
+## Service boundaries
+
+- Model service boundaries on **bounded contexts** (Domain-Driven Design) —
+  each service owns one cohesive domain concept end-to-end
+- A service owns its domain: its data, its logic, its API — no other service
+  reaches into its internals
+- Services MUST NOT share a database — shared databases create invisible
+  coupling and make independent deployment impossible
+- Shared libraries between services MUST contain only cross-cutting
+  infrastructure (logging, tracing, HTTP client config) — never domain logic
+- If two services frequently change together, they are probably one service
+
+---
+
+## Inter-service communication
+
+Choose the communication style based on the interaction type:
+
+| Interaction | Style | Example |
+|---|---|---|
+| Request needs an immediate response | Synchronous (REST or gRPC) | Auth check, price lookup |
+| Caller does not need to wait | Asynchronous (events/messages) | Order placed, user registered |
+| Streaming or bidirectional | gRPC streaming | Live feed, file upload |
+
+- Prefer **async messaging** for cross-service workflows — it decouples
+  availability and reduces cascade failures
+- For synchronous calls, always set a timeout and wrap with a Circuit Breaker
+  (see `backend/quality.md`)
+- Never chain more than two synchronous service calls in a single request path
+  — each hop multiplies latency and failure probability
+
+---
+
+## Data management
+
+- **Database per service** — each service has its own schema and storage;
+  no direct cross-service database access, ever
+- Accept **eventual consistency** — distributed data cannot be both consistent
+  and highly available at the same time (CAP theorem); design UX and business
+  logic around it
+- Duplicate read-only data across service boundaries via events rather than
+  joining across service databases
+- Use the **Outbox pattern** to guarantee that database writes and event
+  publishing are atomic (see `backend/quality.md`)
+
+---
+
+## Distributed transactions
+
+- Avoid distributed transactions (two-phase commit) — they are fragile and
+  do not compose with async systems
+- Use the **Saga pattern** for multi-service workflows that must maintain
+  consistency:
+  - **Choreography saga**: each service listens for events and reacts —
+    simple to implement, harder to trace; suitable for short workflows
+  - **Orchestration saga**: a dedicated orchestrator service drives the
+    workflow and issues compensating actions on failure — preferred for
+    complex or long-running workflows
+- Every saga step MUST have a defined **compensating action** (rollback
+  equivalent) — document it alongside the forward action
+
+---
+
+## API gateway
+
+- Expose a single entry point to external clients via an API gateway —
+  never expose internal service URLs directly
+- The gateway handles: routing, auth token validation, rate limiting,
+  TLS termination, and request logging
+- Do not put business logic in the gateway — it is infrastructure, not a service
+- Internal service-to-service calls bypass the gateway — use a service mesh
+  or direct calls with mutual TLS
+
+---
+
+## Service discovery
+
+- Use a service registry or platform-native discovery (Kubernetes DNS,
+  Consul, AWS Cloud Map) — never hardcode service URLs in configuration
+- Health checks MUST be implemented on every service (see
+  `backend/observability.md`) — the registry uses them to route traffic only
+  to healthy instances
+
+---
+
+## Contract testing
+
+- Define and test the contract between each producer and consumer using
+  **consumer-driven contract tests** (e.g. Pact)
+- The producer MUST NOT break a published contract without a versioned
+  migration path — a failing contract test blocks the producer's deployment
+- Contract tests run in CI on both the producer and the consumer side
+
+---
+
+## Backward compatibility
+
+- Treat every service API as a public API — apply the same versioning and
+  deprecation rules as `backend/api.md`
+- Use **tolerant reader** pattern: consumers ignore unknown fields; producers
+  never remove fields without a deprecation period
+- Add fields; never remove or rename them without a major version bump
+- Event schemas follow the same rules — a schema registry (e.g. Confluent
+  Schema Registry) SHOULD enforce compatibility on publish
+
+---
+
+## Observability
+
+- Distributed tracing is **mandatory** in a microservices system — every
+  service MUST propagate the `traceparent` header (see
+  `backend/observability.md`)
+- Aggregate logs from all services into a single platform — searching
+  across services by trace ID must be possible in under 30 seconds
+- Each service exposes its own metrics; a central dashboard correlates
+  them across service boundaries
+- Define an SLO for each public-facing service; alert on SLO burn rate,
+  not just on errors

--- a/backend/monitoring.md
+++ b/backend/monitoring.md
@@ -1,0 +1,54 @@
+# Backend — Monitoring
+[ID: backend-monitoring]
+
+## Key metrics
+Every service MUST monitor at minimum:
+
+| Metric | Why |
+|--------|-----|
+| CPU usage | Detect resource saturation and scaling needs |
+| Memory usage | Detect leaks and container limit violations |
+| Disk usage | Prevent storage exhaustion |
+| Response time (p50, p95, p99) | Detect latency degradation |
+| Error rate (4xx, 5xx) | Detect functional failures |
+| Throughput (requests/sec) | Detect traffic spikes and capacity limits |
+
+Add custom metrics for business-critical operations specific to the service
+(e.g. orders processed, jobs queued, messages consumed).
+
+## Thresholds and alerts
+- Set thresholds based on historical data and expected usage — not arbitrary values
+- MUST create alerts for all P1 and P2 scenarios before the service goes to production
+- If an incident occurs without a corresponding alert, an alert MUST be created
+  immediately after the incident is resolved to prevent recurrence
+- Alerts MUST be actionable — every alert must have a clear response procedure
+
+### Example thresholds
+- CPU > 80% sustained for 5 minutes → alert
+- Response time p95 > 3s for more than 100 requests in 5 minutes → alert
+- Disk usage > 80% sustained for 30 minutes → alert
+- Error rate > 1% sustained for 2 minutes → alert
+
+## Dashboards
+- Every service MUST have a service health dashboard
+- Dashboard MUST show at minimum: error rate, response time, throughput,
+  and resource usage
+- Dashboards MUST be defined as code — no manually created dashboards in
+  shared environments
+- Non-technical dashboards (business KPIs, MAU) are encouraged alongside
+  technical dashboards
+
+## Status page
+- Maintain a status page for user-facing services to communicate outages
+  and planned maintenance
+- The status page MUST be hosted outside the primary infrastructure — it
+  must remain available during an infrastructure incident
+- Update the status page manually during incidents — automation is not
+  recommended as it can mask or misreport the true state
+- Use the status page proactively to reduce duplicate incident reports from
+  affected users
+
+## Incident response
+- P1/P2 incidents MUST have a post-mortem documented after resolution
+- Post-mortem MUST include: timeline, root cause, impact, corrective actions
+- Corrective actions MUST be tracked to completion — not just documented

--- a/backend/observability.md
+++ b/backend/observability.md
@@ -1,0 +1,73 @@
+# Backend — Observability
+[ID: backend-observability]
+
+## Logging
+
+### Log levels
+Use the correct level — do not elevate debug information to INFO:
+
+| Level | When to use | Examples |
+|-------|-------------|---------|
+| FATAL | App cannot continue — imminent shutdown | Out of memory, missing critical dependency at startup, DB schema mismatch |
+| ERROR | Operation failed — normal flow disrupted | Failed DB write, file not found, unhandled exception in request handler |
+| WARN | Unexpected but recoverable — may lead to error | Low disk space, slow response, retry attempt, deprecated endpoint accessed |
+| INFO | Normal operation — confirm correct functioning | User logged in, service started, transaction committed, scheduled task started |
+| DEBUG | Technical detail for debugging — not for production | Query results, data mapping steps, connection established |
+| TRACE | Most verbose — step-by-step tracing, development only | Function parameters, pipeline steps, request/response payloads |
+
+- Default log level in all environments: **INFO**
+- DEBUG and TRACE MUST NOT be enabled in production by default
+- INFO MUST NOT contain debug or trace information — keep it operational
+
+### Log format
+- Use structured logging in all environments: JSON in production,
+  human-readable in development
+- Every log entry MUST include: timestamp, level, message, properties
+- Include a request ID in all log entries for a given request lifecycle
+- Minimum JSON structure:
+  ```json
+  {
+    "Timestamp": "2024-01-15T12:34:56.789Z",
+    "Level": "Information",
+    "MessageTemplate": "User ({userId}) logged in.",
+    "Message": "User (12345) logged in.",
+    "Properties": { "userId": 12345 }
+  }
+  ```
+
+### Rules
+- Log errors once — at the top of the call stack, not at every level
+- Never log sensitive data: passwords, tokens, API keys, PII
+- Client errors (4xx) — log at INFO
+- Server errors (5xx) — log at ERROR
+- All unhandled errors MUST be logged with enough context to reproduce the issue
+
+## Distributed tracing
+
+- Assign a unique **trace ID** to every inbound request at the service boundary
+- Propagate the trace ID in all outbound calls (HTTP headers, message queue
+  metadata) using the W3C `traceparent` header or OpenTelemetry context
+- Include the trace ID in every log entry for that request — use the same
+  field name across all services (`trace_id`)
+- Use OpenTelemetry as the instrumentation standard — avoid vendor-specific
+  SDKs in application code; export to the backend of choice (Jaeger, Tempo,
+  Datadog, etc.) via the OTel collector
+- Create spans for: inbound HTTP requests, outbound HTTP calls, DB queries,
+  cache operations, and background job execution
+- Span names MUST be low-cardinality — use route templates, not URLs with IDs
+  (e.g. `GET /users/{id}`, not `GET /users/42`)
+- Return the trace ID in error responses (`X-Trace-Id` header) so clients
+  can report it to support
+
+## Health check
+- Expose a health check endpoint: `/health` or `/healthz`
+- Return HTTP 200 when the service is ready to handle traffic
+- Return HTTP 503 when a critical dependency (DB, cache) is unavailable
+- Health check MUST NOT require authentication
+- Health check MUST be the first thing that passes before traffic is routed
+  to a new instance
+
+## Error visibility
+- Distinguish between client errors (4xx) and server errors (5xx) in logs
+- Include correlation/request IDs in error responses to enable log tracing
+- Never expose internal state, stack traces, or file paths in error responses

--- a/backend/quality.md
+++ b/backend/quality.md
@@ -1,0 +1,49 @@
+# Backend — Quality Attributes
+[ID: backend-quality]
+
+## Layered architecture
+- Enforce a strict handler → service → repository separation
+- No database access in handlers — always go through the service layer
+- No HTTP concerns in the service layer — services are framework-agnostic
+- Domain logic lives in the service layer, not in models or schemas
+
+## Design patterns
+
+Prefer these patterns for backend concerns:
+
+- **Repository** — abstract all data access behind a repository interface;
+  the service layer never constructs queries directly
+- **Service layer** — encapsulate business logic in stateless service objects;
+  one service per domain aggregate
+- **Unit of Work** — coordinate multiple repository operations in a single
+  transaction; commit or roll back as one atomic unit
+- **Factory / Factory Method** — centralise object construction, especially
+  for domain objects with complex invariants
+- **Strategy** — swap algorithms or business rules (pricing, validation,
+  export format) at runtime without modifying the caller
+- **Observer / Event** — decouple producers from consumers for domain events
+  (user registered, order placed); use an internal event bus or message queue
+- **Circuit Breaker** — wrap all outbound calls to external services;
+  fail fast and recover gracefully rather than cascading timeouts
+- **Outbox** — when publishing an event must be atomic with a DB write,
+  write to an outbox table in the same transaction and relay asynchronously
+- **CQRS** — separate read models from write models when query and command
+  requirements diverge significantly; do not apply by default
+
+## Security
+- Validate and sanitise all input at the boundary before passing it inward
+- Apply authentication and authorisation before any business logic executes
+- Set security headers on all responses (CORS, HSTS if applicable)
+- Rate-limit public endpoints — never expose unbounded write operations
+- Rotate secrets regularly; invalidate compromised tokens immediately
+
+## Performance
+- Prefer async I/O for network-bound operations
+- Cache only when there is a measured need — document cache invalidation strategy
+- Avoid N+1 queries — use eager loading or batch fetching
+- Set timeouts on all outbound calls (HTTP clients, DB queries)
+
+## API stability
+- Never remove or rename a field in a response without a deprecation period
+- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Document deprecated endpoints; set a removal date before retiring them

--- a/base/cicd.md
+++ b/base/cicd.md
@@ -1,0 +1,52 @@
+# Base — CI/CD and Delivery
+[ID: base-cicd]
+
+## Principle
+Every project MUST have an automated pipeline. No manual steps between a
+merged PR and a deployed artifact — humans approve, machines execute.
+
+## Pipeline stages
+A pipeline MUST include, in order:
+
+1. **Build** — compile or package the application
+2. **Lint / format check** — fail on style violations
+3. **Test** — run unit and integration tests; fail on any failure
+4. **Security scan** — SAST, secret detection, SCA (see `base/devsecops.md`)
+5. **Package** — build the deployable artifact (container image, binary, package)
+6. **Deploy to staging** — automated deployment to a staging/QA environment
+7. **DAST** — automated security scan against the running staging environment
+8. **Deploy to production** — triggered manually or on a release tag
+
+Each stage MUST fail fast — a failed stage stops the pipeline immediately.
+
+## Triggers
+- Every push to a feature branch: run stages 1–4
+- Every merge to `main`: run all stages through staging deployment
+- Every release tag: run full pipeline through production deployment
+
+## Environment separation
+- MUST maintain at least three environments: development, staging, production
+- Never test against production — staging MUST mirror production as closely
+  as possible
+- Environment-specific configuration injected via environment variables —
+  never baked into the artifact
+- Promote the same artifact through environments — never rebuild per environment
+
+## Infrastructure as code
+- All infrastructure MUST be defined in code (Terraform, Pulumi, etc.)
+- No manual changes to any environment — all changes go through the pipeline
+- IaC changes follow the same review process as application code
+- Destroy and recreate environments from IaC to verify correctness periodically
+
+## Deployment strategy
+- MUST support zero-downtime deployments — use rolling updates or blue/green
+- MUST have a documented and tested rollback procedure
+- Health check endpoint MUST return healthy before traffic is routed to a
+  new instance (see `backend/observability.md`)
+- Deploy small and often — large infrequent deployments increase risk
+
+## Pipeline as code
+- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline changes follow the same review process as application code
+- Shared pipeline logic MUST be extracted into reusable templates — never
+  copy-paste pipeline stages across repositories

--- a/base/containers.md
+++ b/base/containers.md
@@ -1,0 +1,49 @@
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+  (see `base/devsecops.md`)
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)

--- a/base/devsecops.md
+++ b/base/devsecops.md
@@ -1,0 +1,58 @@
+# Base — DevSecOps
+[ID: base-devsecops]
+
+## Principle
+Security is not a phase — it is part of every build, review, and release.
+Detect risks as early as possible in the development process.
+
+## SAST (Static Application Security Testing)
+- SAST MUST run in every CI pipeline
+- A failed SAST scan MUST fail the build — code with security issues cannot
+  be merged or deployed
+- Fix SAST findings before merging; document false positives explicitly
+
+## SCA (Software Composition Analysis)
+- All dependencies MUST be tracked for known vulnerabilities and license risks
+- SCA MUST run on every deployment to QA, staging, and production
+- A SBOM (Software Bill of Materials) MUST be generated per release
+- Dependencies with unacceptable licenses MUST NOT be merged
+
+## Secret detection
+- Secret detection MUST run in CI — commits containing credentials, tokens,
+  or API keys MUST be rejected
+- Never store sensitive information in source files, commit history, issue
+  trackers, or documentation tools
+- Secrets used at runtime MUST be stored in a secret vault — never in
+  environment files committed to the repository
+
+## License compliance
+- Before adding a dependency, verify its license is acceptable
+- Copyleft licenses (GPL, AGPL) require explicit approval before use
+- Document and justify any dependency with a non-standard or ambiguous license
+
+## DAST (Dynamic Application Security Testing)
+- DAST MUST run against the staging/QA environment after every deployment
+- Never run DAST against production
+- Automated DAST scans MUST complete before any production release
+- Critical findings MUST block the release and be treated as incidents
+- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+
+## IaC scanning (Infrastructure-as-Code)
+- All infrastructure code (Terraform, Dockerfiles, Helm charts, Kubernetes
+  manifests) MUST be scanned for security misconfigurations in CI
+- A failed IaC scan MUST fail the build — the same rule as SAST
+- Common issues to detect: overprivileged roles, exposed ports, unencrypted
+  storage, hardcoded values, use of `latest` image tags
+- IaC scan results MUST be reviewed in the same PR that introduces the change
+
+## Penetration testing
+- Schedule regular penetration testing by a qualified party
+- Critical findings (severity A) MUST be treated as incidents and resolved
+  immediately
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
+
+## Dependency hygiene
+- Keep dependencies up to date — unpatched dependencies are a security risk
+- Remove unused dependencies promptly
+- Prefer dependencies that are actively maintained and widely adopted

--- a/base/docs.md
+++ b/base/docs.md
@@ -1,6 +1,17 @@
 # Base — Documentation
 [ID: base-docs]
 
+## Rule language
+Use MUST / SHOULD / COULD to express the weight of every rule:
+
+| Word | Meaning |
+|------|---------|
+| MUST | Absolute requirement — no exceptions without explicit rationale |
+| MUST NOT | Absolute prohibition |
+| SHOULD | Recommended — deviations require justification |
+| SHOULD NOT | Not recommended — may be ignored with justification |
+| COULD | Optional — developer decides without further discussion |
+
 ## Single source of truth
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
@@ -8,26 +19,51 @@
 
 ## Standard documents
 
-| File                  | Purpose                                      |
-|-----------------------|----------------------------------------------|
-| `README.md`           | Project overview, structure, setup, commands |
-| `CLAUDE.md`           | AI agent context and project rules           |
-| `docs/ONBOARDING.md`  | Onboarding guide for new contributors        |
-| `docs/PLAYBOOK.md`    | Operational reference for common tasks       |
+| File | Purpose |
+|------|---------|
+| `README.md` | Project overview, structure, setup, commands |
+| `CLAUDE.md` | AI agent context and project rules |
+| `docs/ONBOARDING.md` | Onboarding guide for new contributors |
+| `docs/PLAYBOOK.md` | Operational reference for common tasks |
 
 ## Documentation rule
 Before every commit, update all relevant documentation:
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or
-  conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
-  change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
+
+## Decision logs
+- Significant architectural decisions MUST be recorded as Architecture Decision
+  Records (ADR) in `docs/decisions/`
+- Each ADR documents: context, decision, alternatives considered, consequences
+- ADRs are immutable once merged — create a new ADR to supersede an old one
+
+## Writing style
+- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write as little as necessary but as much as needed — documentation that goes
+  out of sync is worse than no documentation
+- Remove redundant, inconsistent, or outdated documentation promptly
+- Use full, grammatically correct sentences — enumerations are exempt
+
+## Diagrams and assets
+- Prefer text-based diagram formats: Mermaid for flowcharts, sequence diagrams,
+  and Gantt charts; Draw.io for complex visual diagrams
+- Commit all raw editable sources alongside rendered outputs
+- Do not use proprietary formats (Word, Illustrator, Affinity Designer)
+- Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+
+## Docs-as-code
+- Technical documentation lives in the repository alongside the code
+- Documentation follows the same review process as code
+- All documentation MUST be written in Markdown
 
 ## Output file by agent
 
-| Agent              | Context file      |
-|--------------------|-------------------|
-| Claude / Claude Code | `CLAUDE.md`     |
-| Cursor             | `.cursorrules`    |
-| Generic / other    | `AI_CONTEXT.md`   |
+| Agent | Context file |
+|-------|-------------|
+| Claude Code | `CLAUDE.md` |
+| Cursor | `.cursor/rules/project.mdc` |
+| GitHub Copilot | `.github/copilot-instructions.md` |
+| OpenAI Codex CLI | `AGENTS.md` |
+| Generic / other | `AI_CONTEXT.md` |

--- a/base/git.md
+++ b/base/git.md
@@ -1,16 +1,19 @@
 # Base — Git Conventions
 [ID: base-git]
 
+## Committer identity
+- Configure git with your full name and a consistent, professional email address
+- Do not use private or personal email addresses for work repositories
+- Identity must not change — git history and tooling depend on consistent authorship
+
 ## Commit messages
 - Use conventional commit prefixes:
   `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `style:`, `test:`
-- Keep the subject line under 72 characters
+- Keep the subject line under 80 characters
 - Use the imperative mood: "add feature" not "added feature"
 
 ## Branching
 - Always work on a branch — never commit directly to `main`
-- Exception: documentation-only changes (`docs/`, `README.md`, `CLAUDE.md`)
-  may go directly to `main`
 - Branch naming: `feat/description`, `fix/description`, `chore/description`,
   `docs/description`
 
@@ -27,10 +30,12 @@
   git checkout main && git pull
   ```
 
-## Versioning
-- Follows `vA.B.C.D` — A=major, B=minor, C=build, D=hotfix
-- No VERSION file — git tags only
-- Release process:
+## README
+- Every repository MUST contain a `README.md`
+- README must state: the purpose of the repository and a reference to the
+  `docs/` folder if it exists
+
+## Release process
   1. `git checkout -b chore/release-vA.B.C.D`
   2. `git commit --allow-empty -m "chore: release vA.B.C.D"`
   3. Push, open PR, merge
@@ -40,3 +45,5 @@
 ## General
 - Do not commit build output, secrets, or dependency directories
 - Do not commit generated files that can be reproduced by running a build command
+- Treat every repository as if it were public — no secrets, credentials, or
+  sensitive information in source files or history

--- a/base/quality.md
+++ b/base/quality.md
@@ -1,29 +1,84 @@
 # Base — Quality Attributes
 [ID: base-quality]
 
-## Content & architecture
+## Architecture
 - All editable content in a data directory — never hardcoded in components
 - Default to the simplest component type; only reach for heavier abstractions
   when genuinely needed
 - No dead code — remove unused components, styles, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
 
-## CSS
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
-- No hardcoded colour or spacing values — always use CSS custom properties
-  from `:root`
-- Consistent naming convention (e.g. BEM-like `.component-element`)
-- Maximum line length: 80 characters (exempt: prose strings, third-party URLs)
+## SOLID principles
 
-## Performance
-- Preload critical above-the-fold assets
-- Keep client-side JS minimal
-- Avoid unnecessary dependencies
+Apply SOLID at the class, module, and service level:
 
-## SEO & analytics
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Privacy-friendly analytics only — no consent banner required
-- No third-party tracking scripts without explicit user consent
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named `OrderExportStrategy`
+  communicates intent; a class named `OrderHelper` does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging → call the logger directly in the function
+  - Auth → explicit middleware or guard in the call chain
+  - Transactions → explicit context manager or decorator with visible call site
+  - Validation → explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+## Code style
+- Source files MUST use ASCII characters only; files MUST be UTF-8 encoded
+- MUST use LF line endings — never CRLF
+- Style SHOULD be enforced by a linter configured to run on save
+- Write code that requires no comments — if a comment is needed, the code
+  is not clear enough; refactor first
+- Add comments only where the intent cannot be expressed in code
+
+## Debug code
+
+- No debug statements in committed code: no `print()`, `console.log()`,
+  `fmt.Println()`, or equivalent used for debugging
+- No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
+- No commented-out code blocks — delete dead code; version control is the history
+- Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
+  gated behind a flag or environment variable, never on by default
 
 ## Security
 - Never hardcode secrets, API keys, or credentials in source files
@@ -35,3 +90,4 @@
 - Write tests for business logic and edge cases
 - Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
+- Tests MUST be runnable from CI without human intervention

--- a/base/release.md
+++ b/base/release.md
@@ -1,0 +1,45 @@
+# Base — Release Management
+[ID: base-release]
+
+## Versioning
+- All packages and services MUST follow semantic versioning (`MAJOR.MINOR.BUILD.PATCH`)
+- MAJOR — breaking changes
+- MINOR — new backward-compatible functionality
+- BUILD - increments that belong to the next release
+- PATCH — backward-compatible bug fixes
+
+## Version bump propagation
+When upgrading a dependency, the consuming package MUST bump its own version
+to the same level or higher:
+- Dependency bumps MINOR → consumer MUST bump at least MINOR (not just PATCH)
+- Dependency bumps MAJOR → consumer MUST bump MAJOR
+
+> Rationale: A patch bump implies a drop-in replacement. If a dependency
+> changed its minor version, the consumer is no longer a drop-in replacement
+> of its previous patch — failing to bump breaks downstream consumers.
+
+## Backward compatibility
+- APIs SHOULD remain backward compatible across minor and patch versions
+- Never remove or rename a field in a response without a deprecation period
+- Communicate breaking changes to all consumers before making them
+
+## Cut-over phases
+When a breaking change is unavoidable:
+
+1. Deploy the new version alongside the old one
+2. Notify all consumers that the old version is deprecated and set a removal date
+3. Allow consumers to migrate at their own pace within the deprecation window
+4. Remove the old version only after the window has closed
+
+```
+Server:   [--- v1 ---|--- v1 + v2 ---|--- v2 ---]
+Client A: [--- v1 ---|------ v2 -----]
+Client B: [--- v1 ----------|-------- v2 --------]
+```
+
+## Release gate
+- MUST: All automated tests (unit, integration, e2e) MUST be green on the
+  staging/QA environment before releasing to production
+- If tests are not green, DO NOT release to production
+- The team consuming a service is responsible for verifying the overall
+  system — not just the service under change

--- a/base/review.md
+++ b/base/review.md
@@ -1,0 +1,37 @@
+# Base — Peer Review
+[ID: base-review]
+
+## Principle
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+Apply the following order when reviewing, from most to least critical:
+
+1. **Security and compliance** — exploits, credentials in source, license violations
+2. **Correctness** — logic errors, edge cases, unhandled errors, race conditions
+3. **Readability** — code that is difficult to understand or follow
+4. **Guideline adherence** — inconsistencies with project conventions
+
+## MUST checklist
+- [ ] No secrets, credentials, or tokens in source code
+- [ ] All error paths handled — no unhandled exceptions or silent failures
+- [ ] Dependencies have an acceptable license
+- [ ] Critical flows are documented
+- [ ] Documentation is in sync with the code changes
+
+## SHOULD checklist
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — minimal abstraction, minimal dependencies
+
+## Deviations
+- If a SHOULD rule is not followed, the reason MUST be documented
+  (e.g., as a PR comment)
+- If a MUST rule is not followed, it MUST be escalated and explicitly approved
+  before merging

--- a/base/testing.md
+++ b/base/testing.md
@@ -1,0 +1,70 @@
+# Base — Testing
+[ID: base-testing]
+
+## Test pyramid
+Execute in this order — each layer builds on the one before:
+
+1. **Unit** — individual functions/methods in isolation
+2. **Integration** — multiple modules interacting
+3. **Load** — behaviour under concurrent and high-traffic conditions
+4. **Regression** — verify existing functionality after every change
+5. **Smoke** — quick check of the most critical paths after deployment
+6. **Acceptance** — manual verification of changed functionality in the target environment
+7. **E2E** — full system from UI to backend in an automated scenario
+
+## Unit tests
+- MUST cover all happy paths for functional requirements
+- SHOULD cover negative scenarios and edge cases
+- MUST cover at least 90% of new code
+- SHOULD cover at least 80% of the overall codebase
+- Overall coverage MUST NOT decrease over time
+- Tests MUST be runnable from CI without human intervention
+
+### Naming
+Backend: `UnitOfWork_StateUnderTest_ExpectedBehavior`
+```
+Sum_NegativeNumberAs1stParam_ExceptionThrown
+Sum_SimpleValues_Calculated
+```
+
+Frontend: Gherkin syntax (`Given / When / Then`)
+```
+Given the FAQ page is loaded
+  When the user is logged in
+    Then it renders all questions in the accordion
+```
+
+## Integration tests
+- MUST cover the happy path
+- SHOULD cover "only" scenarios — cases where behaviour is valid only under
+  specific conditions
+- SHOULD cover special/recurring issue scenarios
+
+## Load tests
+- MUST implement the happy path scenario
+- MUST define error tolerance thresholds
+- MUST monitor resource consumption (CPU, memory)
+- SHOULD monitor for behavioural deviations under load
+- SHOULD cover non-happy and edge case scenarios
+
+## Regression tests
+- MUST cover the happy case
+- SHOULD cover non-happy cases and edge cases
+- SHOULD run automatically after every change
+
+## Smoke tests
+- MUST cover the happy case
+- SHOULD cover the most critical non-happy cases
+- Scope is intentionally narrow — fast feedback only
+
+## E2E tests
+- MUST cover the happy case scenario
+- SHOULD cover non-happy cases and edge cases
+- COULD provide data-agnostic testing
+
+## General rules
+- Test behaviour, not implementation details
+- Do not mock at the wrong boundary — integration tests should use real
+  dependencies or contract-verified fakes, not hand-written mocks
+- Each test must be independent — no shared mutable state between tests
+- A failing test is a bug — treat it with the same priority as a production issue

--- a/frontend/quality.md
+++ b/frontend/quality.md
@@ -1,0 +1,55 @@
+# Frontend — Quality Attributes
+[ID: frontend-quality]
+
+## Design patterns
+
+Prefer these patterns for frontend concerns:
+
+- **Container / Presentational** — separate data-fetching and state logic
+  (container) from rendering (presentational); presentational components
+  receive only props, have no side effects, and are easy to test in isolation
+- **Custom Hook** — extract reusable stateful logic into a named hook
+  (`use[Name]`); hooks are the frontend equivalent of a service or strategy
+- **Compound Component** — expose a set of related sub-components that share
+  implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
+  prefer over deeply nested prop drilling
+- **Render Props / Slot** — pass render logic as a prop or slot to invert
+  control over what is rendered; use sparingly — prefer custom hooks where possible
+- **Observer** — subscribe to external state changes (store, event bus,
+  WebSocket) via a single subscription point; unsubscribe on component unmount
+- **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
+  behind a thin project-owned interface; never scatter SDK calls across components
+- **Optimistic Update** — apply the expected result of a mutation immediately
+  in the UI and roll back on failure; document the rollback path
+
+Avoid:
+- **Mediator / Event Bus** between components — use shared state or lifting
+  state up instead; an event bus between components creates invisible coupling
+
+## Linting and formatting
+- A linter MUST be configured for all JS/TS code
+- Linter and formatter SHOULD run on save in the IDE — never rely on CI
+  alone to catch style issues
+- No warnings or errors MUST appear in the browser console or test output
+  before a PR is merged — start every review on a clean slate
+- Lint error count SHOULD go down over time — never increase it
+
+## CSS
+- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No hardcoded colour or spacing values — always use CSS custom properties
+  from `:root` or design tokens
+- Consistent naming convention (e.g. BEM-like `.component-element`)
+- Maximum line length: 80 characters (exempt: prose strings, third-party URLs)
+
+## Performance
+- Preload critical above-the-fold assets
+- Keep client-side JS minimal — every dependency adds to bundle size
+- Avoid unnecessary dependencies
+- Defer non-critical scripts
+- Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
+
+## SEO & analytics
+- `robots.txt`, Open Graph, and Twitter Card meta tags required
+- Canonical URLs required
+- Privacy-friendly analytics only — no consent banner required
+- No third-party tracking scripts without explicit user consent

--- a/frontend/ux.md
+++ b/frontend/ux.md
@@ -1,5 +1,5 @@
-# Base — UX Principles
-[ID: base-ux]
+# Frontend — UX Principles
+[ID: frontend-ux]
 
 ## UX principles
 - Mobile-first — design for small screens first, enhance for larger ones
@@ -26,7 +26,16 @@
 - Mobile: max-width 768px
 - Small mobile: max-width 480px
 
+## Design system
+- Use a design system if one exists for the project — never design ad-hoc
+  components that duplicate established patterns
+- Design tokens (colours, spacing, typography, radii) MUST come from the
+  design system — never hardcode visual values
+- Component-driven development: build UI as a hierarchy of reusable,
+  self-contained components; avoid monolithic views
+- New components SHOULD be documented with usage examples before shipping
+
 ## Browser support
 - Default target: last 2 versions of Chrome, Firefox, Safari, and Edge
 - Progressive enhancement: graceful degradation for unsupported features
-- [OVERRIDE: base-ux-browsers] to specify a different support matrix
+- [OVERRIDE: frontend-ux-browsers] to specify a different support matrix

--- a/output/claude.md
+++ b/output/claude.md
@@ -1,0 +1,84 @@
+# Output Format — CLAUDE.md
+[ID: output-claude]
+
+Used by: Claude / Claude Code
+Output filename: `CLAUDE.md`
+Place in: project root
+
+---
+
+## Structure
+
+Render the composed content in this order:
+
+```
+# [Project Name]
+
+[One-sentence description from interview]
+
+---
+
+## Project identity
+[IDENTITY answers]
+
+---
+
+## Stack
+[Stack template — Stack section]
+
+## Architecture
+[Stack template — architecture/structure sections]
+
+---
+
+## Commands
+[Stack template — Commands section]
+
+---
+
+## Git conventions
+[base/git.md + any stack EXTEND/OVERRIDE]
+
+---
+
+## Code conventions
+[Stack template — conventions sections]
+
+---
+
+## Testing
+[Stack template — Testing section]
+
+---
+
+## Documentation
+[base/docs.md]
+
+---
+
+## Design
+[Interview DESIGN answers, if applicable]
+
+## Brand voice
+[Interview BRAND answers, if applicable]
+```
+
+---
+
+## Formatting rules
+
+- Use ATX headings (`##` for sections, `###` for subsections)
+- Use fenced code blocks with a language tag for all commands and code samples
+- Use bullet lists for rules; avoid prose paragraphs inside rule sections
+- Keep lines under 80 characters where possible
+- No HTML — Markdown only
+- Omit sections that are not applicable to the project (e.g. omit Design
+  and Brand for a backend service)
+
+---
+
+## Tone
+
+- Imperative and direct: "Use X", "Never do Y", "Always Z"
+- No explanatory prose unless a rule needs context to be followed correctly
+- Rules are instructions to the agent, not documentation for humans

--- a/output/codex.md
+++ b/output/codex.md
@@ -1,0 +1,102 @@
+# Output Format — OpenAI Codex CLI
+[ID: output-codex]
+
+Used by: OpenAI Codex CLI
+Output filename: `AGENTS.md`
+Place in: project root
+
+Interop note: Claude Code reads `AGENTS.md` as a fallback when no `CLAUDE.md`
+is present. If the project uses both Codex CLI and Claude Code, a single
+`AGENTS.md` can serve both — no separate `CLAUDE.md` needed unless
+Claude-specific rules are required.
+
+---
+
+## Structure
+
+```
+# [Project Name]
+
+[One-sentence description from interview]
+Owner: [owner from interview]
+
+---
+
+## Stack
+[Stack template — Stack section]
+
+## Project structure
+[Stack template — structure section]
+
+---
+
+## Commands
+[Stack template — Commands section]
+
+---
+
+## Code conventions
+[Stack template — conventions sections]
+
+## Git conventions
+[base/git.md + any stack EXTEND/OVERRIDE]
+
+## Testing
+[Stack template — Testing section]
+
+---
+
+## Security
+[base/quality.md — Security section]
+```
+
+---
+
+## Formatting rules
+
+- No required structure — Codex imposes no schema
+- Full Markdown is supported; use headings, bullets, and fenced code blocks
+- Include all sections relevant to the project — Codex benefits from complete context
+- Keep lines under 80 characters where possible
+- No HTML — plain Markdown only
+- No frontmatter required
+
+## What to include
+
+- Exact commands for building, testing, linting, and running the project
+- Code style and naming conventions
+- Security constraints (never hardcode secrets, input validation rules)
+- Git workflow conventions
+- Project structure overview
+
+## What to omit
+
+- Secrets, API keys, credentials — never in this file
+- UI/design/brand rules unless the project has a frontend
+- Lengthy rationale — Codex reads this as task context, not documentation
+
+---
+
+## Monorepo support (optional)
+
+Codex walks the directory tree from the project root to the current working
+directory, reading `AGENTS.md` at each level. For monorepos, add package-level
+`AGENTS.md` files with package-specific rules:
+
+```
+AGENTS.md              # root — shared conventions
+packages/
+  api/
+    AGENTS.md          # API-specific rules (extends root)
+  web/
+    AGENTS.md          # frontend-specific rules (extends root)
+```
+
+Package-level files should only contain rules that differ from or extend the root.
+
+---
+
+## Tone
+
+- Imperative and direct: "Use X", "Never do Y", "Always Z"
+- Include brief rationale only where a rule requires context to be followed correctly

--- a/output/copilot.md
+++ b/output/copilot.md
@@ -1,0 +1,82 @@
+# Output Format — GitHub Copilot
+[ID: output-copilot]
+
+Used by: GitHub Copilot Chat (VS Code, JetBrains, GitHub.com)
+Output filename: `copilot-instructions.md`
+Place in: `.github/` (project root)
+
+---
+
+## Structure
+
+```
+# [Project Name]
+
+[One-sentence description from interview]
+
+## Stack
+[Stack template — Stack section, condensed]
+
+## Code conventions
+[Stack template — conventions sections, condensed]
+
+## Git conventions
+[base/git.md + any stack EXTEND/OVERRIDE, condensed]
+
+## Testing
+[Stack template — Testing section, condensed]
+
+## Commands
+[Stack template — Commands section]
+```
+
+---
+
+## Formatting rules
+
+- Natural language is acceptable — Copilot handles prose well
+- Whitespace and blank lines are ignored by Copilot; use them freely for readability
+- Bullet lists preferred for rules; short prose acceptable for context
+- No HTML — plain Markdown only
+- No frontmatter required
+- Omit sections that have no rules applicable to this project
+- Keep the file concise — Copilot adds it to every Chat session
+
+---
+
+## What to include
+
+- Project purpose and stack (Copilot has no other project context by default)
+- Code style rules that differ from language defaults
+- Testing approach and required commands
+- Git conventions (commit style, branch naming)
+- Any terms, names, or patterns to avoid
+
+## What to omit
+
+- Secrets, API keys, credentials — never in this file
+- Information derivable from the code (e.g. listing every file)
+- UI/UX or brand rules — Copilot is a coding assistant, not a design tool
+- Lengthy rationale — state the rule, not the history behind it
+
+---
+
+## Path-specific instructions (optional)
+
+For rules that apply only to specific parts of the codebase, create additional
+files with an `applyTo` frontmatter field:
+
+```
+# .github/[concern].instructions.md
+---
+applyTo: "src/api/**"
+---
+[API-specific rules]
+```
+
+---
+
+## Tone
+
+- Direct and instructional: "Use X", "Always Y", "Never Z"
+- Short sentences — one rule per bullet point

--- a/output/cursorrules.md
+++ b/output/cursorrules.md
@@ -1,0 +1,96 @@
+# Output Format — Cursor
+[ID: output-cursor]
+
+Used by: Cursor IDE
+Output filename: `.cursor/rules/project.mdc`
+Place in: `.cursor/rules/` (project root)
+
+Note: `.cursorrules` (flat file, project root) is the legacy format and is
+deprecated. New projects should use `.mdc` files in `.cursor/rules/`.
+
+---
+
+## File format
+
+Each `.mdc` file requires a YAML frontmatter block followed by Markdown content.
+
+```
+---
+description: [one-line summary of what these rules cover]
+alwaysApply: true
+---
+
+[rules content]
+```
+
+### Frontmatter fields
+
+| Field | Values | Effect |
+|-------|--------|--------|
+| `alwaysApply` | `true` / `false` | If true, injected into every Cursor session |
+| `description` | string | Shown in the rules list; used for AI relevance matching |
+| `globs` | `"src/**/*.ts"` | Apply only when matching files are open (omit if `alwaysApply: true`) |
+
+For a general project context file, use `alwaysApply: true` and omit `globs`.
+For stack- or path-specific rules, set `alwaysApply: false` and define `globs`.
+
+---
+
+## Structure
+
+```
+---
+description: Project rules for [Project Name]
+alwaysApply: true
+---
+
+## Stack
+[Stack template — Stack section, condensed]
+
+## Project structure
+[Stack template — structure section, condensed]
+
+## Code conventions
+[Stack template — conventions sections]
+
+## Git conventions
+[base/git.md + any stack EXTEND/OVERRIDE, condensed]
+
+## Testing
+[Stack template — Testing section]
+
+## Commands
+[Stack template — Commands section]
+```
+
+---
+
+## Formatting rules
+
+- Keep content short — Cursor injects it into every prompt when `alwaysApply: true`
+- Short, direct bullet points — no prose paragraphs
+- Remove rationale and background — rules only
+- No nested lists beyond one level
+- No HTML — plain Markdown only
+- Omit sections with no applicable rules
+- Target total file length: under 150 lines
+
+---
+
+## Splitting rules (optional)
+
+For large projects, split into multiple `.mdc` files by concern:
+
+```
+.cursor/rules/
+  project.mdc       # alwaysApply: true — identity, stack, commands
+  conventions.mdc   # alwaysApply: true — code and git conventions
+  tests.mdc         # globs: "tests/**" — testing rules only
+```
+
+---
+
+## Tone
+
+- Terse and imperative: "Use X", "No Y", "Always Z"
+- No "you should" or "please" — direct commands only

--- a/output/generic.md
+++ b/output/generic.md
@@ -1,0 +1,91 @@
+# Output Format — AI_CONTEXT.md
+[ID: output-generic]
+
+Used by: any agent not covered by a specific format (Copilot Workspace,
+Gemini, custom agents, etc.)
+Output filename: `AI_CONTEXT.md`
+Place in: project root
+
+---
+
+## Structure
+
+Render the composed content with full section coverage. Prefer clarity and
+completeness over brevity — generic agents have no assumed knowledge of the
+project.
+
+```
+# [Project Name]
+
+[One-sentence description from interview]
+Owner: [owner from interview]
+Live URL / package: [URL or package name from interview]
+
+---
+
+## Stack
+[Stack template — Stack section]
+
+## Project structure
+[Stack template — structure section]
+
+## Architecture
+[Stack template — architecture sections]
+
+---
+
+## Commands
+[Stack template — Commands section]
+
+---
+
+## Code conventions
+[Stack template — conventions sections]
+
+## Git conventions
+[base/git.md + any stack EXTEND/OVERRIDE]
+
+## Testing
+[Stack template — Testing section]
+
+---
+
+## Documentation standards
+[base/docs.md]
+
+## Quality attributes
+[base/quality.md — relevant sections]
+
+---
+
+## Design
+[Interview DESIGN answers, if applicable]
+
+## Brand voice
+[Interview BRAND answers, if applicable]
+
+## Browser support
+[Interview BROWSERS answers, if applicable]
+
+## Third-party services
+[Interview SERVICES answers, if applicable]
+```
+
+---
+
+## Formatting rules
+
+- Use ATX headings (`##` for sections, `###` for subsections)
+- Use fenced code blocks with a language tag for all commands and code samples
+- Use bullet lists for rules
+- Include all sections — do not omit even if sparse; mark as "N/A" if empty
+- No HTML — Markdown only
+- Lines under 80 characters where possible
+
+---
+
+## Tone
+
+- Imperative and direct: "Use X", "Never do Y", "Always Z"
+- Include brief rationale where a rule might otherwise be ignored by an
+  unfamiliar agent (unlike CLAUDE.md, which assumes an opinionated agent)

--- a/stack/astro.md
+++ b/stack/astro.md
@@ -1,5 +1,5 @@
 # Stack — Astro (Static Site)
-[DEPENDS ON: base/git.md, base/ux.md, base/docs.md, base/quality.md, stack/static-site.md]
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, frontend/ux.md, frontend/quality.md, stack/static-site.md]
 
 Extends the static site stack with Astro-specific rules.
 
@@ -61,6 +61,16 @@ for Content Collections.
 - Use a single `IntersectionObserver` script in the base layout for
   `.reveal` → `.reveal.visible` transitions
 - Do not add per-component reveal scripts
+
+---
+
+## Code conventions
+
+- **ESLint** with `@typescript-eslint/recommended` for any `.ts` / `.tsx`
+  files — configured in `eslint.config.js`, run on save
+- **Prettier** owns all formatting — commit `.prettierrc`; no style debates
+  in code review
+- `.astro` files formatted with the official Prettier Astro plugin
 
 ---
 

--- a/stack/fastapi.md
+++ b/stack/fastapi.md
@@ -1,0 +1,165 @@
+# Stack — FastAPI Application
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, backend/config.md, backend/http.md, backend/database.md, backend/observability.md, backend/quality.md, backend/concurrency.md, stack/python-lib.md]
+
+Extends the Python library stack with FastAPI-specific rules. Covers async
+request handling, Pydantic schemas, dependency injection, OpenAPI, and
+deployment.
+
+---
+
+## Stack
+[OVERRIDE: python-lib-stack]
+
+- Language: Python 3.11+
+- Framework: FastAPI
+- Runtime: asyncio (async/await throughout)
+- Validation: Pydantic v2
+- Package manager: [pip / uv / poetry]
+- Linter: ruff
+- Formatter: ruff format
+- Type checker: mypy (strict mode)
+- Test runner: pytest + httpx (AsyncClient)
+- ASGI server (production): uvicorn + gunicorn
+- Distribution: Docker image / [platform]
+
+---
+
+## Project structure
+[OVERRIDE: python-lib-structure]
+
+```
+src/
+  [app_name]/
+    __init__.py
+    main.py              # FastAPI app instance, lifespan, router includes
+    config.py            # Settings via pydantic-settings
+    dependencies.py      # Shared FastAPI dependencies
+    routers/
+      [feature].py       # APIRouter per feature domain
+    schemas/
+      [feature].py       # Pydantic request/response models
+    services/
+      [feature].py       # Business logic (pure, async)
+    models/              # ORM models (if using SQLAlchemy)
+    db.py                # Database session / engine setup
+tests/
+  conftest.py            # async client fixture
+  test_[feature].py
+pyproject.toml
+.env.example
+Dockerfile
+README.md
+CLAUDE.md
+```
+
+---
+
+## Application setup
+[ID: fastapi-app]
+
+- One `FastAPI` instance in `main.py` — no global state elsewhere
+- Use `lifespan` context manager for startup/shutdown (not deprecated events)
+- Include all routers via `app.include_router()` in `main.py`
+- Set `title`, `version`, and `description` on the app instance
+
+---
+
+## Configuration
+[EXTEND: backend-config]
+
+- Use `pydantic-settings` (`BaseSettings`) for all configuration
+- `Settings` instantiated once and injected as a dependency — never imported globally
+
+---
+
+## Routing and dependencies
+[ID: fastapi-routing]
+
+- One `APIRouter` per feature domain with a prefix and tags
+- Routes thin — delegate business logic to service functions
+- Shared logic (auth, DB session, current user) via `Depends()`
+- Use `Annotated` for dependency injection — avoid bare `= Depends()` in signatures
+- Return type annotations on all route functions (FastAPI uses these for OpenAPI)
+
+---
+
+## Schemas
+[ID: fastapi-schemas]
+
+- Separate request and response schemas — never reuse ORM models as responses
+- Use `model_config = ConfigDict(from_attributes=True)` for ORM-backed responses
+- All fields explicitly typed — no bare `Any`
+- Use `Field(...)` for validation constraints (min/max length, regex, ge/le)
+- Validators via `@field_validator` — no custom `__init__`
+
+---
+
+## Async conventions
+[EXTEND: backend-concurrency]
+
+- All route handlers and service functions `async def`
+- Blocking I/O (file reads, sync DB calls) must run in `asyncio.to_thread()`
+- Never `await` inside a list comprehension — use `asyncio.gather()` for concurrency
+- Use `asyncpg` or `aiosqlite` for async database drivers
+
+---
+
+## Error handling
+[EXTEND: backend-http]
+
+- Raise `HTTPException` with explicit `status_code` and `detail`
+- Register custom exception handlers in `main.py` for domain exceptions
+
+---
+
+## Database (if applicable)
+[EXTEND: backend-database]
+
+- SQLAlchemy 2.x with async engine (`create_async_engine`)
+- Session injected per request via `Depends(get_db)` — never a global session
+- Migrations managed by Alembic
+- Use `select()` style queries — no legacy `Query` API
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient` (sync)
+- One async `client` fixture in `conftest.py`
+- Test each route for: success (2xx), validation error (422), auth error (401/403)
+- No mocking of the database in integration tests — use a test database
+- Override dependencies with `app.dependency_overrides` in tests
+- Name tests using the pattern: `test_<route_or_function>_<state>_<expected>`
+  e.g. `test_create_item_invalid_payload_returns_422`
+- Unit tests in `tests/unit/`, integration tests in `tests/integration/`
+- Run before every commit: `pytest && mypy src/ --strict`
+
+---
+
+## OpenAPI
+[ID: fastapi-openapi]
+
+- All routes have `summary`, `tags`, and explicit `response_model`
+- Disable OpenAPI in production if the API is not public: `openapi_url=None`
+- Keep schema clean — avoid `include_in_schema=False` as a crutch
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`
+- Alembic migrations are committed — never regenerate a migration already merged
+
+---
+
+## Commands
+```
+uvicorn app.main:app --reload      # develop — hot reload at localhost:8000
+alembic upgrade head               # apply migrations
+alembic revision --autogenerate -m "..."  # generate a migration
+pytest                             # run tests
+mypy src/ --strict                 # type check
+gunicorn app.main:app -w 4 -k uvicorn.workers.UvicornWorker  # production
+```

--- a/stack/flask.md
+++ b/stack/flask.md
@@ -1,0 +1,126 @@
+# Stack — Flask Web Application
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, backend/config.md, backend/http.md, backend/database.md, backend/observability.md, backend/quality.md, stack/python-lib.md]
+
+Extends the Python library stack with Flask-specific rules for web
+applications and APIs. Covers application factory, blueprints, config,
+extensions, and deployment.
+
+---
+
+## Stack
+[OVERRIDE: python-lib-stack]
+
+- Language: Python 3.11+
+- Framework: Flask
+- Package manager: [pip / uv / poetry]
+- Linter: ruff
+- Formatter: ruff format
+- Type checker: mypy (strict mode)
+- Test runner: pytest + pytest-flask
+- WSGI server (production): gunicorn
+- Distribution: Docker image / [platform]
+
+---
+
+## Project structure
+[OVERRIDE: python-lib-structure]
+
+```
+src/
+  [app_name]/
+    __init__.py          # application factory (create_app)
+    config.py            # Config classes (Dev, Test, Prod)
+    extensions.py        # extension instances (db, login_manager, etc.)
+    blueprints/
+      [feature]/
+        __init__.py
+        routes.py
+        models.py
+        schemas.py
+    templates/           # Jinja2 templates (if serving HTML)
+    static/              # static assets (if serving directly)
+tests/
+  conftest.py            # app fixture, test client
+  test_[feature].py
+pyproject.toml
+.env.example             # committed — never .env
+Dockerfile
+README.md
+CLAUDE.md
+```
+
+---
+
+## Application factory
+[ID: flask-factory]
+
+- Always use the application factory pattern (`create_app(config=None)`)
+- Never use the global `app` object outside of `create_app`
+- Register all blueprints and extensions inside `create_app`
+- Extensions instantiated in `extensions.py`, initialised with `ext.init_app(app)`
+
+---
+
+## Configuration
+[EXTEND: backend-config]
+
+- Three config classes: `DevelopmentConfig`, `TestingConfig`, `ProductionConfig`
+- `FLASK_ENV` / `FLASK_DEBUG` must be `False` in production
+
+---
+
+## Blueprints
+[ID: flask-blueprints]
+
+- One blueprint per feature domain (e.g. `auth`, `api`, `admin`)
+- Blueprint registered with a URL prefix (`/api/v1`, `/auth`, etc.)
+- No cross-blueprint imports — shared logic goes in a service module
+- Routes thin — business logic delegated to service functions, not in route handlers
+
+---
+
+## Request / response
+[EXTEND: backend-http]
+
+- Use `abort()` with HTTP status codes rather than raising raw exceptions
+
+---
+
+## Database (if applicable)
+[EXTEND: backend-database]
+
+- Use Flask-SQLAlchemy or SQLAlchemy Core — no raw SQL strings
+- Migrations managed by Flask-Migrate (Alembic)
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- `pytest-flask` for the test client and app fixture
+- One `app` fixture in `conftest.py` — uses `TestingConfig`
+- Test each route for: success, validation error, auth error (if applicable)
+- No mocking of the database in integration tests — use a test database
+- Name tests using the pattern: `test_<route_or_function>_<state>_<expected>`
+  e.g. `test_create_user_duplicate_email_returns_409`
+- Unit tests in `tests/unit/`, integration tests in `tests/integration/`
+- Run before every commit: `pytest && mypy src/ --strict`
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit `.env`, `instance/`, `*.db`, `__pycache__/`, `.mypy_cache/`
+- Migrations are committed — never regenerate a migration that is already merged
+
+---
+
+## Commands
+```
+flask run                  # develop — hot reload
+flask db upgrade           # apply migrations
+flask db migrate -m "..."  # generate a migration
+pytest                     # run tests
+gunicorn "app:create_app()" # production server
+```

--- a/stack/go-service.md
+++ b/stack/go-service.md
@@ -1,0 +1,158 @@
+# Stack — Go Service / CLI
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, backend/config.md, backend/http.md, backend/database.md, backend/observability.md, backend/quality.md, backend/concurrency.md]
+
+A Go service, API server, or CLI tool. Covers package design, error handling,
+interfaces, concurrency, testing, and tooling.
+
+---
+
+## Stack
+[ID: go-service-stack]
+
+- Language: Go 1.22+
+- HTTP router: [net/http (stdlib) / chi / gin / echo]
+- Database: [database/sql + pgx / sqlc / GORM]
+- CLI framework: [cobra / flag (stdlib)]
+- Config: [viper / env / godotenv]
+- Test runner: go test (stdlib)
+- Containerisation: Docker
+- Distribution: [binary / Docker image / GitHub Releases]
+
+---
+
+## Project structure
+[ID: go-service-structure]
+
+Standard layout for a service with one binary:
+
+```
+cmd/
+  [service]/
+    main.go              # entry point — wires dependencies, starts server
+internal/
+  [feature]/
+    handler.go           # HTTP handlers (thin)
+    service.go           # business logic
+    repository.go        # data access
+    model.go             # domain types
+  config/
+    config.go
+  server/
+    server.go            # HTTP server setup, middleware, routing
+pkg/                     # code safe to import by external packages (if any)
+migrations/              # SQL migration files
+Dockerfile
+Makefile
+go.mod
+go.sum
+README.md
+CLAUDE.md
+```
+
+- `internal/` enforces encapsulation — external packages cannot import it
+- `cmd/` is thin — no business logic, only wiring
+- No `utils/` or `helpers/` packages — name packages by domain
+
+---
+
+## Package and interface design
+[ID: go-service-packages]
+
+- Small, focused packages — one domain concern per package
+- Define interfaces where the caller, not the implementer, owns them
+- Keep interfaces small: prefer 1–3 methods
+- Accept interfaces, return concrete types (in most cases)
+- Avoid package-level `init()` — use explicit initialisation in `main`
+
+---
+
+## Error handling
+[ID: go-service-errors]
+
+- Always handle errors — never `_` discard an error return
+- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
+- Use `errors.Is()` and `errors.As()` for inspection — never string matching
+- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
+  that owns the concept
+- Log errors once — at the top of the call stack, not at every level
+
+---
+
+## HTTP handlers (if applicable)
+[EXTEND: backend-http]
+
+- Decode request body explicitly — never trust unvalidated input
+- Use `http.Error()` or a JSON encoder for all error responses
+
+---
+
+## Configuration
+[EXTEND: backend-config]
+
+- Use a `Config` struct loaded at startup; pass it explicitly, do not use globals
+
+---
+
+## Concurrency
+[EXTEND: backend-concurrency]
+
+- Do not share memory by communicating — communicate by sharing memory sparingly
+- Protect shared state with `sync.Mutex` or `sync.RWMutex`; document which
+  fields are guarded and by which lock
+- Always use `context.Context` as the first argument in functions that may block
+- Cancel contexts and clean up goroutines on shutdown — use `errgroup` for
+  structured concurrency
+- Never start a goroutine without a clear owner and a clear way to stop it
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- Use stdlib `testing` package — no third-party assertion libraries
+- Table-driven tests with `t.Run()` for parameterised cases
+- Test the public API of each package — not unexported functions
+- Use interfaces to inject dependencies in tests — no monkey-patching
+- Integration tests in `internal/[feature]/*_integration_test.go` behind
+  a build tag: `//go:build integration`
+- Name test functions: `TestUnitOfWork_StateUnderTest_ExpectedBehavior`
+  e.g. `TestCreateUser_DuplicateEmail_ReturnsConflictError`
+- Load tests written with k6 — colocated in `loadtest/` at project root
+- Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Code quality
+[EXTEND: base-quality]
+
+- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
+  design decisions — the canonical Go style reference
+- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
+  for common pitfalls and reviewer expectations
+- `gofmt` / `goimports` — code must be formatted; CI will reject unformatted code
+- Run `go vet ./...` — fix all warnings before committing
+- Run `staticcheck ./...` for additional static analysis
+- No unused imports or variables — the compiler rejects these
+- Exported symbols must have a doc comment
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless vendoring intentionally)
+- `go.sum` is committed — do not delete or regenerate without cause
+- Tag releases with `vX.Y.Z` — Go module proxy uses these
+
+---
+
+## Commands
+```
+go run ./cmd/[service]    # develop
+go build ./cmd/[service]  # build binary
+go test ./...             # run all tests
+go vet ./...              # static analysis
+goimports -w .            # format imports
+make migrate-up           # apply DB migrations (if using Makefile)
+docker build -t [name] .  # build container image
+```

--- a/stack/python-lib.md
+++ b/stack/python-lib.md
@@ -1,0 +1,112 @@
+# Stack — Python Library / CLI
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md]
+
+A Python library, CLI tool, or shared package intended to be imported or
+installed. No web server, no frontend. May be published to PyPI.
+
+---
+
+## Stack
+[ID: python-lib-stack]
+
+- Language: Python 3.11+
+- Package manager: [pip / uv / poetry]
+- Build backend: [hatchling / setuptools / flit]
+- Linter: ruff
+- Formatter: ruff format
+- Type checker: mypy (strict mode)
+- Test runner: pytest
+- Distribution: [PyPI / internal / not distributed]
+
+---
+
+## Project structure
+[ID: python-lib-structure]
+
+```
+src/
+  [package]/
+    __init__.py
+    [module].py
+tests/
+  test_[module].py
+pyproject.toml
+README.md
+CLAUDE.md
+```
+
+- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- All public API exported from `__init__.py`
+- No `setup.py` — use `pyproject.toml` only
+
+---
+
+## Code conventions
+[ID: python-lib-conventions]
+
+- Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules
+  to work around style issues, fix the code instead
+- Follow **PEP 257** for docstrings — Google docstring style; every public
+  symbol MUST have a docstring
+- Follow **PEP 484** and **PEP 526** for type annotations — all public
+  functions and class members must be annotated
+- No `Any` in public API — use specific types or `TypeVar`
+- Keep functions small and single-purpose
+- Raise specific exceptions — never bare `except:` or `except Exception:`
+- No mutable default arguments
+
+---
+
+## Typing
+[ID: python-lib-typing]
+
+- Run mypy in strict mode: `mypy src/ --strict`
+- Use `from __future__ import annotations` for forward references
+- Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
+  in public signatures
+- Use `TypeAlias` for complex type aliases
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- pytest for all tests
+- Aim for 100% coverage of public API; use `# pragma: no cover` sparingly
+- Use `pytest.mark.parametrize` for data-driven cases
+- No mocks for pure functions — test with real inputs
+- Unit tests in `tests/unit/`, integration tests in `tests/integration/`
+- Name tests using the pattern: `test_<unit_of_work>_<state>_<expected>`
+  e.g. `test_sum_negative_first_param_raises_value_error`
+- Run before every commit: `pytest && mypy src/ --strict`
+
+---
+
+## Packaging
+[ID: python-lib-packaging]
+
+- All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
+- Pin minimum Python version in `requires-python`
+- Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Lock file for reproducibility: `requirements-dev.lock` or equivalent
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit `.venv/`, `__pycache__/`, `*.egg-info/`, `dist/`, `.mypy_cache/`
+- Tag releases and publish to PyPI from CI only — never from a local machine
+
+---
+
+## Commands
+```
+pip install -e ".[dev]"   # install with dev dependencies
+pytest                    # run tests
+mypy src/ --strict        # type check
+ruff check src/ tests/    # lint
+ruff format src/ tests/   # format
+python -m build           # build distribution
+```

--- a/stack/react-spa.md
+++ b/stack/react-spa.md
@@ -1,0 +1,157 @@
+# Stack — React Single-Page Application
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, frontend/ux.md, frontend/quality.md]
+
+A client-side React application with TypeScript. Covers component model,
+state management, routing, API integration, and tooling.
+
+---
+
+## Stack
+[ID: react-spa-stack]
+
+- Language: TypeScript (strict mode)
+- Framework: React 18+
+- Bundler: [Vite / Create React App / Next.js]
+- Routing: [React Router v6 / TanStack Router]
+- State: [Zustand / Redux Toolkit / React Query + local state]
+- Styling: [CSS Modules / Tailwind / plain CSS]
+- HTTP client: [fetch / axios / TanStack Query]
+- Test runner: Vitest + React Testing Library
+- Package manager: [npm / pnpm / yarn]
+- Deployment: [Vercel / Netlify / GitHub Pages / Docker]
+
+---
+
+## Project structure
+[ID: react-spa-structure]
+
+```
+src/
+  components/
+    [Feature]/
+      [Feature].tsx
+      [Feature].test.tsx
+      [Feature].module.css   # if using CSS Modules
+  pages/                     # or routes/ — one file per route
+  hooks/                     # custom hooks (use[Name].ts)
+  services/                  # API calls (no business logic in components)
+  store/                     # global state slices
+  types/                     # shared TypeScript types and interfaces
+  utils/                     # pure utility functions
+  App.tsx
+  main.tsx
+public/
+tsconfig.json
+vite.config.ts               # or equivalent
+package.json
+README.md
+CLAUDE.md
+```
+
+---
+
+## TypeScript conventions
+[ID: react-spa-typescript]
+
+- Follow the **TypeScript ESLint** recommended ruleset
+  (`@typescript-eslint/recommended`) — enforced by ESLint; do not suppress
+  lint errors without a documented reason
+- **Prettier** owns all formatting decisions — no style discussions in code
+  review; configure once and commit the config
+- `strict: true` in `tsconfig.json` — no exceptions
+- No `any` — use `unknown` and narrow, or define a proper type
+- Explicit return types on all non-trivial functions
+- Use `interface` for object shapes, `type` for unions and aliases
+- Import types with `import type { ... }` to keep runtime bundle clean
+- Enums avoided — use `as const` objects or string literal unions instead
+
+---
+
+## Component conventions
+[ID: react-spa-components]
+
+- One component per file — filename matches component name (PascalCase)
+- Functional components only — no class components
+- Props typed with an explicit `interface` or `type` in the same file
+- No prop drilling beyond two levels — lift state or use context/store
+- Extract reusable logic into custom hooks (`use[Name].ts` in `hooks/`)
+- Keep components small: if a component exceeds ~150 lines, split it
+
+---
+
+## State management
+[ID: react-spa-state]
+
+- Local state (`useState`, `useReducer`) for component-scoped concerns
+- Shared/global state in the chosen store (Zustand slice or Redux slice)
+- Server state (fetched data) managed by React Query / TanStack Query —
+  never duplicate server state in the global store
+- No direct DOM manipulation — all state flows through React
+
+---
+
+## API integration
+[ID: react-spa-api]
+
+- All API calls in `src/services/` — never inline `fetch` in components
+- Return typed response objects — no untyped `any` from API boundaries
+- Handle loading, error, and empty states explicitly in every data-dependent view
+- Never store tokens in `localStorage` — prefer `httpOnly` cookies or memory
+
+---
+
+## Styling
+[ID: react-spa-styling]
+
+- No inline styles except for dynamic/computed values
+- No hardcoded colour or spacing values — use CSS custom properties or
+  design tokens from the chosen system
+- Responsive styles follow a mobile-first approach (per `frontend/ux.md`)
+- Global styles in `src/index.css` only; component styles co-located
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- React Testing Library for component tests — test behaviour, not implementation
+- No `getByTestId` as a first resort — prefer accessible queries
+  (`getByRole`, `getByLabelText`, `getByText`)
+- Vitest for unit tests on utils, hooks, and services
+- Mock API calls at the network boundary (`msw`) — not inside components
+- Name component tests using Given/When/Then:
+  e.g. `given a logged-out user, when they submit the form, then an error is shown`
+- E2E tests MUST cover critical user journeys (login, checkout, key flows)
+- E2E tests SHOULD use Playwright or Cypress — colocated in `e2e/` at project root
+- Run before every commit: `npm test && tsc --noEmit`
+
+---
+
+## Accessibility
+[EXTEND: frontend-ux]
+
+- All interactive elements must be keyboard-accessible
+- Use semantic HTML — prefer `<button>` over `<div onClick>`
+- Every form input has an associated `<label>`
+- Modals and dialogs trap focus and restore it on close
+- Test with a screen reader before shipping new interactive components
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit `node_modules/`, `dist/`, `.env`, `.env.local`
+- Lock file (`package-lock.json` / `pnpm-lock.yaml`) is committed — do not delete it
+- Always run `npm test && tsc --noEmit` before committing
+
+---
+
+## Commands
+```
+npm run dev       # develop — hot reload
+npm run build     # production build
+npm run preview   # preview production build locally
+npm test          # run tests (watch mode)
+tsc --noEmit      # type check without emitting files
+```

--- a/stack/static-site.md
+++ b/stack/static-site.md
@@ -1,5 +1,5 @@
 # Stack — Static Site
-[DEPENDS ON: base/git.md, base/ux.md, base/docs.md, base/quality.md]
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, frontend/ux.md, frontend/quality.md]
 
 A static site generated at build time and served as plain HTML, CSS, and
 minimal JavaScript. No backend, no database, no login.
@@ -60,8 +60,17 @@ to change.
 
 ---
 
+## Code conventions
+
+- **ESLint** for any JS/TS code — configured in `eslint.config.js`, run on save
+- **Prettier** owns all formatting — commit `.prettierrc`; no style debates
+  in code review
+- If no JS/TS is present in the project, skip ESLint
+
+---
+
 ## CSS conventions
-[EXTEND: base-quality]
+[EXTEND: frontend-quality]
 
 - All CSS in a single global stylesheet
 - Use CSS custom properties from `:root` for all colours and spacing
@@ -71,7 +80,7 @@ to change.
 ---
 
 ## Performance
-[EXTEND: base-quality]
+[EXTEND: frontend-quality]
 
 - Preload critical above-the-fold assets (hero image, primary font)
 - Static generation by default — no client-side rendering unless necessary
@@ -80,7 +89,7 @@ to change.
 ---
 
 ## SEO
-[EXTEND: base-quality]
+[EXTEND: frontend-quality]
 
 - `robots.txt` required
 - Open Graph and Twitter Card meta tags required


### PR DESCRIPTION
## Summary

- **backend/ layer** — 12 new templates: `http`, `api`, `observability`, `monitoring`, `config`, `database`, `quality`, `caching`, `auth`, `jobs`, `concurrency`, `microservices`
- **base/ templates** — 6 new: `review`, `devsecops`, `release`, `testing`, `cicd`, `containers`; enriched `quality` with SOLID, OOP, design patterns, AOP avoidance, debug code rules
- **frontend/ layer** — `ux.md` moved from `base/`; `quality.md` enriched with frontend design patterns
- **output/ templates** — 5 new: `claude`, `cursorrules`, `copilot`, `codex`, `generic`
- **stack templates** — 5 new: `python-lib`, `flask`, `fastapi`, `react-spa`, `go-service`; all enriched with test naming conventions and explicit coding style guides (PEP 8/257/484, TypeScript ESLint + Prettier, Effective Go)
- **Renames** — `interview.md` → `INTERVIEW.md`; `base/ux.md` → `frontend/ux.md`
- **ROADMAP.md** — added as single source of truth for project status

## Test plan

- [x] Review inheritance chain: base/ → frontend/ or backend/ → stack/
- [x] Verify all `[DEPENDS ON]` declarations match existing files
- [x] Verify all `[EXTEND:]` and `[OVERRIDE:]` tags reference valid IDs
- [x] Run INTERVIEW.md against a sample project to validate question flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)