### PR TITLE
Add 360-degree analysis template and standardize labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,38 @@ py tools/sync.py --check    # exit 1 if any file is out of sync
   new work
 - Do not commit `.idea/`, editor config, or any generated output
 
+## Issue labels
+
+Every issue MUST have exactly one type label and one priority label.
+Triage labels are terminal — applied when closing without action.
+
+### Type labels (pick one)
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `bug` | `#C9372C` | Defect in existing functionality |
+| `epic` | `#8270DB` | Large initiative spanning multiple tasks |
+| `task` | `#357DE8` | Atomic implementable work |
+| `spike` | `#6CC3E0` | Research or exploration — output is a decision |
+| `incident` | `#AE2E24` | Production outage or degradation affecting users now |
+
+### Priority labels (pick one)
+
+| Label | Color | Meaning |
+|-------|-------|---------|
+| `P0` | `#E06C00` | Critical — blocks everything |
+| `P1` | `#FCA700` | High — must fix before next milestone |
+| `P2` | `#EED12B` | Medium — important but not blocking |
+| `P3` | `#4BCE97` | Low — nice to have |
+| `P4` | `#8590A2` | Backlog — someday |
+
+### Triage labels
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `duplicate` | `#C1C7D0` | Already tracked by another issue |
+| `wontdo` | `#C1C7D0` | Acknowledged but will not be addressed |
+
 ### 2.2 Adding a new stack template
 
 1. Create `stack/<prefix>-<name>.md` following an existing file of

