### PR TITLE
feat(stack): add static-site-tutorial template

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ is coherent and complete.
 | `stack/full-sveltekit.md`       | full-stack | base + frontend + svelte + backend partial    |
 | `stack/static-site-astro.md`    | static     | base + frontend + frontend/static-site        |
 | `stack/static-site-hugo.md`     | static     | base + frontend + frontend/static-site        |
+| `stack/static-site-tutorial.md` | static     | static-site-astro + base/issues + base/scope  |
 | `stack/mobile-react-native.md`  | mobile     | base + react-spa + backend/auth               |
 | `stack/mobile-flutter.md`       | mobile     | base                                          |
 | `stack/iac-terraform.md`        | DevOps     | base                                          |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,11 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 
 - [ ] `base/typescript.md` — new: type design, discriminated unions, naming, strictness
 
-## Phase 14 — Validation
+## Phase 14 — Content stacks
+
+- [x] `stack/static-site-tutorial.md` — new: multi-chapter tutorial site (chapters, diagrams, CI split, CC BY-NC-SA 4.0)
+
+## Phase 15 — Validation
 
 - [ ] Use the system on a real new project end-to-end (see examples)
 - [ ] Use the system on a real refactoring project end-to-end

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,6 +84,7 @@ Technology-specific rules. Each stack declares which layers it depends on.
 stack/
 ├── astro.md          # extends base + frontend + frontend/static-site
 ├── hugo.md           # extends base + frontend + frontend/static-site
+├── tutorial.md       # extends astro + base/issues + base/scope — multi-chapter tutorial site
 ├── react-spa.md      # extends base + frontend — React + TypeScript
 ├── vue.md            # extends base + frontend — Vue 3 + Pinia
 ├── svelte.md         # extends base + frontend — Svelte 5 + runes

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,6 +30,10 @@ base:
   - id: base-typescript
     file: base/typescript.md
     depends_on: [base-quality]
+  - id: base-issues
+    file: base/issues.md
+  - id: base-scope
+    file: base/scope.md
 
 frontend:
   - id: frontend-ux
@@ -96,6 +100,13 @@ stacks:
     depends_on:
       - frontend-static-site
       - base-typescript
+
+  - id: stack-tutorial
+    file: stack/static-site-tutorial.md
+    depends_on:
+      - stack-astro
+      - base-issues
+      - base-scope
 
   - id: stack-react-spa
     file: stack/spa-react.md

