### PR TITLE
feat(scope): harden session protocol with startup hygiene and sequential audit

### DIFF
--- a/base/scope.md
+++ b/base/scope.md
@@ -13,11 +13,36 @@ Before starting any work, the agent MUST:
    `docs/solid-ai-templates/base/git.md`, `base/docs.md`, etc.)
 2. These contain binding conventions that CLAUDE.md inherits — do not
    proceed until you have read and understood them
-3. Confirm the scope with the user before making changes
-4. If the task is ambiguous, ask: "What is the specific deliverable for
+3. Check which branch you are on — if not `main`, ask why before
+   proceeding
+4. Check `git status` — if uncommitted changes exist, resolve before
+   starting new work
+5. Confirm the scope with the user before making changes
+6. If the task is ambiguous, ask: "What is the specific deliverable for
    this session?"
-5. Write down the agreed scope — refer back to it when the session
+7. Write down the agreed scope — refer back to it when the session
    drifts
+8. Review open issues related to the agreed scope before writing code
+
+## Mandatory startup block
+Every project CLAUDE.md MUST include a prominent startup block at the
+top of the file listing all referenced template files with an explicit
+instruction to read them before the first response. This applies to both
+reference mode and hybrid mode.
+
+The startup block MUST:
+- Appear before section 1 (Project)
+- List every template file the project depends on
+- Use imperative language: "You MUST read every file listed below IN
+  FULL using the Read tool before you respond"
+- State the consequence: "If you respond without reading them, you are
+  violating project rules"
+
+This requirement exists because `base/scope.md` says "read all documents
+referenced in CLAUDE.md" — but `scope.md` is one of the files that needs
+to be read first. The startup block breaks this chicken-and-egg problem
+by placing the instruction directly in CLAUDE.md, the one file that is
+always loaded into context automatically.
 
 ## During work
 - If a task grows beyond the original scope, flag it explicitly:
@@ -26,6 +51,8 @@ Before starting any work, the agent MUST:
 - Do not silently absorb new requests into the current work stream
 - Finishing and committing the current work SHOULD take priority over
   starting something new