--- a/base/360.md
+++ b/base/360.md
@@ -1,0 +1,428 @@
+# Base — 360-Degree Analysis
+[ID: base-360]
+
+## Principle
+
+A code review checks changed files. A structure audit checks project
+completeness. A 360-degree analysis checks the whole project from four
+stakeholder perspectives — user, engineer, business analyst, and
+marketer — to surface blind spots that single-perspective reviews miss.
+
+---
+
+## When to run
+[ID: 360-when]
+
+- Before a public launch or major release
+- After completing a major feature or milestone
+- Quarterly for active projects
+- When evaluating whether a project is ready for commercialization
+- When onboarding a new stakeholder who needs the full picture
+
+---
+
+## Execution model
+[ID: 360-execution]
+
+The four categories are independent. They SHOULD be executed as four
+parallel subagents, each with its own role prompt. This provides:
+
+- **Speed** — four evaluations run simultaneously
+- **Perspective isolation** — each agent stays in its role with no
+  bleed between categories
+
+Each subagent starts with a clean context — no conversation history,
+no prior findings. The isolation is structural (separate context
+windows), not just instructional. This prevents the most common
+failure mode: all four perspectives collapsing into a developer
+review.
+
+```
+Parent agent
+├── spawn Agent (role: User)      → Value report
+├── spawn Agent (role: Engineer)  → Quality report
+├── spawn Agent (role: Analyst)   → Viability report
+└── spawn Agent (role: Marketer)  → Discovery report
+└── merge → summary table + overall grade
+```
+
+### Subagent prompt structure
+
+Each subagent prompt MUST include:
+
+1. **Role prompt** — the perspective to adopt (see category sections)
+2. **Project path** — absolute path to the project root
+3. **Checklist** — the sub-dimensions and checklist items for that
+   category
+4. **Output format** — letter grade (A–F), findings table, summary
+
+Sequential execution with role switches is acceptable when parallel
+agents are not available, but the role prompt MUST be restated before
+each category to force a perspective reset.
+
+---
+
+## Categories
+[ID: 360-categories]
+
+### 1. Value (user perspective)
+[ID: 360-value]
+
+**Role prompt:** "You are a first-time user encountering this product.
+You have no knowledge of the codebase, the architecture, or the
+development process. Do NOT read developer documentation (CLAUDE.md,
+package.json, ONBOARDING.md, PLAYBOOK.md). Only examine what a user
+would see: the landing page, the product itself, and the user-facing
+sections of the README (what it does, features, usage). Evaluate
+whether the product delivers on its promise from the outside in."
+
+#### Phase 1 — Extract promises
+
+Before evaluating, discover what the product claims to do. Read
+only user-facing materials:
+
+1. **README** — the "What it does" and feature list sections
+   (skip project structure, commands, contributing)
+2. **Landing page / homepage** — hero text, feature sections, CTAs
+3. **Navigation** — every nav item is an implicit promise that the
+   section exists and works
+4. **Meta descriptions** — what search engines show users
+5. **User journeys** — if `docs/user-journeys.md` exists, read it
+   for cross-feature paths the UI alone does not reveal
+
+Compile a numbered promise list before proceeding to Phase 2.
+
+If the project has no landing page (private repo, library, CLI),
+the README is the sole source of promises.
+
+#### Phase 2 — Evaluate
+
+#### Sub-dimensions
+
+**Functional completeness**
+- [ ] Every capability listed in the README or landing page works
+- [ ] Every navigation item leads to a functioning section with
+  real content
+- [ ] No placeholder content, stub pages, or dead-end links
+- [ ] Data-driven features contain substantive data — no empty
+  tables, no skeleton entries, no counts that contradict claims
+- [ ] Cross-feature journeys (from `docs/user-journeys.md` or
+  inferred from navigation) work end to end without breaking
+
+**Content quality**
+- [ ] Content is accurate — information matches reality, no
+  outdated or contradictory statements
+- [ ] Content is deep enough to be useful — not just surface-level
+  summaries that leave the user needing another source
+- [ ] Sources are cited where claims depend on external data
+- [ ] Content is current — no stale dates, broken external links,
+  or references to discontinued products
+- [ ] Content covers what a user would reasonably expect given the
+  product's stated scope
+
+**Usability**
+- [ ] A new user can identify what the product does and who it is
+  for within 10 seconds of landing
+- [ ] Navigation structure matches the user's mental model — users
+  can predict where to find what they need
+- [ ] Interactive elements (filters, sorts, toggles, search) behave
+  as their labels promise
+- [ ] Layout is consistent across pages — same patterns, same
+  placement of controls
+- [ ] Responsive design works on mobile, tablet, and desktop
+- [ ] Error states and empty states are clear and actionable — not
+  blank screens or cryptic messages
+
+**Trust**
+- [ ] Author or organization is identified
+- [ ] The product feels maintained — no "last updated 2 years ago"
+  signals, no broken features left unfixed
+- [ ] Data sources are disclosed where relevant
+- [ ] There is a way to report errors or give feedback
+- [ ] The product looks professional — consistent styling, no
+  visual glitches, no misaligned elements
+
+**Accessibility (experienced)**
+- [ ] All content is reachable and operable by keyboard alone
+- [ ] Text is readable without zooming on a standard screen
+- [ ] Content remains understandable at 200% zoom without
+  horizontal scrolling
+- [ ] Color is never the only way to convey meaning — labels,
+  icons, or patterns provide redundancy
+- [ ] Interactive elements are visually distinguishable from static
+  content
+
+Note: technical compliance (WCAG audit, axe-core, ARIA attributes)
+is evaluated by the Quality agent, not here. This checks the
+experienced outcome, not the implementation.
+
+**Performance (perceived)**
+- [ ] Pages feel instant — no perceptible delay on navigation
+- [ ] No layout shifts or content flashing during load
+- [ ] Interactive elements respond immediately to input
+- [ ] Large pages (long lists, many images) remain usable — no
+  freezing or excessive scrolling lag
+
+Note: measured performance (Lighthouse scores, Core Web Vitals
+numbers) is evaluated by the Quality agent. This checks what the
+user experiences, not what the metrics say.
+
+---
+
+### 2. Quality (engineer perspective)
+[ID: 360-quality]
+
+**Role prompt:** "You are a senior engineer reviewing this project
+for production readiness. Do NOT evaluate user experience, business
+viability, or marketing effectiveness — those belong to other
+perspectives. Focus on the internals: can this project be built,
+tested, deployed, and maintained by a competent engineer? Use the
+project's own conventions (CLAUDE.md, quality templates) as the
+standard."
+
+#### Sub-dimensions
+
+**Architecture**
+- [ ] A fresh clone builds successfully without undocumented steps
+- [ ] Project structure matches what CLAUDE.md and README describe
+- [ ] Separation of concerns — content, code, configuration, and
+  assets are in distinct directories
+- [ ] No circular dependencies between modules
+- [ ] No dead code, unused files, or orphaned assets
+
+**Code**
+- [ ] Type safety enforced (strict mode, no `any` or equivalent)
+- [ ] Naming conventions followed consistently per the project's
+  own rules
+- [ ] No debug statements (`console.log`, `debugger`, `print`)
+  in committed code
+- [ ] No commented-out code blocks — version control is the history
+- [ ] No hardcoded secrets, API keys, or credentials
+- [ ] No dangerous patterns (`eval`, `set:html`, `innerHTML` with
+  unsanitized input)
+- [ ] Code style consistent — linter configured, or manual rules
+  documented and followed
+
+**Testing**
+- [ ] Tests exist for business logic and critical paths
+- [ ] Tests pass — no skipped, ignored, or known-failing tests
+  without documented reason
+- [ ] Tests are runnable from CI without human intervention
+- [ ] Coverage is measured — threshold enforced or trending upward
+- [ ] Tests verify behavior, not implementation details
+
+**CI/CD and quality gates**
+- [ ] Layer 1 (editor) — lint and format on save configured
+- [ ] Layer 2 (pre-commit) — hooks block bad commits locally
+- [ ] Layer 3 (CI) — automated pipeline runs on every PR
+- [ ] Build, lint, test, and security scan stages present
+- [ ] CI is green on main — no pre-existing failures treated as
+  normal
+- [ ] Pipeline fails fast on violations — no "allowed to fail"
+  stages
+- [ ] Deployment automated on merge to main
+
+**Security**
+- [ ] SAST enabled (CodeQL, Semgrep, or equivalent)
+- [ ] Secret detection enabled (push protection, gitleaks)
+- [ ] Dependencies scanned for known vulnerabilities
+- [ ] No credentials in source history
+- [ ] CI/CD permissions scoped to minimum required
+- [ ] User input validated at system boundaries
+
+**Documentation**
+- [ ] README accurately describes the current state of the project
+- [ ] ONBOARDING enables a new contributor to clone, build, and
+  run the project without asking questions
+- [ ] PLAYBOOK covers daily operational tasks and common workflows
+- [ ] Dev journal maintained with session entries
+- [ ] Architectural decisions recorded as ADRs
+- [ ] All documentation reflects the current state of the code —
+  no stale references to removed features or old paths
+- [ ] User journeys documented in `docs/user-journeys.md` if the
+  product has cross-feature paths (optional but recommended)
+
+---
+
+### 3. Viability (business analyst perspective)
+[ID: 360-viability]
+
+**Role prompt:** "You are a business analyst assessing whether this
+project is sustainable to operate and maintain long-term. You do
+NOT care about code quality, user experience, or marketing. Focus
+on cost, risk, and operational health. Ask: can the owner keep this
+running without it consuming disproportionate time or money? What
+happens if something goes wrong?"
+
+#### Sub-dimensions
+
+**Licensing and compliance**
+- [ ] License is clearly stated in the repository
+- [ ] All dependencies carry compatible licenses
+- [ ] No copyleft dependencies without explicit approval
+- [ ] License terms match the intended use (commercial, open
+  source, educational)
+- [ ] Privacy and data handling comply with applicable regulations
+  (GDPR, CCPA) — or the product collects no personal data
+
+**Cost and vendor risk**
+- [ ] Hosting and infrastructure costs are known and proportional
+  to the project's value
+- [ ] No paid services required without documented justification
+- [ ] No single-vendor lock-in on critical infrastructure — a
+  migration path exists or the cost of switching is acceptable
+- [ ] Build and deploy pipeline costs are sustainable (free tier,
+  budgeted, or self-hosted)
+
+**Maintainability**
+- [ ] A new contributor can onboard from documentation alone —
+  no oral knowledge transfer required
+- [ ] Bus factor risk is documented — if the project is solo,
+  documentation and automation mitigate the risk
+- [ ] A backlog or roadmap exists — the project has a visible
+  direction, not just reactive fixes
+- [ ] Maintenance burden is proportional — the project does not
+  require constant attention to stay operational
+- [ ] Contribution model is clear (who can contribute, how
+  changes get reviewed and merged)
+
+**Dependency and operational risk**
+- [ ] No critical dependency maintained by a single person with
+  no successors
+- [ ] Dependencies are actively maintained — last release within
+  12 months for core dependencies
+- [ ] Dependency count is minimal — no unnecessary packages that
+  increase the attack and maintenance surface
+- [ ] The project can survive a key dependency being abandoned —
+  alternatives exist or the dependency is trivially replaceable
+- [ ] Disaster recovery: the project can be rebuilt from the
+  repository alone (no external state, no manual configuration)
+
+---
+
+### 4. Discovery (marketing perspective)
+[ID: 360-discovery]
+
+**Role prompt:** "You are a marketing specialist evaluating whether
+this product can be found by its target audience and whether it
+makes a compelling first impression. You do NOT care about code
+quality, business costs, or technical implementation. Focus on: can
+people find this? Would they click? Would they share it? Do NOT
+check whether meta tags exist in the HTML — that is the engineer's
+job. Instead, evaluate whether the content of those tags is
+compelling and correctly targeted."
+
+#### Sub-dimensions
+
+**Positioning**
+- [ ] It is immediately clear what this product is and who it is
+  for — no jargon, no ambiguity
+- [ ] The value proposition is stated, not implied — a visitor
+  understands the benefit within seconds
+- [ ] The product is differentiated — it is clear why someone
+  would use this instead of alternatives
+- [ ] The name and domain (if any) are memorable and relevant to
+  the product's purpose
+
+**SEO effectiveness**
+- [ ] Meta titles are compelling — they describe the page AND
+  encourage clicks, not just list keywords
+- [ ] Meta descriptions read like a pitch — they answer "why
+  should I click this?"
+- [ ] Page content targets search intent — what would the target
+  audience actually search for?
+- [ ] Heading hierarchy tells a scannable story — a user skimming
+  headings alone understands the page
+- [ ] URL structure is clean, human-readable, and predictable
+
+**Social shareability**
+- [ ] OG image is visually compelling — not a generic logo or
+  blank placeholder
+- [ ] Shared links preview well on social platforms — title,
+  description, and image form a coherent card
+- [ ] The product contains content worth sharing — insights, data,
+  tools, or reference material that users would send to others
+- [ ] Social proof exists or is being built — stars, testimonials,
+  user count, community activity
+
+**Analytics and feedback**
+- [ ] Analytics are configured and collecting data
+- [ ] Privacy-friendly solution chosen — no consent banner
+  required, no third-party tracking
+- [ ] Success metrics are defined — the owner knows what "working"
+  looks like in numbers
+- [ ] Data informs decisions — there is evidence that analytics
+  have influenced at least one product or content change
+
+**Distribution and reach**
+- [ ] The product is present where its target audience already
+  looks — relevant communities, forums, directories, or platforms
+- [ ] Content is indexable by search engines — no accidental
+  noindex, no broken sitemap, no JavaScript-only rendering
+- [ ] The product can be found through at least two independent
+  channels (search, social, community, word of mouth, directory)
+- [ ] Growth mechanism exists — even if organic, there is a
+  reason new users would discover this over time
+
+---
+
+## Output format
+[ID: 360-output]
+
+### Per-category report
+
+Each subagent returns:
+
+```markdown
+## [Category] — Grade: [A–F]
+
+### Findings
+
+| # | Sub-dimension | Status | Finding |
+|---|---------------|--------|---------|
+| 1 | [name]        | PASS   | —       |
+| 2 | [name]        | FAIL   | [what]  |
+| 3 | [name]        | PARTIAL| [what]  |
+
+### Summary
+[2–3 sentences from the role's perspective]
+```
+
+### Summary table
+
+The parent agent merges into:
+
+```markdown
+| Category | Grade | Findings | Critical |
+|----------|-------|----------|----------|
+| Value    | [A–F] | [n]      | [n]      |
+| Quality  | [A–F] | [n]      | [n]      |
+| Viability| [A–F] | [n]      | [n]      |
+| Discovery| [A–F] | [n]      | [n]      |
+| **Overall** | **[A–F]** | **[n]** | **[n]** |
+```
+
+### Grading scale
+
+| Grade | Meaning |
+|-------|---------|
+| A | All checks pass, no findings |
+| B | Minor findings only, no blockers |
+| C | Some findings, one or more gaps to address |
+| D | Significant gaps, not ready for the stated goal |
+| F | Critical failures, immediate action required |
+
+The overall grade is the lowest category grade — the project is
+only as strong as its weakest perspective.
+
+---
+
+## Relationship to other templates
+[ID: 360-relationships]
+
+- `base/review.md` — peer review checks changed files in a PR;
+  360 checks the whole project
+- `base/scope.md` — end-of-session audit is operational (did I
+  update docs?); 360 is strategic (is this project healthy?)
+- `base/quality-gates.md` — defines enforcement layers; 360 checks
+  whether they are configured and effective

