### PR TITLE
Add review-before-merge rule to PR conventions

### DIFF
--- a/base/git.md
+++ b/base/git.md
@@ -20,6 +20,9 @@
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Before merging**, review the diff against the base branch. Follow
+  `base/review.md` priority order: security → correctness → clarity →
+  conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
   pushing to a stale one.


### PR DESCRIPTION
## Summary

Adds an explicit rule to `base/git.md` PR section: review the diff and check CI before merging. References `base/review.md` priority order.

## Why

The PR section described how to create and clean up PRs but never stated that the diff must be reviewed before merging. This led to PRs being merged after CI check alone, skipping the review step.

## Test plan

- [ ] `py tests/run_smoke.py` passes

Generated with [Claude Code](https://claude.com/claude-code)