### PR TITLE
fix: remove commercialization references from dev journal

### DIFF
--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -90,15 +90,10 @@
 - Severity stays in bug body text, not as label — solo project, priority
   drives triage order
 
-## 2026-04-27 — Skills roadmap and commercialization spike
+## 2026-04-27 — Skills roadmap
 
 - Added Phase 15 (Skills) to `ROADMAP.md` with four categories:
   generative, transformation, review, ops — plus infrastructure tasks
 - Renamed existing Phase 15 (Validation) to Phase 16
-- Updated `SPIKE-IMCONTEXT-COMMERCIALIZATION.md` in `imbra-explore`:
-  added "Skills as a marketplace dimension" subsection under Option 5
 - Key insight: skills (dynamic, on-demand actions) complement static
   context files (CLAUDE.md/AGENTS.md) — they don't replace them
-- Skills fit into the existing im-context product roadmap as an
-  extension of the template marketplace (Year 3+), but should be
-  designed into CLI/web app from the start


### PR DESCRIPTION
## Summary

- Remove cross-repo spike references and marketplace strategy from dev journal
- Commercialization analysis belongs in imbra-spikes, not in product repos

Generated with [Claude Code](https://claude.com/claude-code)