--- a/base/issues.md
+++ b/base/issues.md
@@ -7,14 +7,41 @@ a title convention, and a body template.
 ---
 
 ## Labels
+[ID: base-issues-labels]
 
-| Type | Label | When to use |
-|------|-------|-------------|
-| Epic | `epic` | Large initiative spanning multiple tasks/sessions |
-| Task | domain labels | Atomic implementable work (use `enhancement`, `scoring`, `ui`, etc.) |
-| Bug | `bug` | Defect in existing functionality |
-| Incident | `incident` | Production outage or degradation affecting users now |
-| Spike | `question` | Research or exploration — output is a decision or ADR |
+Every issue MUST have exactly one type label and one priority label.
+Triage labels are terminal — applied when closing without action.
+
+### Type labels (pick one)
+
+Colors follow the Atlassian design system palette.
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `bug` | `#C9372C` | Defect in existing functionality |
+| `epic` | `#8270DB` | Large initiative spanning multiple tasks |
+| `task` | `#357DE8` | Atomic implementable work |
+| `spike` | `#6CC3E0` | Research or exploration — output is a decision |
+| `incident` | `#AE2E24` | Production outage or degradation affecting users now |
+
+### Priority labels (pick one)
+
+Warm-to-cool gradient — visually distinct from type labels.
+
+| Label | Color | Meaning |
+|-------|-------|---------|
+| `P0` | `#E06C00` | Critical — blocks everything |
+| `P1` | `#FCA700` | High — must fix before next milestone |
+| `P2` | `#EED12B` | Medium — important but not blocking |
+| `P3` | `#4BCE97` | Low — nice to have |
+| `P4` | `#8590A2` | Backlog — someday |
+
+### Triage labels
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `duplicate` | `#C1C7D0` | Already tracked by another issue |
+| `wontdo` | `#C1C7D0` | Acknowledged but will not be addressed |
 
 ---
 
