### PR TITLE
Move label implementation to platform/github

### DIFF
--- a/base/issues.md
+++ b/base/issues.md
@@ -6,42 +6,29 @@ a title convention, and a body template.
 
 ---
 
-## Labels
-[ID: base-issues-labels]
+## Issue types
+[ID: base-issues-types]
 
-Every issue MUST have exactly one type label and one priority label.
-Triage labels are terminal — applied when closing without action.
+Every issue MUST have exactly one type and one priority.
 
-### Type labels (pick one)
+| Type | When to use |
+|------|-------------|
+| Bug | Defect in existing functionality |
+| Epic | Large initiative spanning multiple tasks |
+| Task | Atomic implementable work |
+| Spike | Research or exploration — output is a decision |
+| Incident | Production outage or degradation affecting users now |
 
-Colors follow the Atlassian design system palette.
+| Priority | Meaning |
+|----------|---------|
+| P0 | Critical — blocks everything |
+| P1 | High — must fix before next milestone |
+| P2 | Medium — important but not blocking |
+| P3 | Low — nice to have |
+| P4 | Backlog — someday |
 
-| Label | Color | When to use |
-|-------|-------|-------------|
-| `bug` | `#C9372C` | Defect in existing functionality |
-| `epic` | `#8270DB` | Large initiative spanning multiple tasks |
-| `task` | `#357DE8` | Atomic implementable work |
-| `spike` | `#6CC3E0` | Research or exploration — output is a decision |
-| `incident` | `#AE2E24` | Production outage or degradation affecting users now |
-
-### Priority labels (pick one)
-
-Warm-to-cool gradient — visually distinct from type labels.
-
-| Label | Color | Meaning |
-|-------|-------|---------|
-| `P0` | `#E06C00` | Critical — blocks everything |
-| `P1` | `#FCA700` | High — must fix before next milestone |
-| `P2` | `#EED12B` | Medium — important but not blocking |
-| `P3` | `#4BCE97` | Low — nice to have |
-| `P4` | `#8590A2` | Backlog — someday |
-
-### Triage labels
-
-| Label | Color | When to use |
-|-------|-------|-------------|
-| `duplicate` | `#C1C7D0` | Already tracked by another issue |
-| `wontdo` | `#C1C7D0` | Acknowledged but will not be addressed |
+Platform-specific label implementation (names, colors) is defined in
+the platform template (e.g. `platform/github.md`).
 
 ---
 

--- a/platform/github.md
+++ b/platform/github.md
@@ -1,9 +1,9 @@
 # Platform — GitHub
 [ID: platform-github]
-[DEPENDS ON: base/quality-gates.md]
+[DEPENDS ON: base/quality-gates.md, base/issues.md]
 
-GitHub-specific CI and security integration. Maps quality gate categories
-to GitHub Actions workflows and GitHub-native features.
+GitHub-specific CI, security, and issue label integration. Maps quality
+gate categories to GitHub Actions workflows and GitHub-native features.
 
 ---
 
@@ -50,3 +50,44 @@ to GitHub Actions workflows and GitHub-native features.
 | Site quality | `treosh/lighthouse-ci-action` |
 | Link checking | `lycheeverse/lychee-action` |
 | All lint/format/type/test | Language-specific CLI in CI steps |
+
+---
+
+## Issue labels
+[ID: platform-github-labels]
+[EXTEND: base-issues-types]
+
+GitHub implements issue types and priorities as labels. Every issue
+MUST have exactly one type label and one priority label. Triage
+labels are terminal — applied when closing without action.
+
+Colors follow the Atlassian design system palette. Type labels use
+saturated hues; priority labels use a warm-to-cool gradient to
+remain visually distinct when displayed side by side.
+
+### Type labels (pick one)
+
+| Label | Color | Maps to |
+|-------|-------|---------|
+| `bug` | `#C9372C` | Bug |
+| `epic` | `#8270DB` | Epic |
+| `task` | `#357DE8` | Task |
+| `spike` | `#6CC3E0` | Spike |
+| `incident` | `#AE2E24` | Incident |
+
+### Priority labels (pick one)
+
+| Label | Color | Maps to |
+|-------|-------|---------|
+| `P0` | `#E06C00` | P0 — Critical |
+| `P1` | `#FCA700` | P1 — High |
+| `P2` | `#EED12B` | P2 — Medium |
+| `P3` | `#4BCE97` | P3 — Low |
+| `P4` | `#8590A2` | P4 — Backlog |
+
+### Triage labels
+
+| Label | Color | When to use |
+|-------|-------|-------------|
+| `duplicate` | `#C1C7D0` | Already tracked by another issue |
+| `wontdo` | `#C1C7D0` | Acknowledged but will not be addressed |


### PR DESCRIPTION
## Summary

- Move label names, colors, and triage labels from `base/issues.md` to `platform/github.md`
- `base/issues.md` keeps platform-agnostic issue types and priorities
- `platform/github.md` gains the GitHub-specific label implementation with Atlassian-style colors

## Test plan

- [ ] Verify `base/issues.md` has no platform-specific content (no colors, no label names)
- [ ] Verify `platform/github.md` labels match what's deployed across repos
- [ ] Run `py tests/run_smoke.py` to validate references