### PR TITLE
Add end-of-session audit to scope guard

### DIFF
--- a/base/scope.md
+++ b/base/scope.md
@@ -40,3 +40,13 @@ When the user requests something out of scope:
 2. State what the current scope is
 3. Ask: "Should I finish the current work first, or switch to this?"
 4. If switching, commit current progress before starting the new task
+
+## End of session audit
+Before wrapping up a session, verify structural compliance:
+1. Check that all files required by referenced templates (e.g.
+   `base/docs.md`) exist and are populated
+2. Check that `CLAUDE.md` project structure matches the actual directory
+3. Check that `docs/dev-journal.md` has an entry for this session
+4. Check that any decisions made during the session have corresponding
+   ADRs in `docs/decisions/`
+5. Flag any gaps to the user before closing


### PR DESCRIPTION
## Summary
- Add "End of session audit" section to `base/scope.md`
- 5 structural compliance checks: required files, CLAUDE.md accuracy, dev-journal entry, ADRs for decisions

## Context
During a tutorial-git session, required docs (dev-journal, ONBOARDING, PLAYBOOK, decisions/) were not created until the end — a structural audit would have caught this earlier.

## Test plan
- [x] Run `py tests/run_smoke.py`
- [x] Verify no breaking changes to existing scope guard rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)