### PR TITLE
Add base scope guard template

### DIFF
--- a/base/scope.md
+++ b/base/scope.md
@@ -1,0 +1,42 @@
+# Base — Scope Guard
+[ID: base-scope]
+
+## Purpose
+Prevent scope creep during agent-assisted work sessions. Agents tend to
+agree with expansions rather than pushing back, leading to sessions that
+start with one task and end with five unrelated changes — none fully
+finished.
+
+## Before starting work
+- Confirm the scope with the user before making changes
+- If the task is ambiguous, ask: "What is the specific deliverable for
+  this session?"
+- Write down the agreed scope — refer back to it when the session drifts
+
+## During work
+- If a task grows beyond the original scope, flag it explicitly:
+  "This is expanding beyond the original task — should I continue or
+  finish the current work first?"
+- Do not silently absorb new requests into the current work stream
+- Finishing and committing the current work SHOULD take priority over
+  starting something new
+
+## Default scope boundaries
+- One logical unit of work per session (one feature, one chapter, one
+  component, one bug fix)
+- Changes that support the current unit (tests, docs, formatting) are
+  in scope
+- Restructuring unrelated code, creating new projects, or adding
+  infrastructure is out of scope unless explicitly requested
+
+## When in doubt
+- Finish the current task
+- Commit the current work
+- Then ask whether to start the new task
+
+## Scope expansion protocol
+When the user requests something out of scope:
+1. Acknowledge the request
+2. State what the current scope is
+3. Ask: "Should I finish the current work first, or switch to this?"
+4. If switching, commit current progress before starting the new task


### PR DESCRIPTION
## Summary
- Add `base/scope.md` — scope creep prevention for agent-assisted sessions
- Defines rules for confirming scope, flagging expansion, and defaulting to "finish current work first"
- Originated from a tutorial-git session that drifted from reviewing one chapter to restructuring the entire project

## Test plan
- [x] Verify `scope.md` follows template authoring rules (imperative language, `[ID: ...]` tag)
- [x] Run `py tests/run_smoke.py` to confirm no structural issues
- [x] Verify `manifest.yaml` update is needed (pending — not yet registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)