+- Build after every change — do not accumulate multiple changes without
+  verifying the build still passes
 
 ## Default scope boundaries
 - One logical unit of work per session (one feature, one chapter, one
@@ -48,22 +75,30 @@ When the user requests something out of scope:
 4. If switching, commit current progress before starting the new task
 
 ## End of session audit
-Before ending a session, verify all of the following:
-1. **Dev journal** — add a session entry to `docs/dev-journal.md`
-   (date, tool, key changes, PRs merged, issues closed/created, open issues)
-2. **CLAUDE.md** — update if project structure or conventions changed
-3. **README.md** — update if public-facing info (setup, links, structure) changed
-4. **ONBOARDING.md** — update `docs/ONBOARDING.md` if prerequisites,
+When the user signals end of session ("wrap up", "let's finish",
+"end session", "close out", or similar), the agent MUST print the full
+checklist below and execute each item sequentially. Mark each item done
+(with result) before moving to the next. Do not batch, skip, or
+summarize — visible sequential execution prevents missed steps.
+
+1. **Commits and push** — all changes committed and pushed (via PR if
+   branch-protected)
+2. **Close issues** — close completed issues (verify auto-close worked)
+3. **Epic checklists** — update epic checklists if relevant
+4. **Dev journal** — add a session entry to `docs/dev-journal.md`
+   (date, tool, key changes, PRs merged, issues closed/created)
+5. **ADRs** — record any architectural decisions in `docs/decisions/`
+6. **CLAUDE.md** — update if project structure or conventions changed
+7. **README.md** — update if public-facing info changed
+8. **ONBOARDING.md** — update `docs/ONBOARDING.md` if prerequisites,
    setup steps, or project structure changed
-5. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
+9. **PLAYBOOK.md** — update `docs/PLAYBOOK.md` if operational
    workflows or file paths changed
-6. **ADRs** — record any decisions made during the session in
-   `docs/decisions/`
-7. **Open issues** — close resolved issues, create issues for remaining work
-8. **Submodules** — check if upstream submodules need updates
-   (`git submodule update --remote`); commit the pointer bump if needed
-9. **Template feedback** — flag any conventions discovered or changed
-   during the session that should be contributed back to
-   solid-ai-templates
-10. **Flag gaps** — if any of the above cannot be completed, flag it
+10. **Submodules** — check if upstream submodules need updates
+    (`git submodule update --remote`); commit the pointer bump if needed
+11. **Template feedback** — flag any conventions discovered or changed
+    during the session that should be contributed back to
+    solid-ai-templates
+12. **Flag gaps** — if any of the above cannot be completed, flag it
     to the user before closing
+13. **Summary** — summarize what was done and what's next

--- a/examples/hybrid-astro/CLAUDE.md
+++ b/examples/hybrid-astro/CLAUDE.md
@@ -1,0 +1,145 @@
+# Starfield Blog
+
+> **MANDATORY STARTUP — DO THIS BEFORE YOUR FIRST RESPONSE**
+>
+> You MUST read every file listed below IN FULL using the Read tool before
+> you respond to the user's first message. No exceptions. Do not summarize,
+> skip, or defer. These files contain binding conventions that this CLAUDE.md
+> inherits. If you respond without reading them, you are violating project rules.
+>
+> 1. `docs/solid-ai-templates/base/quality.md`
+> 2. `docs/solid-ai-templates/base/typescript.md`
+> 3. `docs/solid-ai-templates/base/review.md`
+> 4. `docs/solid-ai-templates/base/scope.md`
+> 5. `docs/solid-ai-templates/base/git.md`
+> 6. `docs/solid-ai-templates/base/docs.md`
+> 7. `docs/solid-ai-templates/base/readme.md`
+> 8. `docs/solid-ai-templates/base/issues.md`
+> 9. `docs/solid-ai-templates/frontend/quality.md`
+> 10. `docs/solid-ai-templates/frontend/ux.md`
+> 11. `docs/solid-ai-templates/frontend/static-site.md`
+> 12. `docs/solid-ai-templates/stack/static-site-astro.md`
+
+Personal blog about astronomy and astrophotography. Static site with
+content collections and zero client-side JS.
+
+- Model: hybrid
+
+Quality conventions defined in `docs/solid-ai-templates/` (submodule).
+Project-specific overrides and additions follow below.
+
+
+## 1. Project
+
+### 1.1 Identity
+
+- **Name**: starfield-blog
+- **Owner**: Alex Rivera
+- **Repo**: github.com/arivera/starfield-blog
+- **URL**: starfield.blog
+- **Deployment**: GitHub Pages via GitHub Actions
+
+### 1.2 Stack
+
+- Language: TypeScript (strict mode)
+- Framework: Astro 4 (output: static)
+- Content: Astro Content Collections (Markdown + frontmatter)
+- CSS: plain CSS with custom properties
+- Package manager: npm
+- Formatter: Prettier with `prettier-plugin-astro`
+
+### 1.3 Project structure
+
+```
+src/
+  content/
+    posts/          # Markdown blog posts with frontmatter
+    config.ts       # Content collection schemas
+  components/
+    layout/         # BaseLayout, Header, Footer
+    ui/             # Card, Tag, Pagination
+  pages/
+    index.astro
+    posts/[slug].astro
+    tags/[tag].astro
+  styles/
+    global.css      # Custom properties, base styles, dark theme
+public/
+  images/           # Optimized astronomy photos
+  favicon.svg
+```
+
+### 1.3 Commands
+
+```
+npm run dev       # develop at localhost:4321
+npm run build     # production build to dist/
+npm run preview   # preview production build
+npm run lint      # ESLint
+npm run check     # astro check
+```
+
+
+## 2. Code conventions
+
+### 2.1 Git
+
+- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`
+- Always branch — never commit directly to `main`
+- Branch naming: `feat/description`, `fix/description`
+
+### 2.2 TypeScript
+
+- `strict: true` — no exceptions
+- No `any` — use `unknown` and narrow
+- No enums — use `as const` objects or string literal unions
+
+### 2.3 Content rules
+
+- One Markdown file per post in `src/content/posts/`
+- Frontmatter must include: title, date, tags, description
+- Image alt text is required — no decorative images without `alt=""`
+- No inline HTML in Markdown posts
+
+
+## 3. Quality
+
+### 3.1 SEO
+
+- JSON-LD structured data for BlogPosting
+- Open Graph meta tags on all pages
+- Canonical URLs
+- `robots.txt` and auto-generated sitemap
+
+
+## 4. Identity
+
+### 4.1 Design
+
+- Dark background with deep blue accent
+- Minimal layout — content-first
+- No stock photography — only original astrophotos
+
+### 4.2 Brand voice
+
+- Educational and enthusiastic
+- Technical but accessible to hobbyists
+- First person, conversational tone
+
+
+## 5. Review process
+
+### 5.1 Code review
+
+Follow `base/review.md` priority order. Apply `base/quality.md` and
+`base/typescript.md` as the standard.
+
+### 5.2 Structure audit
+
+Verify MUSTs from `base/docs.md`, `base/readme.md`, `base/git.md`,
+`frontend/static-site.md`, and `stack/static-site-astro.md`.
+
+
+## 6. Session protocol
+
+Follow `base/scope.md` for scope guard and end-of-session audit.

--- a/formats/agents.md
+++ b/formats/agents.md
@@ -97,16 +97,13 @@ them*.
 [Which templates to verify, when to run]
 
 ## 6. Session protocol
-### 6.1 Startup
-[base/scope.md — Session startup: read referenced docs, confirm scope]
-### 6.2 End of session
-Before ending a session, verify all of the following:
-1. Dev journal — add a session entry to docs/dev-journal.md
-2. CLAUDE.md — update if project structure or conventions changed
-3. README.md — update if public-facing info changed
-4. ONBOARDING.md — update if setup steps or structure changed
-5. PLAYBOOK.md — update if workflows or file paths changed
-6. Open issues — close resolved issues, create issues for remaining work
+Follow `base/scope.md` for scope guard and end-of-session audit.
+### 6.1 Start of session
+[base/scope.md — Session startup + Mandatory startup block]
+### 6.2 During the session
+[base/scope.md — During work]
+### 6.3 End of session
+[base/scope.md — End of session audit (full checklist)]
 ```
 
 Omit sections that are not applicable to the project (e.g. omit section 4
@@ -169,17 +166,13 @@ relevant layer/stack templates. Run after: new project, migration,
 new layer, or pre-release.
 
 ## 6. Session protocol
-### 6.1 Startup
-Read all referenced template documents before starting work.
-Confirm session scope with the user.
-### 6.2 End of session
-Before ending a session, verify all of the following:
-1. Dev journal — add a session entry to docs/dev-journal.md
-2. CLAUDE.md — update if project structure or conventions changed
-3. README.md — update if public-facing info changed
-4. ONBOARDING.md — update if setup steps or structure changed
-5. PLAYBOOK.md — update if workflows or file paths changed
-6. Open issues — close resolved issues, create issues for remaining work
+Follow `base/scope.md` for scope guard and end-of-session audit.
+### 6.1 Start of session
+[base/scope.md — Session startup + Mandatory startup block]
+### 6.2 During the session
+[base/scope.md — During work]
+### 6.3 End of session
+[base/scope.md — End of session audit (full checklist)]
 ```
 
 ---
@@ -260,11 +253,13 @@ Follow base/review.md priority order, apply base/quality.md and
 language-specific templates as the standard.
 
 ## 6. Session protocol
-### 6.1 Startup
-Read all referenced template documents before starting work.
-Confirm session scope with the user.
-### 6.2 End of session
-[Same checklist as inline/reference models]
+Follow `base/scope.md` for scope guard and end-of-session audit.
+### 6.1 Start of session
+[base/scope.md — Session startup + Mandatory startup block]
+### 6.2 During the session
+[base/scope.md — During work]
+### 6.3 End of session
+[base/scope.md — End of session audit (full checklist)]
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add mandatory startup block requirement for reference/hybrid CLAUDE.md files (`base/scope.md`)
- Add startup hygiene: branch check, git status, issue review before coding
- Add build-after-change rule to during-work section
- Require visible sequential execution of end-of-session checklist with trigger phrases
- Replace incomplete inlined checklists in `formats/agents.md` with single reference to `base/scope.md`
- Add hybrid-mode example (`examples/hybrid-astro/CLAUDE.md`) demonstrating the startup block pattern

## Closes
- #106 — startup hygiene and build-after-change rules
- #107 — mandatory startup block requirement + example
- #110 — check each item independently instruction
- #119 — visible sequential execution of wrap-up checklist
- #105 — align formats/agents.md with base/scope.md

## Test plan
- [x] Smoke tests pass (7/7)
- [ ] Verify `formats/agents.md` all three models reference `base/scope.md` consistently
- [ ] Verify hybrid example includes startup block with all 12 template files listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)