### PR TITLE
docs: add inline vs reference model trade-off guidance

### DIFF
--- a/formats/agent.md
+++ b/formats/agent.md
@@ -8,6 +8,21 @@ frontmatter).
 
 ---
 
+## Choosing a model
+
+| | Inline | Reference |
+|---|---|---|
+| **Runtime** | Rules always in context — applied immediately | Agent must read template files first — may skip them |
+| **Maintenance** | Rules drift from templates over time | Single source of truth across projects |
+| **Best for** | Single project, reliable rule application | Multi-project consistency, shared conventions |
+
+**Recommendation:** default to inline for reliable agent behaviour. Use
+reference when maintaining conventions across multiple projects, and
+consider a hybrid — inline the most critical project-specific rules,
+reference the templates for the full quality framework.
+
+---
+
 ## Inline model (default)
 
 All rules are inlined — the output file is self-contained. Render the


### PR DESCRIPTION
## Summary
- Add "Choosing a model" section to formats/agent.md with trade-off table
- Inline: reliable agent behaviour, rules always in context
- Reference: multi-project consistency, single source of truth
- Recommend inline by default, reference for multi-project setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)