### PR TITLE
Make end-of-session checklist explicit

### DIFF
--- a/base/scope.md
+++ b/base/scope.md
@@ -48,11 +48,17 @@ When the user requests something out of scope:
 4. If switching, commit current progress before starting the new task
 
 ## End of session audit
-Before wrapping up a session, verify structural compliance:
-1. Check that all files required by referenced templates (e.g.
-   `base/docs.md`) exist and are populated
-2. Check that `CLAUDE.md` project structure matches the actual directory
-3. Check that `docs/dev-journal.md` has an entry for this session
-4. Check that any decisions made during the session have corresponding
-   ADRs in `docs/decisions/`
-5. Flag any gaps to the user before closing
+Before ending a session, verify all of the following:
+1. **Dev journal** — add a session entry to `docs/dev-journal.md`
+   (date, tool, key changes, PRs merged, issues closed/created, open issues)
+2. **CLAUDE.md** — update if project structure or conventions changed
+3. **README.md** — update if public-facing info (setup, links, structure) changed
+4. **ONBOARDING.md** — update `docs/ONBOARDING.md` if prerequisites,
+   setup steps, or project structure changed
+5. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
+   workflows or file paths changed
+6. **ADRs** — record any decisions made during the session in
+   `docs/decisions/`
+7. **Open issues** — close resolved issues, create issues for remaining work
+8. **Flag gaps** — if any of the above cannot be completed, flag it
+   to the user before closing

--- a/formats/agent.md
+++ b/formats/agent.md
@@ -77,7 +77,13 @@ them*.
 ### 6.1 Startup
 [base/scope.md — Session startup: read referenced docs, confirm scope]
 ### 6.2 End of session
-[base/scope.md — End of session audit: dev journal, ADRs, issues]
+Before ending a session, verify all of the following:
+1. Dev journal — add a session entry to docs/dev-journal.md
+2. CLAUDE.md — update if project structure or conventions changed
+3. README.md — update if public-facing info changed
+4. ONBOARDING.md — update if setup steps or structure changed
+5. PLAYBOOK.md — update if workflows or file paths changed
+6. Open issues — close resolved issues, create issues for remaining work
 ```
 
 Omit sections that are not applicable to the project (e.g. omit section 4
@@ -141,7 +147,13 @@ new layer, or pre-release.
 Read all referenced template documents before starting work.
 Confirm session scope with the user.
 ### 6.2 End of session
-Update dev journal, verify docs, close resolved issues, flag gaps.
+Before ending a session, verify all of the following:
+1. Dev journal — add a session entry to docs/dev-journal.md
+2. CLAUDE.md — update if project structure or conventions changed
+3. README.md — update if public-facing info changed
+4. ONBOARDING.md — update if setup steps or structure changed
+5. PLAYBOOK.md — update if workflows or file paths changed
+6. Open issues — close resolved issues, create issues for remaining work
 ```
 
 ---


### PR DESCRIPTION
## Summary

Replaces vague end-of-session instructions with an explicit numbered checklist in:

- `base/scope.md` — the canonical source for session protocol
- `formats/agent.md` — both inline and reference model templates

Each item names the document, the trigger condition for updating it, and (for the dev journal) what to include.

## Why

Downstream projects using the vague "verify docs, flag gaps" instruction consistently missed dev journal updates and doc synchronization. The explicit checklist was validated in braboj/tutorial-git across multiple sessions.

## Test plan

- [ ] `py tests/run_smoke.py` passes
- [ ] Checklist items are clear and actionable

Generated with [Claude Code](https://claude.com/claude-code)