### PR TITLE
fix: pre-tag cleanup for v1.0.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 - [x] `frontend/quality.md` — added state management decision guide
 - [x] `frontend/ux.md` — added accessibility testing (axe, Lighthouse, screen reader, keyboard)
 - [x] `SPEC.md` — documented precedence rules and OVERRIDE/EXTEND conflict resolution
-- [x] `CONCEPTS.md` — new: concept-to-file navigation index
+- [x] ~`CONCEPTS.md`~ — removed; `manifest.yaml` serves as the concept-to-file index
 - [x] `examples/` — new: three complete generated context files (FastAPI, React SPA, Astro)
 
 ## Phase 7 — Quality improvements (post-assessment)

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,7 +64,8 @@ base/
 ├── issues.md       # Issue templates — epic, task, bug, incident, spike
 ├── scope.md        # Scope guard, session protocol, drift prevention
 ├── quality-gates.md # Three-layer gate model (editor, pre-commit, CI), thresholds
-└── ai-workflow.md  # AI-assisted development lifecycle, work item hierarchy
+├── ai-workflow.md  # AI-assisted development lifecycle, work item hierarchy
+└── 360.md          # 360-degree project analysis — four stakeholder perspectives, grading
 ```
 
 ```

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -45,7 +45,6 @@ No build step, no dependencies to install. All templates are plain Markdown.
 | `CLAUDE.md` | Rules for contributing to this repo |
 | `ROADMAP.md` | What has been done and what is planned |
 | `manifest.yaml` | Machine-readable dependency graph |
-| `CONCEPTS.md` | Concept-to-file navigation index |
 | `examples/` | Complete generated CLAUDE.md files — the target output |
 
 ## How templates relate

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -26,8 +26,7 @@ composition model.
 4. Add to the stack list in `SPEC.md` (alphabetical within category)
 5. Add a row to the stacks table in `README.md`
 6. Add an entry to `ROADMAP.md` under the current phase
-7. Add to `CONCEPTS.md` if the stack introduces new concepts
-8. Validate: attach `INTERVIEW.md` + new stack to an agent and confirm output
+7. Validate: attach `INTERVIEW.md` + new stack to an agent and confirm output
 
 ---
 
@@ -56,7 +55,7 @@ composition model.
 1. `git mv <old-path> <new-path>`
 2. Update every `[DEPENDS ON: ...]` header that references the old path
 3. Update `manifest.yaml` — change the `file:` field for the entry
-4. Update `SPEC.md`, `README.md`, `ROADMAP.md`, `CONCEPTS.md`, `INTERVIEW.md`
+4. Update `SPEC.md`, `README.md`, `ROADMAP.md`, `INTERVIEW.md`
    — search for the old filename and replace
 5. Update any `examples/` files that reference the old path
 6. Verify with `git status` that no old references remain
@@ -69,7 +68,7 @@ composition model.
 2. Search all template files for `[EXTEND: <old>]` and `[OVERRIDE: <old>]`
    — update every occurrence
 3. Update `manifest.yaml` if the ID is referenced in `depends_on` lists
-4. Update `CONCEPTS.md` if the concept is indexed there
+4. Update `manifest.yaml` if the concept maps to a template entry
 
 ---
 
@@ -133,7 +132,7 @@ check.
 1. Ensure you are on a feature branch — never commit to `main` directly
 2. Run the validation steps above for every changed template
 3. Update all affected documents (`SPEC.md`, `README.md`, `ROADMAP.md`,
-   `manifest.yaml`, `CONCEPTS.md`) before committing
+   `manifest.yaml`) before committing
 4. Commit with a conventional message:
    ```
    feat(stack): add python-celery-worker template

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -67,6 +67,9 @@ base:
   - id: base-ai-workflow
     file: base/ai-workflow.md
     description: AI-assisted development lifecycle, work item hierarchy
+  - id: base-360
+    file: base/360.md
+    description: 360-degree project analysis — four stakeholder perspectives, grading
 
 platform:
   - id: platform-github

--- a/tests/run_e2e.py
+++ b/tests/run_e2e.py
@@ -813,7 +813,7 @@ def run_test(test, dry_run=False):
     tid = test["id"]
 
     if "skip" in test:
-        return SKIP, test["skip"], None
+        return SKIP, test["skip"], None, None
 
     prompt = build_prompt(
         test["stack"], test["answers"],


### PR DESCRIPTION
## Summary

Fixes all P1 blockers found by the 360-degree analysis before tagging v1.0.0.

- **#82** Fix runtime crash in `run_e2e.py` — skip return tuple was 3 values, caller expects 4
- **#83** Add `base/360.md` to `manifest.yaml` — was the only template missing from the manifest
- **#84** Remove all `CONCEPTS.md` references — file was never committed, referenced in 4 documents
- **#86** Add 8 GitHub topics for discoverability (claude-md, ai-coding-agent, claude-code, etc.)

## Test plan

- [x] `py tests/run_smoke.py` — 7/7 pass
- [x] `py tools/sync.py --check` — all files in sync
- [ ] CI smoke passes

Closes #82, Closes #83, Closes #84, Closes #86

Generated with [Claude Code](https://claude.com/claude-code)