### PR TITLE
Add single-source content pattern for Astro

### DIFF
--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -89,6 +89,79 @@ src/content.config.ts   # schema definitions
    at build time
 5. Delete the old `src/data/` files
 
+### Single-source content pattern
+[ID: astro-single-source-content]
+
+When content MUST remain SSG-agnostic (e.g. tutorial chapters that
+work as plain Markdown on GitHub, in ebooks, and in other SSGs), point
+the content collection at an external directory instead of duplicating
+files into `src/content/`.
+
+**Setup:**
+
+1. Set the glob loader `base` to the external directory:
+   ```typescript
+   // src/content.config.ts
+   const docs = defineCollection({
+     loader: glob({
+       pattern: "**/*.md",
+       base: "../chapters",  // relative to astro project root
+     }),
+     schema: z.object({ ... }),
+   });
+   ```
+
+2. Add a remark plugin to rewrite cross-reference links at build time.
+   Chapters use `[Link](02-slug.md)` for GitHub compatibility; the
+   plugin rewrites to `../slug/` for Astro routing:
+   ```typescript
+   // src/plugins/remark-rewrite-links.ts
+   import { visit } from "unist-util-visit";
+   import type { Root, Link } from "mdast";
+
+   const CHAPTER_LINK = /^(\d{2}-)(.+)\.md(#.*)?$/;
+
+   export function remarkRewriteLinks() {
+     return (tree: Root) => {
+       visit(tree, "link", (node: Link) => {
+         const match = node.url.match(CHAPTER_LINK);
+         if (match) {
+           node.url = `../${match[2]}/${match[3] || ""}`;
+         }
+       });
+     };
+   }
+   ```
+
+3. Register the plugin in `astro.config.mjs`:
+   ```javascript
+   import { remarkRewriteLinks } from
+     './src/plugins/remark-rewrite-links.ts';
+
+   export default defineConfig({
+     markdown: {
+       remarkPlugins: [remarkRewriteLinks],
+     },
+   });
+   ```
+
+4. In CI, create a symlink for shared assets if chapters reference
+   them via relative paths:
+   ```yaml
+   - name: Create assets symlink
+     run: >
+       mkdir -p astro-site/src/content &&
+       ln -s ../../../assets astro-site/src/content/assets
+   ```
+
+**Rules:**
+- MUST NOT duplicate content files into `src/content/` — the external
+  directory is the single source of truth
+- The remark plugin MUST handle all link patterns used in the source
+  Markdown (numbered prefixes, anchors)
+- Image paths from the source directory MUST resolve correctly in both
+  GitHub rendering and the Astro build
+
 ---
 
 ## Assets

--- a/stack/static-site-tutorial.md
+++ b/stack/static-site-tutorial.md
@@ -68,8 +68,9 @@ and Quiz sections.
 - Reference other chapters by file: `[Topic A](02-topic-a.md)`
 - Reference sections within a chapter by heading anchor:
   `[Section Name](#section-name)`
-- The Astro build SHOULD rewrite chapter cross-references
-  automatically (see CI section)
+- The Astro build rewrites chapter cross-references automatically
+  via a remark plugin (see
+  [Single-source content pattern](static-site-astro.md#single-source-content-pattern))
 
 ---
 


### PR DESCRIPTION
## Summary

- Add single-source content pattern to `stack/static-site-astro.md` under Content Collections
- Documents how to point glob loader at an external directory with a remark plugin for link rewriting
- Includes setup steps: content config, remark plugin code, astro config, CI symlink
- Update `stack/static-site-tutorial.md` to reference the new pattern

Closes #53

## Test plan

- [x] Pattern matches working implementation in braboj/tutorial-git PR #115
- [x] Smoke tests pass

Generated with [Claude Code](https://claude.com/claude-code)