### PR TITLE
docs: add submodule and template feedback checks to end-of-session audit

### DIFF
--- a/base/scope.md
+++ b/base/scope.md
@@ -60,5 +60,10 @@ Before ending a session, verify all of the following:
 6. **ADRs** — record any decisions made during the session in
    `docs/decisions/`
 7. **Open issues** — close resolved issues, create issues for remaining work
-8. **Flag gaps** — if any of the above cannot be completed, flag it
-   to the user before closing
+8. **Submodules** — check if upstream submodules need updates
+   (`git submodule update --remote`); commit the pointer bump if needed
+9. **Template feedback** — flag any conventions discovered or changed
+   during the session that should be contributed back to
+   solid-ai-templates
+10. **Flag gaps** — if any of the above cannot be completed, flag it
+    to the user before closing


### PR DESCRIPTION
## Summary

- Add item 8 (submodules — pull upstream updates) and item 9 (template feedback — flag conventions to contribute back) to the end-of-session audit in `base/scope.md`
- Renumber "Flag gaps" to item 10

## Test plan

- [ ] Verify numbering is correct in rendered Markdown
- [ ] Confirm downstream CLAUDE.md files can reference the new items

🤖 Generated with [Claude Code](https://claude.com/claude-code)