### PR TITLE
docs: update CLAUDE.md and dev journal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,8 @@ Triage labels are terminal — applied when closing without action.
 | Label | Color | When to use |
 |-------|-------|-------------|
 | `bug` | `#C9372C` | Defect in existing functionality |
-| `epic` | `#8270DB` | Large initiative spanning multiple tasks |
-| `task` | `#357DE8` | Atomic implementable work |
+| `epic` | `#9F8FEF` | Large initiative spanning multiple tasks |
+| `task` | `#579DFF` | Atomic implementable work |
 | `spike` | `#6CC3E0` | Research or exploration — output is a decision |
 | `incident` | `#AE2E24` | Production outage or degradation affecting users now |
 
@@ -186,27 +186,37 @@ Triage labels are terminal — applied when closing without action.
 
 ### 3.1 Testing
 
-Two test runners live in `tests/`:
+Four files in `tests/`:
+
+| File | Purpose |
+|------|---------|
+| `tests/lib.py` | Shared utilities (constants, file reading, report writing, arg parsing) |
+| `tests/cases.py` | E2E test case definitions, grouped by area (STK, FMT, ITV, DPL) |
+| `tests/run_smoke.py` | Smoke test runner (7 structural checks) |
+| `tests/run_e2e.py` | E2E test runner (30 tests) |
 
 ```bash
 py tests/run_smoke.py              # 7 structural checks
 py tests/run_smoke.py SYS-01       # run one check by ID
 
-py tests/run_e2e.py                # 30 agent-based tests
-py tests/run_e2e.py STK-01 FMT-01  # run specific tests
-py tests/run_e2e.py --dry-run      # build prompts only
+py tests/run_e2e.py                # 30 agent-based tests (live, needs API key)
+py tests/run_e2e.py --offline      # validate test infrastructure without API
+py tests/run_e2e.py --area=STK     # run all stack tests
+py tests/run_e2e.py STK-01 FMT-01  # run specific tests by ID
+py tests/run_e2e.py --fail-fast    # stop on first failure
+py tests/run_e2e.py --dry-run      # print prompts, skip execution
 ```
 
 - Both runners write a timestamped Markdown report to
   `tests/reports/` after every run (gitignored)
 - Spec files live in `tests/specs/` — see `tests/CODIFICATION.md`
   for the ID scheme and `tests/INDEX.md` for the full list
+- CI runs smoke + gitleaks on PRs, e2e offline on push to main
+- Live e2e mode (without `--offline`) calls Claude via the API —
+  run manually on the dev machine for functional validation
 - To validate a new template: run `py tests/run_smoke.py` and
   attach `INTERVIEW.md` + the new stack to an agent to confirm
   coherent output
-- To validate a structural change: run `py tests/run_smoke.py` —
-  it checks all `[DEPENDS ON: ...]`, `[EXTEND: ...]`,
-  `[OVERRIDE: ...]`, and `manifest.yaml` references automatically
 
 ## 4. Documentation
 

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -1,5 +1,52 @@
 # Dev Journal
 
+## 2026-04-30 — v1.0.0 release, repo transfer, CI hardening
+
+**Tool:** Claude Code (Opus 4.6, 1M context)
+
+**Key changes:**
+- Tagged v1.0.0 release
+- Transferred repo from Imbra-Ltd to braboj
+- Added `base/quality.md` rule: never hardcode derived counts
+- Added audit decomposition guidance to `base/review.md`
+- Added SEO conventions to `frontend/static-site.md` and
+  `stack/static-site-astro.md` (sitemap, description, JSON-LD)
+- Fixed stale references in SPEC.md, ROADMAP.md, ONBOARDING.md,
+  PLAYBOOK.md (CONCEPTS.md, format files, section ordering)
+- Fixed e2e crash bug (3-tuple return on skipped tests)
+- Added `base/360.md` to manifest.yaml
+- Fixed test spec frontmatter ID mismatch
+- Added `--offline` mode to e2e runner — validates test
+  infrastructure without API calls
+- Refactored test runners: extracted `tests/lib.py` (shared
+  utilities) and `tests/cases.py` (30 test cases grouped by area)
+- Added `--area` and `--fail-fast` flags to e2e runner
+- CI hardened: enforce_admins, require PR before merge, gitleaks
+  in smoke workflow, push protection enabled, e2e switched to
+  offline mode in CI
+- Updated label colors: task `#579DFF`, epic `#9F8FEF`
+- Added 8 GitHub topics for discoverability
+- Updated all in-repo URLs and submodule pointers after transfer
+
+**PRs merged:** #80, #81, #91, #92, #93, #94, #95, #96, #97, #98, #99
+
+**Issues closed:** #79, #78, #55, #15, #16, #82, #83, #84, #85,
+#86, #87, #88, #89, #69, #72, #10
+
+**Issues created:** #82–#90, #100
+
+**Issues remaining (3):**
+- #90 task P2 — Write launch post and submit to awesome lists
+- #100 task P2 — Replace claude CLI with Anthropic SDK in e2e runner
+- #13 task P3 — Regenerate examples
+
+**Decisions:**
+- Repo transferred to braboj for better OSS discoverability
+- E2E CI runs offline mode — live mode is manual/nightly only
+- gitleaks CLI preferred over gitleaks-action (no license key needed)
+- Label colors updated for accessibility (task, epic were too dark)
+- pytest adoption deferred — hand-rolled runners are sufficient
+
 ## 2026-04-28 — 360 analysis, labels, ADRs, license
 
 **Tool:** Claude Code (Opus 4.6, 1M context)


### PR DESCRIPTION
## Summary

- Fix stale label colors in CLAUDE.md (task, epic)
- Document new test runner structure (lib.py, cases.py)
- Document --offline, --area, --fail-fast flags
- Add 2026-04-30 session entry to dev journal

Generated with [Claude Code](https://claude.com/claude-code)