--- a/stack/static-site-tutorial.md
+++ b/stack/static-site-tutorial.md
@@ -1,0 +1,199 @@
+# Stack — Static Site Tutorial
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, base/issues.md, base/scope.md, base/typescript.md, frontend/ux.md, frontend/quality.md, frontend/static-site.md, stack/static-site-astro.md]
+
+Extends the Astro static site stack with conventions for multi-chapter
+tutorial sites. Covers content structure, chapter format, diagram
+pipeline, CI/CD, and licensing.
+
+---
+
+## Content layer
+[OVERRIDE: static-site-content]
+
+Canonical tutorial content lives in `chapters/` as SSG-agnostic
+Markdown. The Astro site imports from this directory — never edit
+content inside `astro-site/` directly.
+
+```
+chapters/
+  01-introduction.md
+  02-topic-a.md
+  ...
+  NN-glossary.md
+```
+
+- Number-prefixed filenames control chapter order
+- Frontmatter MUST include `title`, `section`, `order`
+- Content is SSG-agnostic — no Astro-specific syntax in chapters
+
+---
+
+## Chapter structure
+
+Every chapter MUST follow this structure in order:
+
+1. Frontmatter (`title`, `section`, `order`)
+2. `## Overview` — what the chapter covers and why
+3. Content sections with `##` and `###` headings
+4. `## Exercises` — hands-on tasks with verification steps
+5. `## Quiz` — multiple-choice questions with answers at the bottom
+
+Reference chapters (playbook, appendix, glossary) MAY omit Exercises
+and Quiz sections.
+
+---
+
+## Quiz formatting
+
+- Each option on a bullet line: `- A) ...`, `- B) ...`
+- Vary the correct answer positions — never all the same letter
+- Answers section at the bottom: `1. C — explanation`
+
+---
+
+## Writing style
+[EXTEND: base-docs]
+
+- **American English** spelling (analyze, not analyse)
+- Concise, direct sentences — no filler, no preamble
+- Explain technical terms inline for beginners
+- No `---` separators between subsections — headings provide separation
+- No inline Practice sections — all practice goes in Exercises
+- No emojis unless explicitly requested
+
+---
+
+## Cross-references
+
+- Reference other chapters by file: `[Topic A](02-topic-a.md)`
+- Reference sections within a chapter by heading anchor:
+  `[Section Name](#section-name)`
+- The Astro build SHOULD rewrite chapter cross-references
+  automatically (see CI section)
+
+---
+
+## Assets
+[OVERRIDE: static-site-assets]
+
+```
+assets/
+  images/              # PNG exports used in chapters
+  drawio/              # draw.io source files (editable)
+  archive/             # Superseded images (kept for reference)
+  banners/             # Banner images
+```
+
+- Source files: `assets/drawio/<name>.drawio`
+- Exported PNGs: `assets/images/<name>.png`
+- Reference from chapters: `![Alt text](../assets/images/name.png)`
+- Superseded images move to `assets/archive/` — not deleted
+- `.bkp` files (draw.io temp) MUST be in `.gitignore`
+
+---
+
+## Project structure
+[OVERRIDE: static-site-architecture]
+
+```
+chapters/              # Canonical tutorial content (SSG-agnostic)
+assets/
+  images/              # PNG exports
+  drawio/              # draw.io source files
+  archive/             # Superseded images
+astro-site/            # Astro static site
+  src/
+    content/           # Content collection (imports from chapters/)
+    components/        # Astro components
+    layouts/           # Page layouts
+    pages/             # Route definitions
+    styles/            # Global CSS
+    data/              # Site configuration (site.json)
+docs/                  # Project docs
+  decisions/           # ADRs
+  solid-ai-templates/  # Submodule — quality conventions
+  dev-journal.md       # Session log
+  ONBOARDING.md        # Contributor setup
+  PLAYBOOK.md          # Operational reference
+```
+
+---
+
+## Navigation
+
+- Hamburger menu for mobile (breakpoint ≤768px)
+- All chapters visible when menu is open
+- Tab bar for desktop navigation
+- `rel="noopener noreferrer"` on all `target="_blank"` links
+
+---
+
+## CI/CD
+[EXTEND: base-git]
+
+Two workflows:
+
+**`build.yml`** — triggers on pull requests to `main`
+- Checkout, setup Node (pinned to match `engines` in package.json),
+  npm ci (with cache), build, link check
+
+**`deploy.yml`** — triggers on push to `main`
+- Same build steps as above, plus upload artifact and deploy to
+  GitHub Pages
+
+- Use `actions/setup-node` built-in cache (keyed on
+  `package-lock.json`)
+- Use lychee for link checking against built `dist/` output
+- Pin Node version to exact version matching `engines` in
+  `package.json`
+
+---
+
+## Release process
+[EXTEND: base-git]
+
+Follow `base/git.md` release process:
+1. `git checkout -b chore/release-vX.Y.Z`
+2. `git commit --allow-empty -m "chore: release vX.Y.Z"`
+3. Push, open PR, merge
+4. `git checkout main && git pull`
+5. `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+Tags use semver: `v1.0.0` (lowercase v, three segments).
+
+---
+
+## Issue templates
+
+Use 5 typed templates from `base/issues.md`:
+- Epic, Task, Bug, Incident, Spike
+- Placed in `.github/ISSUE_TEMPLATE/`
+- No title prefix — labels identify the type
+
+---
+
+## Licensing
+
+- Tutorial content: CC BY-NC-SA 4.0
+- Allows copying and adapting with attribution
+- Prohibits commercial use without permission
+- Derivatives must use the same license
+
+---
+
+## Scope guard
+[EXTEND: base-scope]
+
+- One chapter per session is the default scope for content work
+- Diagram, exercise, and quiz changes within that chapter are in scope
+- Restructuring other chapters or adding infrastructure is out of scope
+  unless explicitly requested
+
+---
+
+## Commands
+```
+npm run dev      # develop — hot reload at localhost:4321/<base>/
+npm run build    # compile — production build to dist/
+npm run preview  # verify — preview the production build locally
+```


### PR DESCRIPTION
## Summary
- New `stack/static-site-tutorial.md` extending static-site-astro with multi-chapter tutorial conventions
- Registers `base-issues` and `base-scope` in `manifest.yaml` (files existed but were missing from manifest)
- Updated SPEC.md, README.md, ROADMAP.md

Patterns validated in braboj/tutorial-git (4 sessions, v2.0.0).

Closes #45.

## Test plan
- [x] `py tests/run_smoke.py` — 7/7 passed
- [ ] Attach template to agent and generate a CLAUDE.md for a new tutorial project

🤖 Generated with [Claude Code](https://claude.com/claude-code)