### PR TITLE
test: add BDD procedure specifications (Imbra standard)

### DIFF
--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -1,0 +1,105 @@
+# Test Codification Scheme
+
+Defines the procedure ID scheme for solid-ai-templates test specifications.
+Follows the Imbra Procedure Specification Standard
+(`imbra-knowledge/standards/PROCEDURE-SPECIFICATION.md`).
+
+---
+
+## ID format
+
+```
+{PRODUCT}-{TYPE}-{AREA}-{GG}{NNN}{VER}
+```
+
+---
+
+## Product code
+
+| Code | Product |
+|------|---------|
+| `SAIT` | solid-ai-templates |
+
+---
+
+## Procedure types
+
+| Code | Type | Description |
+|------|------|-------------|
+| `SMOKE` | Smoke test | Quick structural health check — files exist, IDs unique, paths resolve |
+| `INT` | Integration test | Verify two or more templates work together correctly |
+| `E2E` | End-to-end test | Verify a complete interview → output generation flow |
+
+---
+
+## Areas
+
+| Code | Area | Description |
+|------|------|-------------|
+| `SYS` | System | Cross-cutting structural checks spanning multiple concerns |
+| `COMP` | Composition | Template composition — DEPENDS ON chain, EXTEND, OVERRIDE directives |
+| `MANIF` | Manifest | manifest.yaml consistency — IDs, file paths, dependency references |
+| `OUT` | Output | Context file generation — interview → CLAUDE.md / AGENTS.md / etc. |
+
+---
+
+## Component groups (GG)
+
+Component group codes are fixed per area. Once assigned, a code is never
+reused for a different component within the same area.
+
+### SYS
+
+| Code | Component |
+|------|-----------|
+| `FS` | File structure — DEPENDS ON path resolution, file existence |
+| `ID` | ID uniqueness — section IDs across all templates |
+
+### COMP
+
+| Code | Component |
+|------|-----------|
+| `DO` | DEPENDS ON — dependency chain assembly |
+| `EX` | EXTEND — additive directive behaviour |
+| `OV` | OVERRIDE — replacement directive behaviour |
+
+### MANIF
+
+| Code | Component |
+|------|-----------|
+| `MF` | Manifest entries — file paths, IDs, depends_on references |
+
+### OUT
+
+| Code | Component |
+|------|-----------|
+| `FA` | FastAPI output — python-fastapi stack interview flow |
+| `GE` | Go Echo output — go-echo stack interview flow |
+
+---
+
+## Version suffix
+
+| Suffix | Meaning |
+|--------|---------|
+| `A` | Original version |
+| `B` | First major revision (scope or assertions changed) |
+| `C` | Second major revision |
+
+Amend in place (no new suffix) for: typo fixes, wording clarifications,
+corrected prerequisites where test intent is unchanged.
+
+---
+
+## Full ID examples
+
+| ID | Meaning |
+|----|---------|
+| `SAIT-SMOKE-SYS-FS001A` | Smoke — system — file structure — spec 1, version A |
+| `SAIT-SMOKE-SYS-ID001A` | Smoke — system — ID uniqueness — spec 1, version A |
+| `SAIT-INT-COMP-DO001A` | Integration — composition — DEPENDS ON chain — spec 1, version A |
+| `SAIT-INT-COMP-EX001A` | Integration — composition — EXTEND directive — spec 1, version A |
+| `SAIT-INT-COMP-OV001A` | Integration — composition — OVERRIDE directive — spec 1, version A |
+| `SAIT-INT-MANIF-MF001A` | Integration — manifest — manifest entries — spec 1, version A |
+| `SAIT-E2E-OUT-FA001A` | E2E — output — FastAPI flow — spec 1, version A |
+| `SAIT-E2E-OUT-GE001A` | E2E — output — Go Echo flow — spec 1, version A |

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Tests
+
+Procedure specifications for solid-ai-templates following the
+[Imbra Procedure Specification Standard](https://github.com/Imbra-Ltd/imbra-knowledge/blob/main/standards/PROCEDURE-SPECIFICATION.md).
+
+See `CODIFICATION.md` for the ID scheme, area codes, and component group registry.
+
+## Specs
+
+| ID | Type | Priority | Title |
+|----|------|----------|-------|
+| `SAIT-SMOKE-SYS-FS001A` | SMOKE | P0 | All DEPENDS ON file paths resolve to existing files |
+| `SAIT-SMOKE-SYS-ID001A` | SMOKE | P0 | All section IDs are unique across all templates |
+| `SAIT-INT-COMP-DO001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
+| `SAIT-INT-COMP-EX001A` | INT | P1 | EXTEND adds rules without removing base rules |
+| `SAIT-INT-COMP-OV001A` | INT | P1 | OVERRIDE replaces parent section entirely |
+| `SAIT-INT-MANIF-MF001A` | INT | P0 | All manifest entries reference valid paths and IDs |
+| `SAIT-E2E-OUT-FA001A` | E2E | P0 | Full interview → CLAUDE.md for a FastAPI project |
+| `SAIT-E2E-OUT-GE001A` | E2E | P0 | Full interview → CLAUDE.md for a Go Echo project |

--- a/tests/SAIT-E2E-OUT-FA001A.md
+++ b/tests/SAIT-E2E-OUT-FA001A.md
@@ -1,0 +1,95 @@
+---
+id: SAIT-E2E-OUT-FA001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567807
+title: Full interview produces a correct CLAUDE.md for a Python FastAPI project
+product: sait
+type: e2e
+area: OUT
+priority: p0
+status: draft
+environment: [local]
+automatable: manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [e2e, output, fastapi, claude-md]
+---
+
+## Short description
+
+> **Given** `INTERVIEW.md` and `stack/python-fastapi.md` are attached to an agent
+> **When** the agent conducts the interview with a defined set of answers
+> **Then** the agent produces a `CLAUDE.md` that contains all required sections
+> with rules drawn from the correct templates in the dependency chain
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Generated `CLAUDE.md` contains all required sections; base rules and FastAPI-specific rules are both present; no section is empty or contradictory |
+| FAILED | One or more required sections are missing; base rules absent; FastAPI-specific rules absent; sections are contradictory |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-COMP-DO001A` is failing |
+| ERROR | Agent fails to load template files or produce output |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code available
+- Interview answers prepared (see Setup)
+
+### Setup
+
+1. Open Claude Code in any working directory
+2. Attach the following files:
+   - `INTERVIEW.md`
+   - `stack/python-fastapi.md`
+   - `output/claude.md`
+3. Prepare the following interview answers:
+   - **Project name**: OrderService
+   - **Owner**: Platform team
+   - **Repo**: github.com/acme/order-service
+   - **Deployment**: Docker → Kubernetes (cloud)
+   - **Database**: PostgreSQL via SQLAlchemy 2 + Alembic
+   - **Auth**: JWT bearer tokens
+   - **Feature flags**: no
+   - **Messaging**: no
+   - **Output format**: CLAUDE.md
+
+### Execution
+
+1. Ask the agent:
+   ```
+   Using INTERVIEW.md and stack/python-fastapi.md, generate a CLAUDE.md
+   for this project. Use output/claude.md for formatting rules.
+   ```
+2. Provide the prepared interview answers when the agent asks
+3. Save the generated output as `CLAUDE.md` in a temp directory
+
+### Assertions
+
+1. Assert the output contains all required top-level sections:
+   - `## Stack`
+   - `## Architecture`
+   - `## Commands`
+   - `## Git conventions`
+   - `## Code conventions`
+   - `## Testing`
+2. Assert `## Stack` lists Python 3.11+, FastAPI, and SQLAlchemy
+3. Assert `## Testing` references `pytest` and `pytest-asyncio`
+4. Assert `## Code conventions` includes async handler rules (from `python-fastapi.md`)
+5. Assert `## Code conventions` includes configuration rules (from `backend/config.md`)
+6. Assert `## Git conventions` includes conventional commit prefixes (from `base/git.md`)
+7. Assert no section references placeholder text such as `[your project]`
+   or `[feature]` without substitution
+
+### Teardown
+
+1. Delete the temporary `CLAUDE.md` generated during the test
+
+## Related
+
+- Related procedures: `SAIT-E2E-OUT-GE001A`
+- Implements: SPEC.md §How an agent uses the system

--- a/tests/SAIT-E2E-OUT-GE001A.md
+++ b/tests/SAIT-E2E-OUT-GE001A.md
@@ -1,0 +1,101 @@
+---
+id: SAIT-E2E-OUT-GE001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567808
+title: Full interview produces a correct CLAUDE.md for a Go Echo project
+product: sait
+type: e2e
+area: OUT
+priority: p0
+status: draft
+environment: [local]
+automatable: manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [e2e, output, go-echo, claude-md]
+---
+
+## Short description
+
+> **Given** `INTERVIEW.md` and `stack/go-echo.md` are attached to an agent
+> **When** the agent conducts the interview with a defined set of answers
+> **Then** the agent produces a `CLAUDE.md` that contains all required sections
+> with rules drawn from the correct templates in the dependency chain
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Generated `CLAUDE.md` contains all required sections; base rules, go-service rules, and go-echo-specific rules are all present; no section is empty or contradictory |
+| FAILED | One or more required sections are missing; base rules absent; go-echo-specific rules absent; sections are contradictory |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-COMP-DO001A` is failing |
+| ERROR | Agent fails to load template files or produce output |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code available
+- Interview answers prepared (see Setup)
+
+### Setup
+
+1. Open Claude Code in any working directory
+2. Attach the following files:
+   - `INTERVIEW.md`
+   - `stack/go-echo.md`
+   - `output/claude.md`
+3. Prepare the following interview answers:
+   - **Project name**: MetricsHub
+   - **Owner**: Infrastructure team
+   - **Repo**: github.com/acme/metricshub
+   - **Deployment**: Docker → Kubernetes (cloud)
+   - **Database**: PostgreSQL via sqlc + pgx
+   - **Auth**: JWT bearer tokens
+   - **Feature flags**: yes — OpenFeature Go SDK
+   - **Messaging**: no
+   - **Output format**: CLAUDE.md
+
+### Execution
+
+1. Ask the agent:
+   ```
+   Using INTERVIEW.md and stack/go-echo.md, generate a CLAUDE.md
+   for this project. Use output/claude.md for formatting rules.
+   ```
+2. Provide the prepared interview answers when the agent asks
+3. Save the generated output as `CLAUDE.md` in a temp directory
+
+### Assertions
+
+1. Assert the output contains all required top-level sections:
+   - `## Stack`
+   - `## Architecture`
+   - `## Commands`
+   - `## Git conventions`
+   - `## Code conventions`
+   - `## Testing`
+2. Assert `## Stack` lists Go 1.22+, Echo v4, sqlc, and pgx
+3. Assert `## Architecture` contains the `cmd/` and `internal/` layout
+   (from `stack/go-service.md`)
+4. Assert `## Code conventions` includes Echo routing and middleware rules
+   (from `stack/go-echo.md`)
+5. Assert `## Code conventions` includes concurrency and graceful shutdown
+   rules (from `backend/concurrency.md` via `go-service.md`)
+6. Assert `## Code conventions` includes feature flag rules using OpenFeature
+   (from `backend/features.md`)
+7. Assert `## Git conventions` includes `go.sum` committed rule
+   (from `stack/go-lib.md`)
+8. Assert no section references placeholder text such as `[service]`
+   without substitution
+
+### Teardown
+
+1. Delete the temporary `CLAUDE.md` generated during the test
+
+## Related
+
+- Related procedures: `SAIT-E2E-OUT-FA001A`
+- Implements: SPEC.md §How an agent uses the system

--- a/tests/SAIT-INT-COMP-DO001A.md
+++ b/tests/SAIT-INT-COMP-DO001A.md
@@ -1,0 +1,80 @@
+---
+id: SAIT-INT-COMP-DO001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567803
+title: DEPENDS ON chain assembles a complete, non-contradictory rule set
+product: sait
+type: int
+area: COMP
+priority: p0
+status: draft
+environment: [local]
+automatable: manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [composition, depends-on, inheritance]
+---
+
+## Short description
+
+> **Given** a concrete stack template with a multi-level DEPENDS ON chain
+> **When** an agent loads the stack template and all its declared dependencies
+> **Then** every rule from every template in the chain is present in the
+> assembled rule set and no rule is silently dropped
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | All sections from all templates in the dependency chain appear in the assembled output; no section is missing |
+| FAILED | One or more sections from a parent template are absent from the assembled output |
+| SKIPPED | No agent available to run the assembly |
+| BLOCKED | `SAIT-SMOKE-SYS-FS001A` is failing — DEPENDS ON paths do not resolve |
+| ERROR | Agent fails to load or process the template files |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code or equivalent agent available
+- `stack/python-flask.md` and its full dependency chain accessible:
+  `stack/python-lib.md`, `stack/python-service.md`, `base/git.md`,
+  `base/docs.md`, `base/quality.md`, `backend/config.md`, `backend/http.md`,
+  `backend/database.md`, `backend/observability.md`, `backend/quality.md`,
+  `backend/features.md`, `backend/messaging.md`
+
+### Setup
+
+1. Open Claude Code in the repository root
+2. Attach `stack/python-flask.md` to the conversation
+
+### Execution
+
+1. Ask the agent:
+   ```
+   List every template in the full DEPENDS ON chain for stack/python-flask.md,
+   then list every section heading that will appear in the assembled rule set.
+   ```
+2. Record the list of templates and sections returned
+
+### Assertions
+
+1. Assert the dependency chain includes all of the following:
+   - `stack/python-lib.md`
+   - `stack/python-service.md`
+   - `base/git.md`, `base/docs.md`, `base/quality.md`
+   - `backend/config.md`, `backend/http.md`, `backend/database.md`
+   - `backend/observability.md`, `backend/quality.md`
+   - `backend/features.md`, `backend/messaging.md`
+2. Assert section headings from every template in the chain are present
+3. Assert no template in the chain is referenced but not loaded
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-COMP-EX001A`, `SAIT-INT-COMP-OV001A`
+- Implements: SPEC.md §Inheritance model

--- a/tests/SAIT-INT-COMP-EX001A.md
+++ b/tests/SAIT-INT-COMP-EX001A.md
@@ -1,0 +1,75 @@
+---
+id: SAIT-INT-COMP-EX001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567804
+title: EXTEND directive adds stack rules on top of parent section without removing base rules
+product: sait
+type: int
+area: COMP
+priority: p1
+status: draft
+environment: [local]
+automatable: manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [composition, extend, inheritance]
+---
+
+## Short description
+
+> **Given** a stack template section marked `[EXTEND: <id>]` referencing a
+> parent section tagged `[ID: <id>]`
+> **When** an agent assembles the rule set for that section
+> **Then** the output contains all rules from the parent section followed by
+> all rules from the EXTEND section — no base rules are removed
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Assembled section contains all base rules AND all stack extension rules; order is base first, extension second |
+| FAILED | One or more base rules are absent; or extension rules replace rather than extend base rules |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-COMP-DO001A` is failing |
+| ERROR | Agent fails to load or process the template files |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code or equivalent agent available
+- Test pair: `base/testing.md` (contains `[ID: base-testing]`) and
+  `stack/python-flask.md` (contains `[EXTEND: base-testing]` in its Testing section)
+
+### Setup
+
+1. Open Claude Code in the repository root
+2. Attach `base/testing.md` and `stack/python-flask.md`
+
+### Execution
+
+1. Ask the agent:
+   ```
+   Show me the assembled Testing section for a Flask project.
+   Include all rules from base/testing.md and all rules from the
+   EXTEND in stack/python-flask.md.
+   ```
+2. Record the assembled output
+
+### Assertions
+
+1. Assert all rules from `base/testing.md` `[ID: base-testing]` are present
+2. Assert all rules from `stack/python-flask.md` `[EXTEND: base-testing]`
+   are present
+3. Assert base rules appear before extension rules
+4. Assert no base rule is missing or overwritten
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-COMP-DO001A`, `SAIT-INT-COMP-OV001A`
+- Implements: SPEC.md §Override mechanism

--- a/tests/SAIT-INT-COMP-OV001A.md
+++ b/tests/SAIT-INT-COMP-OV001A.md
@@ -1,0 +1,74 @@
+---
+id: SAIT-INT-COMP-OV001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567805
+title: OVERRIDE directive replaces parent section entirely in the assembled output
+product: sait
+type: int
+area: COMP
+priority: p1
+status: draft
+environment: [local]
+automatable: manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [composition, override, inheritance]
+---
+
+## Short description
+
+> **Given** a stack template section marked `[OVERRIDE: <id>]` referencing a
+> parent section tagged `[ID: <id>]`
+> **When** an agent assembles the rule set for that section
+> **Then** the output contains only the rules from the OVERRIDE section —
+> the parent section rules are fully replaced
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Assembled section contains only the OVERRIDE rules; no rules from the parent section appear |
+| FAILED | Parent section rules appear alongside or instead of the OVERRIDE rules |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-COMP-DO001A` is failing |
+| ERROR | Agent fails to load or process the template files |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code or equivalent agent available
+- Test pair: `stack/go-lib.md` (contains `[ID: go-lib-stack]`) and
+  `stack/go-service.md` (contains `[OVERRIDE: go-lib-stack]` in its Stack section)
+
+### Setup
+
+1. Open Claude Code in the repository root
+2. Attach `stack/go-lib.md` and `stack/go-service.md`
+
+### Execution
+
+1. Ask the agent:
+   ```
+   Show me the assembled Stack section for a Go service project.
+   stack/go-service.md overrides the Stack section from stack/go-lib.md.
+   Which rules appear?
+   ```
+2. Record the assembled output
+
+### Assertions
+
+1. Assert the assembled Stack section contains the rules from
+   `stack/go-service.md` `[OVERRIDE: go-lib-stack]`
+2. Assert the rules from `stack/go-lib.md` `[ID: go-lib-stack]` do NOT appear
+3. Assert the section is not empty
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-COMP-DO001A`, `SAIT-INT-COMP-EX001A`
+- Implements: SPEC.md §Override mechanism

--- a/tests/SAIT-INT-MANIF-MF001A.md
+++ b/tests/SAIT-INT-MANIF-MF001A.md
@@ -1,0 +1,113 @@
+---
+id: SAIT-INT-MANIF-MF001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567806
+title: All manifest entries reference valid file paths and depend on valid IDs
+product: sait
+type: int
+area: MANIF
+priority: p0
+status: draft
+environment: [local, ci]
+automatable: semi-manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [manifest, consistency, dependency-graph]
+---
+
+## Short description
+
+> **Given** the repository is cloned and `manifest.yaml` is present
+> **When** every entry in `manifest.yaml` is validated against the file system
+> and against other entries in the manifest
+> **Then** every `file:` path resolves to an existing file and every ID in
+> every `depends_on:` list matches a declared `id:` elsewhere in the manifest
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | All `file:` paths exist; all `depends_on` IDs resolve to a declared `id:` in the manifest; all IDs are unique |
+| FAILED | One or more `file:` paths do not exist; or one or more `depends_on` IDs have no matching declaration; or duplicate IDs exist |
+| SKIPPED | `manifest.yaml` is absent from the repository |
+| BLOCKED | `SAIT-SMOKE-SYS-FS001A` is failing |
+| ERROR | YAML parser fails; file system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Shell with a YAML-capable tool (`python3 -c "import yaml"` or `yq`)
+
+### Setup
+
+1. Change to the repository root
+2. Confirm `manifest.yaml` is present
+
+### Execution
+
+1. Extract all declared IDs from the manifest:
+   ```bash
+   python3 -c "
+   import yaml
+   m = yaml.safe_load(open('manifest.yaml'))
+   ids = []
+   for section in m.values():
+       if isinstance(section, list):
+           for entry in section:
+               ids.append(entry['id'])
+   print('\n'.join(ids))
+   "
+   ```
+2. Extract all `file:` paths and check they exist:
+   ```bash
+   python3 -c "
+   import yaml, os
+   m = yaml.safe_load(open('manifest.yaml'))
+   for section in m.values():
+       if isinstance(section, list):
+           for entry in section:
+               path = entry.get('file','')
+               exists = os.path.exists(path)
+               print(f'{\"OK\" if exists else \"MISSING\"}: {path}')
+   "
+   ```
+3. Extract all `depends_on` references and cross-check against declared IDs:
+   ```bash
+   python3 -c "
+   import yaml
+   m = yaml.safe_load(open('manifest.yaml'))
+   ids = set()
+   refs = []
+   for section in m.values():
+       if isinstance(section, list):
+           for entry in section:
+               ids.add(entry['id'])
+               for dep in entry.get('depends_on', []):
+                   refs.append((entry['id'], dep))
+   for src, dep in refs:
+       if dep not in ids:
+           print(f'DANGLING: {src} depends on {dep} (not declared)')
+   "
+   ```
+
+### Assertions
+
+1. Assert no `MISSING` lines appear in the file path check
+2. Assert no `DANGLING` lines appear in the depends_on cross-check
+3. Assert no duplicate IDs appear in the extracted ID list
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Notes
+
+The three scripts above can be combined into a single validation script
+and added to CI as a pre-merge check.
+
+## Related
+
+- Related procedures: `SAIT-SMOKE-SYS-FS001A`, `SAIT-SMOKE-SYS-ID001A`
+- Implements: SPEC.md §Inheritance model, manifest.yaml

--- a/tests/SAIT-SMOKE-SYS-FS001A.md
+++ b/tests/SAIT-SMOKE-SYS-FS001A.md
@@ -1,0 +1,76 @@
+---
+id: SAIT-SMOKE-SYS-FS001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567801
+title: All DEPENDS ON file paths in stack templates resolve to existing files
+product: sait
+type: smoke
+area: SYS
+priority: p0
+status: draft
+environment: [local, ci]
+automatable: semi-manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [structure, depends-on, paths]
+---
+
+## Short description
+
+> **Given** the repository is cloned and all template files are present
+> **When** every `[DEPENDS ON: ...]` header in every stack template is read
+> **Then** each listed file path resolves to an existing file in the repository
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every path listed in every `[DEPENDS ON: ...]` header exists as a file in the repository |
+| FAILED | One or more paths listed in a `[DEPENDS ON: ...]` header do not resolve to an existing file |
+| SKIPPED | Repository cannot be cloned or accessed |
+| BLOCKED | — |
+| ERROR | File system is inaccessible; `find` or equivalent tool fails |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Shell access with `grep` and file listing tools available
+
+### Setup
+
+1. Change to the repository root
+2. Confirm the `stack/` directory is present
+
+### Execution
+
+1. Extract all `[DEPENDS ON: ...]` lines from every file in `stack/`:
+   ```bash
+   grep -r "DEPENDS ON" stack/
+   ```
+2. For each file path listed in the extracted lines, verify the file exists:
+   ```bash
+   # Example: verify stack/go-service.md depends resolve
+   ls stack/go-lib.md backend/config.md backend/http.md
+   ```
+3. Repeat for every stack file
+
+### Assertions
+
+1. Assert every path extracted from `[DEPENDS ON: ...]` exists in the repository
+2. Assert no path is a directory — all references must point to `.md` files
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Notes
+
+Semi-manual because no automated parser for `[DEPENDS ON: ...]` exists yet.
+A future CI step should automate this check using `manifest.yaml` as the
+source of truth.
+
+## Related
+
+- Related procedures: `SAIT-SMOKE-SYS-ID001A`, `SAIT-INT-MANIF-MF001A`

--- a/tests/SAIT-SMOKE-SYS-ID001A.md
+++ b/tests/SAIT-SMOKE-SYS-ID001A.md
@@ -1,0 +1,73 @@
+---
+id: SAIT-SMOKE-SYS-ID001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567802
+title: All section IDs are unique across all templates
+product: sait
+type: smoke
+area: SYS
+priority: p0
+status: draft
+environment: [local, ci]
+automatable: semi-manual
+created: 2026-03-22
+author: Branimir Georgiev
+product-version: "1.x"
+tags: [structure, ids, uniqueness]
+---
+
+## Short description
+
+> **Given** the repository is cloned and all template files are present
+> **When** all `[ID: ...]` tags across every template file are collected
+> **Then** no two tags share the same ID value
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every `[ID: ...]` value is unique across all files in `base/`, `backend/`, `frontend/`, and `stack/` |
+| FAILED | Two or more templates declare the same `[ID: ...]` value |
+| SKIPPED | Repository cannot be cloned or accessed |
+| BLOCKED | — |
+| ERROR | File system is inaccessible; `grep` or equivalent tool fails |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Shell access with `grep` and `sort` available
+
+### Setup
+
+1. Change to the repository root
+
+### Execution
+
+1. Extract all `[ID: ...]` values from all template files:
+   ```bash
+   grep -rh "\[ID:" base/ backend/ frontend/ stack/ | sort
+   ```
+2. Identify duplicates:
+   ```bash
+   grep -rh "\[ID:" base/ backend/ frontend/ stack/ | sort | uniq -d
+   ```
+
+### Assertions
+
+1. Assert the output of the duplicate check is empty — no duplicates exist
+2. Assert every `[EXTEND: <id>]` and `[OVERRIDE: <id>]` reference matches
+   an `[ID: ...]` that exists somewhere in the template tree
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Notes
+
+Semi-manual because cross-file ID resolution requires a script.
+A future CI step should automate this using `manifest.yaml`.
+
+## Related
+
+- Related procedures: `SAIT-SMOKE-SYS-FS001A`, `SAIT-INT-COMP-EX001A`, `SAIT-INT-COMP-OV001A`


### PR DESCRIPTION
## Summary

- `tests/CODIFICATION.md` — ID scheme, area codes, and component group registry for all SAIT specs
- `tests/README.md` — spec index table
- 8 procedure specifications following the Imbra Procedure Specification Standard (Given/When/Then, five result conditions, explicit steps and assertions)

## Specs

| ID | Type | P | Title |
|----|------|---|-------|
| `SAIT-SMOKE-SYS-FS001A` | SMOKE | P0 | All DEPENDS ON file paths resolve to existing files |
| `SAIT-SMOKE-SYS-ID001A` | SMOKE | P0 | All section IDs unique across all templates |
| `SAIT-INT-COMP-DO001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
| `SAIT-INT-COMP-EX001A` | INT | P1 | EXTEND adds rules without removing base rules |
| `SAIT-INT-COMP-OV001A` | INT | P1 | OVERRIDE replaces parent section entirely |
| `SAIT-INT-MANIF-MF001A` | INT | P0 | All manifest entries reference valid paths and IDs |
| `SAIT-E2E-OUT-FA001A` | E2E | P0 | Full interview → CLAUDE.md for a FastAPI project |
| `SAIT-E2E-OUT-GE001A` | E2E | P0 | Full interview → CLAUDE.md for a Go Echo project |

## Test plan

- [ ] Verify CODIFICATION.md area and component group codes are consistent with spec IDs used in all 8 files
- [ ] Execute `SAIT-SMOKE-SYS-FS001A` and `SAIT-SMOKE-SYS-ID001A` manually to confirm they pass on the current repo state
- [ ] Execute `SAIT-INT-MANIF-MF001A` using the provided Python scripts to confirm manifest is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)