### PR TITLE
feat: add rule against hardcoded derived counts

### DIFF
--- a/base/quality.md
+++ b/base/quality.md
@@ -3,6 +3,8 @@
 
 ## Architecture
 - All editable content in a data directory — never hardcoded in components
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
 - Default to the simplest component type; only reach for heavier abstractions
   when genuinely needed
 - No dead code — remove unused components, styles, and data files promptly


### PR DESCRIPTION
## Summary

- Add architecture rule to `base/quality.md`: never hardcode derived counts or statistics — compute them from the data source
- Triggered by stale "17 recipes" in tutorial-git (actual count: 25) and "241 lenses" in Wuseria

## Test plan

- [ ] Verify the rule reads clearly and sits logically under Architecture
- [ ] Run `py tests/run_smoke.py` to confirm no structural regressions

Closes #79

Generated with [Claude Code](https://claude.com/claude-code)