### PR TITLE
Add session entry and Phase 16 to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,7 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 
 ## Phase 13 — Language-specific base templates
 
-- [ ] `base/typescript.md` — new: type design, discriminated unions, naming, strictness
+- [x] `base/typescript.md` — new: type design, discriminated unions, naming, strictness
 
 ## Phase 14 — Content stacks
 
@@ -182,7 +182,18 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 - [ ] Claude Code skill integration (first target)
 - [ ] Document skill authoring in `docs/PLAYBOOK.md`
 
-## Phase 16 — Validation
+## Phase 16 — Assessment and governance
+
+- [x] `base/360.md` — new: four-category project assessment (Value, Quality, Viability, Discovery)
+- [x] `base/issues.md` — updated: platform-agnostic issue types and priorities
+- [x] `platform/github.md` — updated: canonical label set (12 labels, Atlassian colors)
+- [x] `base/readme.md` — updated: capability list requirement, dual-audience
+- [x] `docs/decisions/` — new: 3 ADRs (inheritance, labels, 360 analysis)
+- [x] `LICENSE` — new: CC BY 4.0
+- [x] `docs/ONBOARDING.md` — updated: bus factor documentation
+- [x] `README.md` — updated: capability list, structure, links
+
+## Phase 17 — Validation
 
 - [ ] Use the system on a real new project end-to-end (see examples)
 - [ ] Use the system on a real refactoring project end-to-end

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,5 +1,48 @@
 # Dev Journal
 
+## 2026-04-28 — 360 analysis, labels, ADRs, license
+
+**Tool:** Claude Code (Opus 4.6, 1M context)
+
+**Key changes:**
+- Created `base/360.md` — four-category project assessment template
+  (Value, Quality, Viability, Discovery) with role prompts and parallel
+  subagent execution model (19 sub-dimensions, 78 checklist items)
+- Standardized issue labels to 12 canonical labels with Atlassian-style
+  colors across 11 repos (10 Imbra-Ltd + braboj/tutorial-git)
+- Split `base/issues.md` (platform-agnostic types) from
+  `platform/github.md` (GitHub label implementation)
+- Updated `base/readme.md` — capability list requirement, dual-audience
+  clarification
+- Created `docs/decisions/` with 3 ADRs: inheritance model, label
+  standardization, 360 analysis
+- Added CC BY 4.0 license (LICENSE file + README update)
+- Documented bus factor mitigation in ONBOARDING.md
+- Improved README: capability list, project structure, dev setup, links
+
+**PRs merged:** #73, #74, #75, #76
+
+**Issues closed:** #58 (duplicate), #66, #67, #68, #70, #71, #18
+
+**Issues remaining (7):**
+- #69 task P1 — Add offline E2E test mode
+- #55 task P2 — Add SEO conventions
+- #16 task P2 — Review e2e test pipeline
+- #15 task P2 — Review smoke test pipeline
+- #72 task P3 — Tag v1.0.0 release
+- #13 task P3 — Regenerate examples
+- #10 task P4 — Refactor test runners
+
+**Decisions:**
+- ADR-001: Three-layer inheritance model (base → layer → stack)
+- ADR-002: 12 canonical labels, Atlassian colors, type/priority split
+- ADR-003: 360-degree analysis as parallel subagent evaluation
+- License: CC BY 4.0 — maximizes adoption funnel, requires attribution
+- Labels split: types in base/ (platform-agnostic), colors in platform/
+  (GitHub-specific)
+- Severity stays in bug body text, not as label — solo project, priority
+  drives triage order
+
 ## 2026-04-27 — Skills roadmap and commercialization spike
 
 - Added Phase 15 (Skills) to `ROADMAP.md` with four categories:


### PR DESCRIPTION
## Summary

- Dev journal: 2026-04-28 session (360 template, labels, ADRs, license, 4 PRs merged, 7 issues closed)
- ROADMAP: add Phase 16 (Assessment and governance) with all session deliverables, renumber Validation to Phase 17
- Mark base/typescript.md as done in Phase 13