### PR TITLE
fix: clean up stale docs before v1.0.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,11 +49,10 @@ See `SPEC.md` for design decisions and `README.md` for an overview.
 
 ## Phase 5 — Agent output coverage
 
-- [x] `formats/claude.md` — Claude Code → `CLAUDE.md`
-- [x] `formats/cursorrules.md` — Cursor → `.cursor/rules/project.mdc`
-- [x] `formats/copilot.md` — GitHub Copilot → `.github/copilot-instructions.md`
-- [x] `formats/codex.md` — OpenAI Codex CLI → `AGENTS.md`
-- [x] `formats/generic.md` — fallback → `AI_CONTEXT.md`
+- [x] `formats/agents.md` — consolidated output format template covering all
+  agents (Claude Code, Cursor, Copilot, Codex CLI); original per-agent files
+  (`formats/claude.md`, `formats/cursorrules.md`, `formats/copilot.md`,
+  `formats/codex.md`, `formats/generic.md`) were merged into a single file
 
 ## Phase 6 — Quality pass
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -137,7 +137,17 @@ stack/
 ```
 <!-- /generated:spec-directories -->
 
-### 6. Interview template (orchestrator)
+### 6. Output format template
+
+Rendering rules for the generated output. Describes structure, model
+selection (inline/reference/hybrid), and formatting constraints.
+
+```
+formats/
+└── agents.md    # Output structure, models, formatting rules
+```
+
+### 7. Interview template (orchestrator)
 
 A single file any agent uses to ask the user the required questions before
 generating the output context file. Questions are grouped by concern and
@@ -147,19 +157,7 @@ reference the relevant base/stack templates.
 INTERVIEW.md
 ```
 
-### 4. Output format templates
-
-Rendering rules for each output format. Describe structure, formatting
-constraints, and tone.
-
-```
-formats/
-├── shared.md    # Shared structure, model selection (inline/reference/hybrid)
-├── claude.md    # Claude Code → CLAUDE.md
-└── codex.md     # Codex CLI / Devin / Cursor → AGENTS.md
-```
-
-### 5. Profile (generated output)
+### 8. Profile (generated output)
 
 The context file generated for a specific project by combining interview
 answers + base templates + stack template + output format template.
@@ -181,7 +179,7 @@ base/git.md ──────────────────────�
 base/docs.md ───────────────────────────────────────────┤
 base/quality.md ────────────────────────────────────────┤
                                                         ▼
-frontend/ux.md ─────────────────────────────► stack/static-site.md
+frontend/ux.md ─────────────────────────────► frontend/static-site.md
 frontend/quality.md ────────────────────────►          │
                                                         ▼
                                              stack/static-site-astro.md

--- a/tests/specs/SAIT-E2E-FMT-02-001A.md
+++ b/tests/specs/SAIT-E2E-FMT-02-001A.md
@@ -1,5 +1,5 @@
 ---
-id: SAIT-E2E-FMT-05-001A
+id: SAIT-E2E-FMT-02-001A
 uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567811
 title: Full interview produces a correct AGENTS.md for a FastAPI project
 product: sait


### PR DESCRIPTION
## Summary

Last three bugs before tagging v1.0.0.

- **#85** SPEC.md: fix section ordering, replace deleted format file references with `formats/agents.md`, fix inheritance diagram path
- **#87** ROADMAP: update Phase 5 to reflect format consolidation into single file
- **#88** Test spec `SAIT-E2E-FMT-02-001A.md`: fix frontmatter ID mismatch (said FMT-05, should be FMT-02)

## Test plan

- [x] `py tools/sync.py --check` — all files in sync
- [x] `py tests/run_smoke.py` — 7/7 pass
- [ ] CI smoke passes

Closes #85, Closes #87, Closes #88

Generated with [Claude Code](https://claude.com/claude-code)