### PR TITLE
feat(base): add data quality pattern for data-heavy projects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,6 +146,7 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 ## Phase 14 — Content stacks
 
 - [x] `stack/static-site-tutorial.md` — new: multi-chapter tutorial site (chapters, diagrams, CI split, CC BY-NC-SA 4.0)
+- [x] `base/data-quality.md` — new: data sourcing, completeness, freshness, scoring, validation for data-heavy projects
 
 ## Phase 15 — Validation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,8 +35,9 @@ base/
 ├── cicd.md        # Pipeline stages, triggers, environments, IaC, deployment
 ├── containers.md  # Dockerfile, runtime security, resource limits, Kubernetes
 ├── deployment.md  # Deployment targets (cloud/hybrid/offline), certs, LB, registries, secrets
-├── typescript.md  # Type design, naming, strictness — applies to all TypeScript projects
-└── templating.md  # Server-side rendering — partials, escaping, caching, forms, testing
+├── typescript.md    # Type design, naming, strictness — applies to all TypeScript projects
+├── templating.md    # Server-side rendering — partials, escaping, caching, forms, testing
+└── data-quality.md  # Data sourcing, completeness, freshness, scoring — data-heavy projects
 ```
 
 ### 2. Frontend templates (abstract, frontend layer)

--- a/base/data-quality.md
+++ b/base/data-quality.md
@@ -1,0 +1,87 @@
+# Base — Data Quality
+[ID: base-data-quality]
+
+Rules for projects where content or data accuracy matters as much as
+code quality. Applies to lens databases, product catalogs, tutorial
+content, wiki entries, and any project that declares data as a
+first-class concern.
+
+---
+
+## Data sourcing
+[ID: data-quality-sourcing]
+
+- Every data point MUST trace to a named source (URL, publication,
+  manufacturer spec sheet)
+- Record the source alongside the data — not in a separate document
+- Prefer primary sources (manufacturer, official docs) over aggregators
+- When multiple sources conflict, document the conflict and the chosen
+  value with rationale
+- Never fabricate or estimate values without marking them as estimates
+
+---
+
+## Completeness tracking
+[ID: data-quality-completeness]
+
+- Define a completeness score for each entry: fields populated / total
+  fields (e.g. `14/14`)
+- Track completeness at the entry level, not just the collection level
+- Incomplete entries MUST be queryable — add a `completeness` or
+  `dataStatus` field
+- Set a minimum completeness threshold for publishing (e.g. 80%)
+- Entries below the threshold MAY exist in the database but MUST NOT
+  appear in user-facing views
+
+---
+
+## Freshness
+[ID: data-quality-freshness]
+
+- Record when each entry was last verified: `lastVerified` date field
+- Define a freshness window per collection (e.g. prices: 30 days,
+  specs: 12 months)
+- Entries beyond their freshness window SHOULD be flagged for review
+- Price data MUST include a `priceDate` field — never show a price
+  without indicating when it was captured
+- Discontinued or unavailable items MUST be marked, not deleted
+
+---
+
+## Exact vs estimated values
+[ID: data-quality-precision]
+
+- Distinguish exact values (from specs or measurements) from estimates
+  (derived, rounded, or interpolated)
+- Use a naming convention or field suffix to mark estimates (e.g.
+  `weightEstimated: true` or `~` prefix in display)
+- Default to realistic/pessimistic estimates — never optimistic
+- Document the estimation method when not obvious
+
+---
+
+## Scoring and derived fields
+[ID: data-quality-scoring]
+
+- Scoring formulas MUST be documented — not buried in code
+- All inputs to a score MUST be traceable to source data
+- Scores MUST be reproducible: same inputs always produce the same
+  output
+- Define the scoring scale once (e.g. 1–5, step 0.5) and use it
+  consistently
+- Features (boolean attributes like "weather sealed") are UI filter
+  badges, not scoring inputs — keep them separate
+
+---
+
+## Validation
+[ID: data-quality-validation]
+
+- Validate data at ingest time — reject or flag entries that fail
+  schema validation
+- Use typed schemas (Zod, JSON Schema, TypeScript interfaces) for all
+  data collections
+- Range checks for numeric fields (e.g. weight > 0, price > 0)
+- Enum checks for constrained fields (e.g. mount type, category)
+- Build-time validation is acceptable for static sites — runtime
+  validation for APIs

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -30,6 +30,8 @@ base:
   - id: base-typescript
     file: base/typescript.md
     depends_on: [base-quality]
+  - id: base-data-quality
+    file: base/data-quality.md
   - id: base-issues
     file: base/issues.md
   - id: base-scope


### PR DESCRIPTION
## Summary
- New `base/data-quality.md` with 6 sections: sourcing, completeness, freshness, precision, scoring, validation
- Registered in manifest.yaml, SPEC.md, ROADMAP.md
- For projects that declare data as a first-class concern (me-fuji, product catalogs, wiki content)

Closes #34.

## Test plan
- [x] `py tests/run_smoke.py` — 7/7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)