### PR TITLE
feat: add quality gates template with platform layer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -36,11 +36,24 @@ base/
 ├── containers.md  # Dockerfile, runtime security, resource limits, Kubernetes
 ├── deployment.md  # Deployment targets (cloud/hybrid/offline), certs, LB, registries, secrets
 ├── typescript.md    # Type design, naming, strictness — applies to all TypeScript projects
-├── templating.md    # Server-side rendering — partials, escaping, caching, forms, testing
-└── data-quality.md  # Data sourcing, completeness, freshness, scoring — data-heavy projects
+├── templating.md      # Server-side rendering — partials, escaping, caching, forms, testing
+├── data-quality.md    # Data sourcing, completeness, freshness, scoring — data-heavy projects
+└── quality-gates.md   # Three-layer gate model (editor → pre-commit → CI), thresholds, constraints
 ```
 
-### 2. Frontend templates (abstract, frontend layer)
+### 2. Platform templates (CI and security integration)
+
+CI and security tool mappings specific to a hosting platform. Orthogonal
+to the stack choice — a Python project on GitHub and a Python project on
+GitLab use the same tools; only the CI config and SAST tool differ.
+
+```
+platform/
+├── github.md      # CodeQL, GitHub Actions, gitleaks action, push protection
+└── gitlab.md      # Semgrep OSS, GitLab CI/CD, gitleaks CLI
+```
+
+### 3. Frontend templates (abstract, frontend layer)
 
 Concerns that apply to all frontend projects but not to backend or library
 projects. Extend base templates. Never used directly by a project.

--- a/base/cicd.md
+++ b/base/cicd.md
@@ -5,6 +5,12 @@
 Every project MUST have an automated pipeline. No manual steps between a
 merged PR and a deployed artifact — humans approve, machines execute.
 
+## Quality gates
+- Stages 2–4 (lint, test, security scan) are defined in detail in
+  `base/quality-gates.md` — categories, thresholds, and tool constraints
+- Platform-specific CI integration is in `platform/github.md` or
+  `platform/gitlab.md`
+
 ## Pipeline stages
 A pipeline MUST include, in order:
 

--- a/base/devsecops.md
+++ b/base/devsecops.md
@@ -6,6 +6,11 @@ Security is not a phase — it is part of every build, review, and release.
 Vulnerabilities and legal exposure MUST be surfaced during development —
 not after deployment.
 
+## Tool selection
+- Specific SAST and secret detection tools are defined per platform in
+  `platform/github.md` (CodeQL) and `platform/gitlab.md` (Semgrep)
+- See `base/quality-gates.md` for the three-layer enforcement model
+
 ## SAST (Static Application Security Testing)
 - Every pipeline run MUST include a static security analysis step
 - A failed scan MUST stop the build — the branch MUST NOT progress until

--- a/base/quality-gates.md
+++ b/base/quality-gates.md
@@ -1,0 +1,125 @@
+# Base — Quality Gates
+[ID: base-quality-gates]
+[DEPENDS ON: base/quality.md, base/git.md, base/testing.md, base/devsecops.md, base/cicd.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category | Layer 1 | Layer 2 | Layer 3 | Description |
+|----------|---------|---------|---------|-------------|
+| Lint | MUST | MUST | MUST | Code smells, unused variables, complexity |
+| Format | MUST | MUST | MUST | Consistent style (indentation, spacing, line length) |
+| Type check | SHOULD | SHOULD | MUST | Type errors before runtime |
+| Secret detection | — | MUST | MUST | API keys, tokens, passwords |
+| File hygiene | — | MUST | — | Trailing whitespace, merge conflicts, large files |
+| Security (SAST) | — | — | MUST | Static analysis for vulnerabilities |
+| Tests | — | — | MUST | Unit and integration tests |
+| Coverage | — | — | MUST | Percentage of code exercised by tests |
+| Build | — | — | MUST | Does it compile / build successfully |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+---
+
+## Thresholds
+[ID: quality-gates-thresholds]
+
+| Metric | Threshold | Enforcement |
+|--------|-----------|-------------|
+| Lint errors | 0 | CI fails |
+| Format compliance | 100% | CI fails |
+| Type errors | 0 | CI fails |
+| Security (high/critical) | 0 | CI fails |
+| Secrets detected | 0 | Pre-commit blocks + CI fails |
+| Build | Success | CI fails |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool

--- a/base/quality.md
+++ b/base/quality.md
@@ -100,6 +100,11 @@ Apply SOLID at the class, module, and service level:
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 
+## Automated enforcement
+- Quality conventions in this document are enforced automatically via
+  quality gates — see `base/quality-gates.md` for the three-layer model
+  (editor → pre-commit → CI), categories, and thresholds
+
 ## Code style
 - Encode all source files in UTF-8; content MUST be restricted to ASCII
   characters

--- a/base/testing.md
+++ b/base/testing.md
@@ -25,7 +25,9 @@ driver is TDD — tests are written alongside or before the code.
 - MUST cover all happy paths defined by functional requirements
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
-- The total codebase SHOULD maintain 80% unit test coverage
+- The total codebase SHOULD maintain 80% unit test coverage — see
+  `base/quality-gates.md` for the coverage policy (80% for new projects,
+  warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
 - Names are not part of any external report or traceability system — they

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -36,6 +36,17 @@ base:
     file: base/issues.md
   - id: base-scope
     file: base/scope.md
+  - id: base-quality-gates
+    file: base/quality-gates.md
+    depends_on: [base-quality, base-git, base-testing, base-devsecops, base-cicd]
+
+platform:
+  - id: platform-github
+    file: platform/github.md
+    depends_on: [base-quality-gates]
+  - id: platform-gitlab
+    file: platform/gitlab.md
+    depends_on: [base-quality-gates]
 
 frontend:
   - id: frontend-ux

--- a/platform/github.md
+++ b/platform/github.md
@@ -1,0 +1,52 @@
+# Platform — GitHub
+[ID: platform-github]
+[DEPENDS ON: base/quality-gates.md]
+
+GitHub-specific CI and security integration. Maps quality gate categories
+to GitHub Actions workflows and GitHub-native features.
+
+---
+
+## CI
+[ID: platform-github-ci]
+
+- Pipeline definitions: `.github/workflows/*.yml`
+- Trigger: `on: pull_request` for validation, `on: push` for main branch
+- Actions marketplace for reusable steps
+
+---
+
+## SAST
+[ID: platform-github-sast]
+
+- **CodeQL** — GitHub-native, free for all repositories (public and private)
+- Enable via Settings → Code security → CodeQL analysis
+- Runs as a GitHub Actions workflow or as automatic analysis
+- Supports: JavaScript, TypeScript, Python, Go, Java, C/C++, C#, Ruby
+- Stack-specific SAST supplements (Bandit, govulncheck) run as CI steps
+
+---
+
+## Secret detection
+[ID: platform-github-secrets]
+
+- **GitHub push protection** — native, blocks pushes containing known
+  secret patterns; enable via Settings → Code security
+- **gitleaks** — `gitleaks/gitleaks-action` in CI for additional coverage
+- Both SHOULD be enabled — push protection catches on push, gitleaks
+  catches in PR validation
+
+---
+
+## Quality gate integration
+[ID: platform-github-gates]
+
+| Category | Tool / Integration |
+|----------|--------------------|
+| SAST | CodeQL (GitHub-native) |
+| SAST (Python) | + Bandit (CI step) |
+| SAST (Go) | + govulncheck (CI step) |
+| Secret detection | GitHub push protection + gitleaks action |
+| Site quality | `treosh/lighthouse-ci-action` |
+| Link checking | `lycheeverse/lychee-action` |
+| All lint/format/type/test | Language-specific CLI in CI steps |

--- a/platform/gitlab.md
+++ b/platform/gitlab.md
@@ -1,0 +1,53 @@
+# Platform — GitLab
+[ID: platform-gitlab]
+[DEPENDS ON: base/quality-gates.md]
+
+GitLab-specific CI and security integration. Maps quality gate categories
+to GitLab CI/CD pipelines and GitLab-native features.
+
+---
+
+## CI
+[ID: platform-gitlab-ci]
+
+- Pipeline definitions: `.gitlab-ci.yml`
+- Trigger: merge request pipelines for validation, branch pipelines for main
+- Reusable configuration via `include:` and `extends:`
+
+---
+
+## SAST
+[ID: platform-gitlab-sast]
+
+- **Semgrep OSS** — open-source, free for all repositories
+- Runs as `semgrep ci` in a pipeline job
+- Supports: JavaScript, TypeScript, Python, Go, Java, C/C++, Ruby, and more
+- Community rules cover OWASP Top 10 and language-specific patterns
+- Stack-specific SAST supplements (Bandit, govulncheck) run as pipeline jobs
+- GitLab Ultimate includes built-in SAST, but Semgrep OSS avoids the
+  tier dependency
+
+---
+
+## Secret detection
+[ID: platform-gitlab-secrets]
+
+- **gitleaks** — `gitleaks detect` in a pipeline job
+- GitLab Ultimate includes native secret detection, but gitleaks avoids
+  the tier dependency
+- MUST run on every merge request pipeline
+
+---
+
+## Quality gate integration
+[ID: platform-gitlab-gates]
+
+| Category | Tool / Integration |
+|----------|--------------------|
+| SAST | Semgrep OSS (pipeline job) |
+| SAST (Python) | + Bandit (pipeline job) |
+| SAST (Go) | + govulncheck (pipeline job) |
+| Secret detection | gitleaks (pipeline job) |
+| Site quality | `@lhci/cli` (pipeline job) |
+| Link checking | lychee CLI (pipeline job) |
+| All lint/format/type/test | Language-specific CLI in pipeline jobs |

--- a/stack/go-lib.md
+++ b/stack/go-lib.md
@@ -1,5 +1,5 @@
 # Stack — Go Library / CLI
-[DEPENDS ON: base/git.md, base/docs.md, base/quality.md]
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, base/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `stack/go-service.md`.
@@ -92,3 +92,19 @@ go vet ./...          # static analysis
 goimports -w .        # format imports
 staticcheck ./...     # additional static analysis
 ```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
+| Format | gofmt | gofmt | gofmt -l | built-in |
+| Type check | built-in | built-in | go vet | — |
+| Security | — | — | govulncheck + platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
+| Tests | — | — | go test ./... | — |
+| Coverage | — | — | go test -cover ≥ 80% | — |
+
+- Hook framework: `pre-commit` or Makefile

--- a/stack/python-lib.md
+++ b/stack/python-lib.md
@@ -1,5 +1,5 @@
 # Stack — Python Library / CLI
-[DEPENDS ON: base/git.md, base/docs.md, base/quality.md]
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, base/quality-gates.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -111,3 +111,22 @@ ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
 ```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
+| Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
+| Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Security | — | — | Bandit + platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
+| Tests | — | — | pytest | `pyproject.toml` |
+| Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+
+- Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
+- Docstring convention: Google — enforced via Ruff `D` rules with
+  `convention = "google"` in `pyproject.toml`

--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -1,5 +1,5 @@
 # Stack — Astro (Static Site)
-[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, base/typescript.md, frontend/ux.md, frontend/quality.md, frontend/static-site.md]
+[DEPENDS ON: base/git.md, base/docs.md, base/quality.md, base/quality-gates.md, base/typescript.md, frontend/ux.md, frontend/quality.md, frontend/static-site.md]
 
 Extends the static site stack with Astro-specific rules.
 
@@ -206,3 +206,22 @@ npm run dev      # develop — hot reload at localhost:4321
 npm run build    # compile — production build to dist/
 npm run preview  # verify — preview the production build locally
 ```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | ESLint | ESLint | ESLint | `eslint.config.js` |
+| Format | Prettier | Prettier | Prettier --check | `.prettierrc` |
+| Type check | TypeScript | tsc --noEmit | tsc --noEmit | `tsconfig.json` |
+| Security | — | — | Platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | — |
+| Build | — | — | astro build | — |
+| Links | — | — | lychee | `lychee.toml` |
+| Site quality | — | — | Lighthouse CI ≥ 90 | `lighthouserc.json` |
+
+- Hook framework: `husky` + `lint-staged` — config in `package.json`
+- Lighthouse thresholds: accessibility ≥ 90 (error), performance / SEO /
+  best practices ≥ 90 (warn)


### PR DESCRIPTION
## Summary

- New `base/quality-gates.md` — stack-agnostic three-layer gate model (editor → pre-commit → CI), categories, thresholds, coverage policy (80% new, warn-only legacy), what not to gate, tool constraints
- New `platform/` directory with `github.md` (CodeQL, GitHub Actions) and `gitlab.md` (Semgrep, GitLab CI)
- Stack extensions for Python (`python-lib.md`), Go (`go-lib.md`), and Astro (`static-site-astro.md`)
- Cross-references from `base/quality.md`, `base/cicd.md`, `base/devsecops.md`, `base/testing.md`
- Registered in `manifest.yaml` and documented in `SPEC.md`

All tools free for private repos. No SaaS dependency.

## Test plan

- [ ] `manifest.yaml` references are valid (no dangling IDs)
- [ ] `DEPENDS ON` lists in new/modified files match manifest
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)