### PR TITLE
feat(base): add typed data arrays rule for discriminated unions

### DIFF
--- a/base/typescript.md
+++ b/base/typescript.md
@@ -10,6 +10,9 @@
   `type` or `kind` field plus a union is safer than class hierarchies
 - Compose sub-interfaces when a domain has multiple categories with
   different fields; keep single-purpose types flat
+- When declaring data arrays that use a discriminated union, type each
+  section with its specific sub-interface (`FlashItem[]`), not the
+  broad union (`Item[]`) — spread into the union array at the end
 - No enums — use `as const` objects or string literal unions
 - No `any` — use `unknown` and narrow, or define a proper type
 


### PR DESCRIPTION
## Summary
- Add rule to `base/typescript.md` type design section: when declaring data arrays with a discriminated union, type each section with the specific sub-interface, not the broad union
- Discovered in me-fuji: `FlashAccessory[]` catches errors better than `Accessory[]` because type errors point to the specific sub-interface

## Test plan
- [ ] `py tests/run_smoke.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)