### PR TITLE
Add ADRs, document bus factor, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,23 @@
 
 Composable, SOLID-inspired templates for generating AI agent context files.
 
+## What it does
+
+- Generate consistent `CLAUDE.md` or `AGENTS.md` files for any project
+- Compose rules from reusable layers — base, backend/frontend, stack
+- Cover 30+ technology stacks (Python, Go, Java, Node, Rust, mobile, DevOps)
+- Output for any agent — Claude Code, Cursor, Copilot, Codex CLI
+- Run a 360-degree project assessment across four perspectives (user,
+  engineer, analyst, marketer)
+- Enforce standardized issue labels, quality gates, and review processes
+
 ## Overview
 
-Most AI context files (`CLAUDE.md`, `AGENTS.md`)
-are written from scratch for each project and quickly fall out of sync.
-This repository provides a reusable template system — structured like
-object-oriented design — where base rules are defined once and composed with
-stack-specific extensions to produce a complete, consistent context file for
-any project type.
-
-The system is agent-agnostic: the same templates produce output for Claude
-Code, Cursor, GitHub Copilot, or OpenAI Codex CLI by applying a different
-output format guide.
+Most AI context files are written from scratch for each project and quickly
+fall out of sync. This repository provides a reusable template system —
+structured like object-oriented design — where base rules are defined once
+and composed with stack-specific extensions to produce a complete, consistent
+context file for any project type.
 
 Works for new projects and refactoring alike — the generated context file
 describes how code *should be written*, giving your agent a consistent target
@@ -212,10 +217,13 @@ solid-ai-templates/
 ├── base/           # Cross-cutting rules — apply to every project
 ├── backend/        # Backend layer — HTTP, API, database, observability
 ├── frontend/       # Frontend layer — UX, accessibility, CSS, SEO
+├── platform/       # CI and security tool mappings (GitHub, GitLab)
 ├── stack/          # Concrete stacks — extend base + layer templates
 ├── formats/        # Output format guides per agent tool
 ├── examples/       # Complete generated context files (reference)
+├── tests/          # Smoke and E2E test runners and specs
 ├── tools/          # sync.py — generates tables from manifest.yaml
+├── docs/           # Onboarding, playbook, decision logs
 ├── INTERVIEW.md    # Agent-driven project setup interview
 ├── SPEC.md         # System design, composition rules, precedence
 └── ROADMAP.md      # Project status and planned work
@@ -235,8 +243,8 @@ No build step or runtime dependencies — all templates are plain Markdown.
 1. Create `stack/<name>.md` following the structure of an existing stack.
 2. Declare `DEPENDS ON` at the top referencing the base and layer templates
    it builds on.
-3. Add the stack to the supported stacks table in this README.
-4. Add an entry to `CONCEPTS.md`.
+3. Register in `manifest.yaml` under `stacks:`.
+4. Run `py tools/sync.py` to update generated tables.
 5. Add a `examples/<name>/CLAUDE.md` to demonstrate the output.
 
 **To verify your changes:** open your agent, attach the new template alongside
@@ -294,6 +302,9 @@ See `formats/agents.md` for structure, models, and formatting rules.
 - [System design and composition rules](SPEC.md)
 - [Project status and roadmap](ROADMAP.md)
 - [Example generated context files](examples/)
+- [Onboarding guide](docs/ONBOARDING.md)
+- [Operational playbook](docs/PLAYBOOK.md)
+- [Architecture decision records](docs/decisions/)
 
 ## License
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -98,8 +98,18 @@ fixing content, and submitting a PR.
 - Stack files follow the `<prefix>-<name>.md` naming convention (see `CLAUDE.md`)
 - `manifest.yaml` must be updated whenever a file is added, removed, or renamed
 
+## Maintainership
+
+This project has a bus factor of 1 — Branimir Georgiev is the sole
+author and maintainer. The mitigation is documentation: everything
+needed to understand, maintain, and extend the project is in the
+repository (SPEC.md, CLAUDE.md, PLAYBOOK.md, ADRs in docs/decisions/,
+dev journal). No oral knowledge transfer is required.
+
+If the maintainer becomes unavailable, the project can be forked and
+continued from the repository alone.
+
 ## Getting help
 
 - `SPEC.md` — answers most "how does X work" questions
-- `CONCEPTS.md` — find which file covers a given concept
 - Open a GitHub Discussion if something is unclear

