### PR TITLE
docs: add set:html prohibition to Astro stack template

### DIFF
--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -187,6 +187,8 @@ files into `src/content/`.
 - **Prettier** owns all formatting — commit `.prettierrc`; no style debates
   in code review
 - `.astro` files formatted with the official Prettier Astro plugin
+- MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
+  bypasses escaping; use `{expression}` for text content instead
 
 ---
 


### PR DESCRIPTION
## Summary

- Add MUST NOT rule for `set:html` in `stack/static-site-astro.md` code conventions
- Astro's `set:html` bypasses escaping like `innerHTML` — caught during tutorial-git code review

## Context

Found during tutorial-git deep code review: `Footer.astro` used `set:html` to render copyright text from JSON. While the data was hardcoded, the pattern is unsafe by convention. `base/quality.md` covers `innerHTML` but not Astro's framework-specific equivalent.