### PR TITLE
feat: add gitleaks secret detection to CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,3 +18,9 @@ jobs:
         run: pip install pyyaml
       - name: Run smoke tests
         run: python tests/run_smoke.py
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+      - name: Secret detection (gitleaks)
+        run: gitleaks detect --source . --verbose


### PR DESCRIPTION
## Summary

- Add gitleaks CLI to the smoke workflow for secret detection on every PR
- Uses direct CLI install (free) instead of gitleaks-action v2 (requires paid license)
- Also enabled GitHub push protection and secret scanning on the repo
- Branch protection now requires PRs before merging (enforce_admins: true)

## Test plan

- [ ] CI passes — gitleaks finds no secrets in the repo
- [ ] Smoke tests still pass alongside gitleaks

Generated with [Claude Code](https://claude.com/claude-code)