### PR TITLE
feat: add audit decomposition and SEO conventions

### DIFF
--- a/base/review.md
+++ b/base/review.md
@@ -49,11 +49,16 @@ completeness. Run a structure audit after:
 Verify every MUST from:
 
 - `base/docs.md` — standard documents (README, ONBOARDING, PLAYBOOK, ADRs)
-- `base/readme.md` — README has all 9 required sections
+- `base/readme.md` — README has all 8 required sections
 - `base/git.md` — .gitignore, README exist
 - The relevant frontend or backend layer template — required assets,
   config files, SEO files
 - The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`base/readme.md` Usage requires both usage examples AND expected output
+per example — these are two separate checks.
 
 ## Deviations
 - Deviating from a SHOULD rule requires a written explanation in the pull

--- a/frontend/static-site.md
+++ b/frontend/static-site.md
@@ -136,4 +136,11 @@ to change.
 - `robots.txt` required
 - Open Graph and Twitter Card meta tags required
 - Canonical URLs required
+- Sitemap MUST be generated at build time and referenced in `robots.txt`
+- Every content page MUST have a unique `description` in frontmatter — used
+  for `<meta name="description">`, OG description, and Twitter Card
+- Meta descriptions MUST read as a pitch, not a summary — answer "why
+  should I click this?"
+- JSON-LD structured data SHOULD be present on content pages (Article,
+  Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)

--- a/frontend/static-site.md
+++ b/frontend/static-site.md
@@ -131,6 +131,7 @@ to change.
 ---
 
 ## SEO
+[ID: static-site-seo]
 [EXTEND: frontend-quality]
 
 - `robots.txt` required

--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -225,3 +225,24 @@ npm run preview  # verify — preview the production build locally
 - Hook framework: `husky` + `lint-staged` — config in `package.json`
 - Lighthouse thresholds: accessibility ≥ 90 (error), performance / SEO /
   best practices ≥ 90 (warn)
+
+---
+
+## SEO
+[EXTEND: static-site-seo]
+
+- `@astrojs/sitemap` MUST be installed as an Astro integration — generates
+  `sitemap-index.xml` at build time
+- Content collections MUST include a `description` field in the Zod schema:
+  ```typescript
+  z.object({
+    title: z.string(),
+    description: z.string(),
+    // ...
+  })
+  ```
+- Layouts MUST render the description as `<meta name="description">`, OG
+  description, and Twitter Card description
+- JSON-LD structured data SHOULD be rendered in a `<script type="application/ld+json">`
+  tag in the layout — use `JSON.stringify()` with `set:html` (acceptable
+  exception to the `set:html` ban since the input is fully server-controlled)


### PR DESCRIPTION
## Summary

- **#78:** Add sub-clause decomposition guidance to structure audit in `base/review.md`. Fix section count from 9 to 8.
- **#55:** Add SEO conventions (sitemap, description frontmatter, JSON-LD, meta description quality) to `frontend/static-site.md` and `stack/static-site-astro.md`.

## Changes

### `base/review.md`
- Add rule: verify each MUST sub-clause independently, not sections as a whole
- Fix README section count (8, not 9)

### `frontend/static-site.md`
- Add sitemap generation requirement
- Add `description` frontmatter requirement for content pages
- Add meta description quality rule (pitch, not summary)
- Add JSON-LD structured data recommendation

### `stack/static-site-astro.md`
- Add `@astrojs/sitemap` as required integration
- Add `description` as required Zod schema field
- Add layout rendering requirements for description meta tags
- Add JSON-LD implementation guidance with `set:html` exception

## Test plan

- [ ] Run `py tests/run_smoke.py` to confirm no structural regressions
- [ ] Verify new rules are clear and non-redundant with existing content

Closes #78, Closes #55

Generated with [Claude Code](https://claude.com/claude-code)