### PR TITLE
fix: add explicit permissions to CI workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,6 +3,9 @@ name: Smoke tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to both `smoke.yml` and `e2e.yml`
- Scopes workflows to minimum required access

Closes #89

Generated with [Claude Code](https://claude.com/claude-code)