### PR TITLE
docs: add dev journal

### DIFF
--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,0 +1,14 @@
+# Dev Journal
+
+## 2026-04-27 — Skills roadmap and commercialization spike
+
+- Added Phase 15 (Skills) to `ROADMAP.md` with four categories:
+  generative, transformation, review, ops — plus infrastructure tasks
+- Renamed existing Phase 15 (Validation) to Phase 16
+- Updated `SPIKE-IMCONTEXT-COMMERCIALIZATION.md` in `imbra-explore`:
+  added "Skills as a marketplace dimension" subsection under Option 5
+- Key insight: skills (dynamic, on-demand actions) complement static
+  context files (CLAUDE.md/AGENTS.md) — they don't replace them
+- Skills fit into the existing im-context product roadmap as an
+  extension of the template marketplace (Year 3+), but should be
+  designed into CLI/web app from the start


### PR DESCRIPTION
## Summary

- Create `docs/dev-journal.md` with first session entry (skills roadmap and commercialization spike)

## Test plan

- [x] Docs-only change — no structural impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)