### PR TITLE
feat(formats): add optional Session Protocol section

### DIFF
--- a/formats/agent.md
+++ b/formats/agent.md
@@ -72,10 +72,17 @@ them*.
 [base/review.md priority order + checklists to apply]
 ### 5.2 Structure audit
 [Which templates to verify, when to run]
+
+## 6. Session protocol (if applicable)
+### 6.1 Startup
+[base/scope.md — Session startup: read referenced docs, confirm scope]
+### 6.2 End of session
+[base/scope.md — End of session audit: dev journal, ADRs, issues]
 ```
 
 Omit sections that are not applicable to the project (e.g. omit section 4
-for a backend service, omit 3.2+ if only testing applies).
+for a backend service, omit 3.2+ if only testing applies, omit section 6
+if the project does not use base/scope.md).
 
 ---
 
@@ -129,6 +136,13 @@ language-specific templates as the standard.
 Verify MUSTs from base/docs.md, base/readme.md, base/git.md, and
 relevant layer/stack templates. Run after: new project, migration,
 new layer, or pre-release.
+
+## 6. Session protocol (if applicable)
+### 6.1 Startup
+Read all referenced template documents before starting work.
+Confirm session scope with the user.
+### 6.2 End of session
+Update dev journal, verify docs, close resolved issues, flag gaps.
 ```
 
 ---

--- a/formats/agent.md
+++ b/formats/agent.md
@@ -73,7 +73,7 @@ them*.
 ### 5.2 Structure audit
 [Which templates to verify, when to run]
 
-## 6. Session protocol (if applicable)
+## 6. Session protocol
 ### 6.1 Startup
 [base/scope.md — Session startup: read referenced docs, confirm scope]
 ### 6.2 End of session
@@ -81,8 +81,7 @@ them*.
 ```
 
 Omit sections that are not applicable to the project (e.g. omit section 4
-for a backend service, omit 3.2+ if only testing applies, omit section 6
-if the project does not use base/scope.md).
+for a backend service, omit 3.2+ if only testing applies).
 
 ---
 
@@ -137,7 +136,7 @@ Verify MUSTs from base/docs.md, base/readme.md, base/git.md, and
 relevant layer/stack templates. Run after: new project, migration,
 new layer, or pre-release.
 
-## 6. Session protocol (if applicable)
+## 6. Session protocol
 ### 6.1 Startup
 Read all referenced template documents before starting work.
 Confirm session scope with the user.


### PR DESCRIPTION
## Summary
- Adds section 6 (Session protocol) to both inline and reference models in `formats/agent.md`
- Optional — omit if the project does not use `base/scope.md`
- Covers startup (read referenced docs, confirm scope) and end-of-session audit (dev journal, ADRs, issues)

Closes #33.

## Test plan
- [x] `py tests/run_smoke.py` — 7/7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)