### PR TITLE
fix: switch e2e CI to offline mode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: E2E tests
+name: E2E tests (offline)
 
 on:
   push:
@@ -17,10 +17,6 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install pyyaml anthropic
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
-      - name: Run E2E tests
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: python tests/run_e2e.py
+        run: pip install pyyaml
+      - name: Run E2E tests (offline)
+        run: python tests/run_e2e.py --offline


### PR DESCRIPTION
## Summary

- Switch e2e workflow from live (claude -p) to offline (--offline)
- Removes anthropic SDK and Claude Code CLI as CI dependencies
- Validates test infrastructure without API calls or costs
- Live mode still available locally: `py tests/run_e2e.py`

## Test plan

- [ ] CI smoke passes
- [ ] After merge, e2e workflow runs green on push to main

Generated with [Claude Code](https://claude.com/claude-code)