### PR TITLE
Add onClick-on-non-focusable-element a11y rule

### DIFF
--- a/frontend/ux.md
+++ b/frontend/ux.md
@@ -12,6 +12,9 @@
 - Target standard: WCAG 2.1 AA
 - Minimum text contrast ratio: 4.5:1 (normal text), 3:1 (large text)
 - All interactive elements reachable and operable by keyboard
+- Any non-focusable element (`<th>`, `<div>`, `<span>`) with `onClick` MUST
+  contain a `<button>` — `onClick` alone does not add the element to the tab
+  order or provide keyboard activation
 - Focus indicators must be visible at all times
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`


### PR DESCRIPTION
## Summary

- Adds a MUST rule to `frontend/ux.md` accessibility section: any non-focusable element (`<th>`, `<div>`, `<span>`) with `onClick` must contain a `<button>`
- `onClick` alone does not add an element to the tab order or provide Enter/Space activation

## Context

Caught in me-fuji where all three sortable tables used `<th onClick>` — visually interactive but unreachable by keyboard. axe-core didn't flag it either.

Closes #37

## Test plan

- [ ] Verify rule renders correctly in `frontend/ux.md`
- [ ] Run `py tests/run_smoke.py` to confirm no structural issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)