### PR TITLE
docs: add CLAUDE.md, ONBOARDING.md, and PLAYBOOK.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# solid-ai-templates
+
+Composable, SOLID-inspired template system for generating AI agent context
+files (CLAUDE.md, AGENTS.md, .cursor/rules/project.mdc, etc.) for any
+project type.
+
+## Project identity
+
+- **Name**: solid-ai-templates
+- **Owner**: Imbra Ltd — Branimir Georgiev
+- **Repo**: github.com/Imbra-Ltd/solid-ai-templates
+- **Stack**: plain Markdown — no build step, no runtime dependencies
+- **Output**: context files for Claude Code, Cursor, GitHub Copilot, Codex CLI
+
+## Architecture
+
+```
+base/           # Cross-cutting rules — apply to every project
+backend/        # Backend layer — HTTP, API, database, observability, etc.
+frontend/       # Frontend layer — UX, accessibility, CSS, SSG
+stack/          # Concrete stacks — extend base + layer templates
+output/         # Rendering rules per AI agent tool
+examples/       # Complete generated context files (reference)
+INTERVIEW.md    # Agent-driven project setup interview
+SPEC.md         # System design, composition rules, precedence
+ROADMAP.md      # Project status and planned work
+manifest.yaml   # Machine-readable dependency graph
+CONCEPTS.md     # Concept-to-file navigation index
+```
+
+### Template naming convention
+
+Stack files follow a `<prefix>-<name>.md` pattern:
+
+| Prefix | Examples |
+|--------|---------|
+| `python-` | python-flask, python-fastapi, python-django, python-grpc |
+| `go-` | go-lib, go-service, go-echo, go-grpc |
+| `java-` | java-spring-boot, java-grpc |
+| `node-` | node-express, node-nestjs |
+| `spa-` | spa-react, spa-vue, spa-svelte |
+| `full-` | full-nextjs, full-sveltekit |
+| `mobile-` | mobile-flutter, mobile-react-native |
+| `static-site-` | static-site-astro, static-site-hugo |
+| `iac-` | iac-terraform |
+
+### Inheritance model
+
+```
+base/ → frontend/ or backend/ → stack/
+```
+
+- Every stack declares `[DEPENDS ON: ...]` at the top
+- Sections are tagged `[ID: ...]`, extended with `[EXTEND: ...]`,
+  replaced with `[OVERRIDE: ...]`
+- `manifest.yaml` is the machine-readable dependency graph
+
+## Commands
+
+```bash
+# No build step — all templates are plain Markdown
+git clone https://github.com/Imbra-Ltd/solid-ai-templates.git
+
+# To generate a context file for a project:
+# 1. Open your agent
+# 2. Attach INTERVIEW.md and the relevant stack template
+# 3. Ask the agent to generate CLAUDE.md (or AGENTS.md, etc.)
+```
+
+## Git conventions
+
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `docs/<scope>`, `chore/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, docs, refactor
+- PRs are small and focused — one concern per PR; one approval required to merge
+- After a PR is merged, delete branch and pull main before starting new work
+- Do not commit `.idea/`, editor config, or any generated output
+
+## Code conventions
+
+### Adding a new stack template
+
+1. Create `stack/<prefix>-<name>.md` following an existing file of the same category
+2. Add `[DEPENDS ON: ...]` at the top — list every template this extends
+3. Tag every section with `[ID: <name>]` or `[EXTEND: <id>]` / `[OVERRIDE: <id>]`
+4. Register in `manifest.yaml` under `stacks:` with a `depends_on` list
+5. Add to the stack list in `SPEC.md`
+6. Add to the stacks table in `README.md`
+7. Add to `ROADMAP.md` under the current phase
+8. Add an example in `examples/<name>/CLAUDE.md` if the stack is concrete
+
+### Adding a new base or layer template
+
+1. Create `base/<name>.md`, `backend/<name>.md`, or `frontend/<name>.md`
+2. Tag the file with `[ID: <layer>-<name>]`
+3. Tag every section with a unique `[ID: ...]`
+4. Register in `manifest.yaml` under the correct layer key
+5. Update `SPEC.md` — add to the relevant directory listing
+6. Reference from dependent stack templates via `[DEPENDS ON: ...]`
+
+### Template authoring rules
+
+- Sections use imperative, direct language: "Use X", "Never Y", "Always Z"
+- No explanatory prose in rule lists — rules only
+- Use `[ID: ...]` on every section that another template might EXTEND or OVERRIDE
+- Optional sections are marked `(if applicable)` in the heading
+- Keep line length under 80 characters
+- No HTML — Markdown only
+
+### manifest.yaml
+
+- Every template file MUST have a corresponding entry in `manifest.yaml`
+- IDs MUST be unique across all layers
+- `depends_on` lists MUST reference valid IDs — no dangling references
+- Stack entries go under `stacks:`, base under `base:`, layer under `backend:` or `frontend:`
+
+## Testing
+
+- No automated tests — validation is done by running the interview with an agent
+- To validate a new template: attach `INTERVIEW.md` + the new stack to an agent
+  and confirm the generated output is coherent and complete
+- To validate a structural change: verify all `[DEPENDS ON: ...]` references
+  resolve to real files and all `[EXTEND: ...]` / `[OVERRIDE: ...]` IDs exist
+
+## Documentation
+
+### Standard documents
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Public-facing overview, quick start, stacks table, agents table |
+| `CLAUDE.md` | AI agent context and project rules (this file) |
+| `SPEC.md` | System design, composition rules, inheritance model, precedence |
+| `ROADMAP.md` | Project status and planned work — single source of truth for phase progress |
+| `CONCEPTS.md` | Concept-to-file navigation index |
+| `manifest.yaml` | Machine-readable dependency graph for all templates |
+| `docs/ONBOARDING.md` | Onboarding guide for new contributors |
+| `docs/PLAYBOOK.md` | Operational reference — how to add templates, run interviews, validate output |
+
+### Documentation rules
+
+- Before every commit, update all relevant documents:
+  - `CLAUDE.md` — if architecture, naming conventions, or authoring rules change
+  - `README.md` — if the stacks table, project structure, or quick start change
+  - `SPEC.md` — if the composition model, inheritance rules, or ID system change
+  - `ROADMAP.md` — if a template is added, removed, or renamed
+  - `manifest.yaml` — if any template is added, removed, renamed, or re-depended
+- Do not duplicate content across documents — cross-reference instead
+- Write in present tense — past or future tense indicates out-of-sync documentation
+
+### Decision logs
+
+- Significant structural decisions (new layer, naming convention change, override
+  model change) MUST be recorded as ADRs in `docs/decisions/`
+- Each ADR documents: context, decision, alternatives considered, consequences
+- ADRs are immutable once merged — create a new ADR to supersede an old one
+
+### Rule language
+
+All rules in templates use RFC 2119 keywords:
+
+| Word | Meaning |
+|------|---------|
+| MUST | Absolute requirement |
+| MUST NOT | Absolute prohibition |
+| SHOULD | Recommended — deviations require justification |
+| MAY | Optional |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,92 @@
+# Onboarding
+
+Welcome to solid-ai-templates. This guide gets a new contributor from zero
+to first PR.
+
+## What this project is
+
+A composable, SOLID-inspired template system for generating AI agent context
+files. Instead of writing a `CLAUDE.md` or `AGENTS.md` from scratch for every
+project, you compose templates from three layers:
+
+```
+base/       → rules that apply to every project
+backend/    → rules for backend services and APIs
+frontend/   → rules for frontend and UI projects
+stack/      → concrete, technology-specific rules
+```
+
+An agent reads the relevant templates, asks a short interview, and outputs
+a ready-to-use context file for Claude Code, Cursor, Copilot, or Codex CLI.
+
+Read `SPEC.md` for the full composition model before contributing.
+
+## Prerequisites
+
+- Git
+- A Markdown editor (any)
+- An AI agent for validation (Claude Code recommended)
+
+## First steps
+
+```bash
+git clone https://github.com/Imbra-Ltd/solid-ai-templates.git
+cd solid-ai-templates
+```
+
+No build step, no dependencies to install. All templates are plain Markdown.
+
+## Understand the structure
+
+| File / folder | Read this to understand |
+|---------------|------------------------|
+| `SPEC.md` | The full composition model — inheritance, OVERRIDE, EXTEND, IDs |
+| `CLAUDE.md` | Rules for contributing to this repo |
+| `ROADMAP.md` | What has been done and what is planned |
+| `manifest.yaml` | Machine-readable dependency graph |
+| `CONCEPTS.md` | Concept-to-file navigation index |
+| `examples/` | Complete generated CLAUDE.md files — the target output |
+
+## How templates relate
+
+Every stack template starts with `[DEPENDS ON: ...]` listing its parent
+templates. Read those parent templates first — the stack only adds or overrides
+what differs from the parent.
+
+Example chain:
+```
+base/git.md + base/quality.md + ...
+    ↓
+stack/python-lib.md
+    ↓
+stack/python-service.md
+    ↓
+stack/python-flask.md
+```
+
+## Validate your understanding
+
+Before writing any template, run the system end-to-end:
+
+1. Open Claude Code in any project directory
+2. Attach `INTERVIEW.md` and `stack/python-flask.md`
+3. Ask: "Generate a CLAUDE.md for this project using output/claude.md format"
+4. Review the output — this is what users get
+
+## Making your first contribution
+
+See `docs/PLAYBOOK.md` for step-by-step instructions on adding templates,
+fixing content, and submitting a PR.
+
+## Conventions to know before you write
+
+- Rules use RFC 2119 keywords: MUST, MUST NOT, SHOULD, MAY
+- Every section that another template might reference needs `[ID: ...]`
+- Stack files follow the `<prefix>-<name>.md` naming convention (see `CLAUDE.md`)
+- `manifest.yaml` must be updated whenever a file is added, removed, or renamed
+
+## Getting help
+
+- `SPEC.md` — answers most "how does X work" questions
+- `CONCEPTS.md` — find which file covers a given concept
+- Open a GitHub Discussion if something is unclear

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -1,0 +1,129 @@
+# Playbook
+
+Operational reference for common tasks. Each section is a self-contained
+procedure. See `CLAUDE.md` for authoring rules and `SPEC.md` for the
+composition model.
+
+---
+
+## Add a new stack template
+
+1. Identify the parent template(s) — check `manifest.yaml` for the closest
+   existing stack and trace its `depends_on` chain
+2. Create `stack/<prefix>-<name>.md`:
+   - First line: `# Stack — <Full Name>`
+   - Second line: `[DEPENDS ON: <parent1>, <parent2>, ...]`
+   - One section per concern, each tagged `[ID: <name>]`
+   - Use `[EXTEND: <id>]` to add rules on top of a parent section
+   - Use `[OVERRIDE: <id>]` to replace a parent section entirely
+3. Register in `manifest.yaml`:
+   ```yaml
+   - id: stack-<name>
+     file: stack/<prefix>-<name>.md
+     depends_on:
+       - <parent-id>
+   ```
+4. Add to the stack list in `SPEC.md` (alphabetical within category)
+5. Add a row to the stacks table in `README.md`
+6. Add an entry to `ROADMAP.md` under the current phase
+7. Add to `CONCEPTS.md` if the stack introduces new concepts
+8. Validate: attach `INTERVIEW.md` + new stack to an agent and confirm output
+
+---
+
+## Add a new base or layer template
+
+1. Create the file in the correct layer directory:
+   - `base/<name>.md` — cross-cutting, applies to all projects
+   - `backend/<name>.md` — backend services only
+   - `frontend/<name>.md` — frontend/UI projects only
+2. Tag the file root with `[ID: <layer>-<name>]`
+3. Tag every section with a unique `[ID: <layer>-<name>-<section>]`
+4. Register in `manifest.yaml` under the correct layer key:
+   ```yaml
+   - id: <layer>-<name>
+     file: <layer>/<name>.md
+   ```
+5. Update `SPEC.md` — add to the directory listing for the relevant layer
+6. Add `backend/<name>.md` (or frontend/) references in dependent stack
+   `[DEPENDS ON: ...]` headers as appropriate
+7. Update `ROADMAP.md`
+
+---
+
+## Rename a template file
+
+1. `git mv <old-path> <new-path>`
+2. Update every `[DEPENDS ON: ...]` header that references the old path
+3. Update `manifest.yaml` — change the `file:` field for the entry
+4. Update `SPEC.md`, `README.md`, `ROADMAP.md`, `CONCEPTS.md`, `INTERVIEW.md`
+   — search for the old filename and replace
+5. Update any `examples/` files that reference the old path
+6. Verify with `git status` that no old references remain
+
+---
+
+## Rename a section ID
+
+1. Change `[ID: <old>]` to `[ID: <new>]` in the source template
+2. Search all template files for `[EXTEND: <old>]` and `[OVERRIDE: <old>]`
+   — update every occurrence
+3. Update `manifest.yaml` if the ID is referenced in `depends_on` lists
+4. Update `CONCEPTS.md` if the concept is indexed there
+
+---
+
+## Generate a context file for a project
+
+1. Open your agent (Claude Code recommended)
+2. Attach two files:
+   - `INTERVIEW.md`
+   - The relevant stack template (e.g. `stack/python-flask.md`)
+3. For full-stack projects, attach additional layer templates if needed
+   (e.g. `backend/auth.md`)
+4. Ask the agent to generate the output:
+   ```
+   Generate a CLAUDE.md for this project using output/claude.md format.
+   ```
+5. Review the output — check that base rules and stack-specific rules are
+   both present and consistent
+6. Place the generated file at the project root as `CLAUDE.md`
+
+---
+
+## Validate a template change
+
+1. **Reference check**: confirm every `[DEPENDS ON: ...]` path resolves to a
+   real file in the repo
+2. **ID check**: confirm every `[EXTEND: <id>]` and `[OVERRIDE: <id>]`
+   references an `[ID: ...]` that exists in a parent template
+3. **Manifest check**: confirm the changed template has a matching entry in
+   `manifest.yaml` with correct `depends_on` IDs
+4. **Agent check**: attach `INTERVIEW.md` + the changed template to an agent
+   and confirm the generated output is coherent and complete
+
+---
+
+## Submit a pull request
+
+1. Ensure you are on a feature branch — never commit to `main` directly
+2. Run the validation steps above for every changed template
+3. Update all affected documents (`SPEC.md`, `README.md`, `ROADMAP.md`,
+   `manifest.yaml`, `CONCEPTS.md`) before committing
+4. Commit with a conventional message:
+   ```
+   feat(stack): add python-celery-worker template
+   docs(spec): update backend layer listing
+   ```
+5. Push and open a PR — one concern per PR
+6. After merge: delete the branch and pull `main`
+
+---
+
+## Release a new version
+
+1. Create a release branch: `git checkout -b chore/release-vA.B.C`
+2. Update `ROADMAP.md` — mark the new phase complete
+3. Commit: `git commit --allow-empty -m "chore: release vA.B.C"`
+4. Push, open PR, merge
+5. Tag on `main`: `git tag vA.B.C && git push origin vA.B.C`


### PR DESCRIPTION
## Summary

- `CLAUDE.md` — AI agent context for this repo covering architecture, stack naming conventions, template authoring rules, manifest rules, testing approach, and standard documents table
- `docs/ONBOARDING.md` — contributor onboarding: what the project is, prerequisites, structure walkthrough, template chain explanation, end-to-end validation exercise
- `docs/PLAYBOOK.md` — step-by-step operational procedures for every common task: add stack, add layer template, rename file/ID, generate context file, validate changes, submit PR, release

## Test plan

- [ ] Verify CLAUDE.md renders correctly in GitHub
- [ ] Follow ONBOARDING.md end-to-end as a new contributor would
- [ ] Run one procedure from PLAYBOOK.md (e.g. "Add a new stack template") and confirm steps are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)