@@ -158,7 +185,7 @@ bug — a bug is a defect you discover, an incident is something burning.
 
 Research or exploration where the output is a decision, not code.
 
-**Title:** the question being investigated (no prefix — the `question`
+**Title:** the question being investigated (no prefix — the `spike`
 label identifies the type)
 
 **Format:** use the task format. The acceptance criteria describe what the

--- a/base/readme.md
+++ b/base/readme.md
@@ -15,6 +15,11 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- A capability list MUST follow the summary — bullet points stating
+  what the product can do, written as capabilities not counts (e.g.
+  "browse and filter lenses by specs" not "240+ lenses"); this list
+  is the product's contract and the primary input for value evaluation
+  (see `base/360.md`)
 - A badges line SHOULD follow: build status, latest version, license
 
 ### 2. Quick start
@@ -76,8 +81,13 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- Write for a technically competent reader who has not seen this project
-  before — MUST NOT assume familiarity with internal terminology
+- A README serves two audiences. The first three sections (title,
+  quick start, usage) are user-facing — what the product does and
+  how to use it. The remaining sections (structure, setup, config)
+  are developer-facing — how to build and contribute. Write each
+  section for its audience.
+- Write for a reader who has not seen this project before — MUST
+  NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use
 
 ### Maintenance


### PR DESCRIPTION
## Summary

- Add `base/360.md` — four-category project assessment template (Value, Quality, Viability, Discovery) with role prompts and parallel subagent execution
- Standardize issue labels across all Imbra repos — 12 canonical labels with Atlassian-style colors, applied to 11 repos
- Update `base/issues.md` with the canonical label set (5 type, 5 priority, 2 triage)
- Update `base/readme.md` — capability list requirement, dual-audience clarification
- Update `CLAUDE.md` — issue labels section

## Test plan

- [ ] Verify `base/360.md` follows template authoring rules (IDs, imperative language, RFC 2119)
- [ ] Verify label tables in `base/issues.md` and `CLAUDE.md` match
- [ ] Verify `base/readme.md` changes are backwards-compatible
- [ ] Run `py tests/run_smoke.py` after merging to validate references

Closes #66