--- a/docs/decisions/001-inheritance-model.md
+++ b/docs/decisions/001-inheritance-model.md
@@ -1,0 +1,54 @@
+# ADR-001: Inheritance model for template composition
+
+**Status:** Accepted
+**Date:** 2025-03-01
+
+## Context
+
+AI context files (CLAUDE.md, AGENTS.md) contain rules that are largely
+the same across projects using the same stack. Writing them from
+scratch per project leads to inconsistency and drift. We needed a
+system to define rules once and compose them for any project type.
+
+## Decision
+
+Use a three-layer inheritance model inspired by SOLID principles:
+
+```
+base/ → frontend/backend/ → stack/
+```
+
+- **base/** — cross-cutting rules (git, docs, quality, testing, security)
+  that apply to every project regardless of stack
+- **frontend/** and **backend/** — layer-specific rules that apply to
+  all projects in that layer
+- **stack/** — concrete, technology-specific rules that extend or
+  override parent templates
+- **platform/** — orthogonal to the chain; a project picks one
+  platform (GitHub, GitLab) regardless of stack
+
+Composition uses three directives:
+- `[DEPENDS ON: ...]` — declares parent templates
+- `[EXTEND: ...]` — adds rules to a parent section
+- `[OVERRIDE: ...]` — replaces a parent section entirely
+
+## Alternatives considered
+
+1. **Monolithic templates** — one large file per stack with all rules
+   inline. Rejected: duplicates base rules across 30+ stacks, making
+   updates a maintenance nightmare.
+2. **Copy-paste with manual sync** — share rules by copying. Rejected:
+   drift is inevitable, no enforcement mechanism.
+3. **Runtime includes** — tooling that merges files at build time.
+   Rejected: adds complexity; agents can follow DEPENDS ON references
+   natively without preprocessing.
+
+## Consequences
+
+- Adding a new base rule (e.g. a security convention) automatically
+  applies to all stacks that depend on it
+- Stack templates are small — they only contain what differs from
+  the parent
+- The dependency graph must be acyclic — enforced by smoke tests
+- New contributors must understand the inheritance model before
+  contributing (mitigated by ONBOARDING.md and SPEC.md)

--- a/docs/decisions/002-label-standardization.md
+++ b/docs/decisions/002-label-standardization.md
@@ -1,0 +1,54 @@
+# ADR-002: Standardized issue labels across repositories
+
+**Status:** Accepted
+**Date:** 2026-04-28
+
+## Context
+
+Imbra repositories used GitHub's default labels (enhancement, question,
+documentation, good first issue, help wanted, invalid, wontfix) with
+no consistency across repos. Labels had no priority dimension, making
+triage by urgency impossible. Some labels were misleading (e.g.
+`question` for spikes, `enhancement` for tasks).
+
+## Decision
+
+Standardize to 12 labels across all repositories, split into three
+groups:
+
+**Type labels (pick one per issue):**
+`bug`, `epic`, `task`, `spike`, `incident`
+
+**Priority labels (pick one per issue):**
+`P0` (critical), `P1` (high), `P2` (medium), `P3` (low), `P4` (backlog)
+
+**Triage labels (terminal — applied when closing):**
+`duplicate`, `wontdo`
+
+Rules:
+- Every issue MUST have exactly one type + one priority
+- Colors follow the Atlassian design system palette
+- Type labels use saturated hues; priority labels use a warm-to-cool
+  gradient to remain visually distinct when displayed side by side
+- Issue types and priorities are platform-agnostic (base/issues.md);
+  label names and colors are GitHub-specific (platform/github.md)
+
+## Alternatives considered
+
+1. **Keep GitHub defaults** — rejected: no priority dimension, labels
+   like `enhancement` are verbose, `question` is misleading for spikes.
+2. **Minimal set (bug + P0-P4 only)** — rejected: issue list becomes
+   unreadable without type labels; you can't tell bugs from tasks at
+   a glance.
+3. **GitHub Projects custom fields** — rejected: requires a project
+   board, fields not visible on the issue list, overhead for a solo
+   project.
+
+## Consequences
+
+- Every issue in every Imbra repo has a complete type + priority
+  matrix — no gaps when filtering or exporting
+- Labels are documented in base/issues.md (types) and
+  platform/github.md (implementation) — new repos get the same set
+- Old labels (enhancement, question, documentation) were migrated
+  and deleted — 55+ issues re-labeled with zero data loss

--- a/docs/decisions/003-360-analysis.md
+++ b/docs/decisions/003-360-analysis.md
@@ -1,0 +1,57 @@
+# ADR-003: 360-degree analysis as a reusable template
+
+**Status:** Accepted
+**Date:** 2026-04-28
+
+## Context
+
+Existing review templates (base/review.md for code review,
+base/scope.md for session audit) are purely technical. They miss
+user value, business viability, and marketing discoverability.
+A 360-degree analysis was performed ad-hoc on tutorial-git and
+proved useful, but the methodology was improvised and all four
+perspectives were evaluated from a developer lens.
+
+## Decision
+
+Add base/360.md as a four-category assessment template:
+
+1. **Value** (user) — functional completeness, content quality,
+   usability, trust, accessibility, performance
+2. **Quality** (engineer) — architecture, code, testing, CI/CD,
+   security, documentation
+3. **Viability** (analyst) — licensing, cost, maintainability,
+   dependency and operational risk
+4. **Discovery** (marketer) — positioning, SEO effectiveness,
+   social shareability, analytics, distribution
+
+Each category has a role prompt that the evaluating agent MUST
+adopt. Categories are independent and SHOULD be executed as
+parallel subagents — each starts with a clean context to enforce
+structural perspective isolation (not just instructional).
+
+The Value agent reads user-facing materials (README capability
+list, landing page, docs/user-journeys.md) and verifies promises.
+It does NOT read developer documentation.
+
+## Alternatives considered
+
+1. **Extend base/review.md with non-technical checks** — rejected:
+   review.md is scoped to PR changes, not whole-project assessment.
+2. **Single-agent sequential evaluation** — rejected: perspective
+   bleed causes all four categories to collapse into a developer
+   review. Parallel subagents with clean contexts fix this.
+3. **Separate templates per category** — rejected: the four
+   categories are designed to be used together; splitting them
+   loses the summary table and overall grade.
+
+## Consequences
+
+- Projects can run a structured assessment before launch, at
+  milestones, or quarterly
+- The Value agent needs a README with a capability list
+  (base/readme.md updated to require this)
+- Cross-feature user journeys should be documented in
+  docs/user-journeys.md for the Value agent to verify
+- The overall grade is the lowest category grade — the project
+  is only as strong as its weakest perspective


### PR DESCRIPTION
## Summary

- Add 3 ADRs: inheritance model, label standardization, 360-degree analysis
- Document bus factor mitigation in ONBOARDING.md
- Improve README: capability list, fix project structure, update dev setup, add links

Closes #68, #71, #18

## Test plan

- [ ] ADRs follow format from base/docs.md
- [ ] README project structure matches actual directories
- [ ] All README links resolve
- [ ] ONBOARDING maintainership section is accurate