### PR TITLE
feat(astro): add View Transitions section with DOMContentLoaded warning

### DIFF
--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -173,6 +173,25 @@ files into `src/content/`.
 
 ---
 
+## View Transitions
+[ID: astro-view-transitions]
+
+- SHOULD enable Astro View Transitions via `<ClientRouter />` from
+  `astro:transitions` in the base layout — eliminates full-page flash
+  between navigations; static site feels like a SPA with zero
+  client-side routing JS (~244 bytes gzip overhead per page)
+- When using `<ClientRouter />`, MUST NOT use `DOMContentLoaded` in
+  page scripts — it only fires on full page loads, not on client-side
+  navigations
+- Use `astro:page-load` instead — it fires on every navigation
+  including View Transitions
+- Scripts in `<script>` tags (not `is:inline`) are re-executed on
+  navigation by default; `is:inline` scripts are not
+- Gracefully degrades to full page loads if JS is disabled — no
+  framework lock-in
+
+---
+
 ## Reveal animations
 - Use a single `IntersectionObserver` script in the base layout for
   `.reveal` → `.reveal.visible` transitions


### PR DESCRIPTION
## Summary
- Add View Transitions section to `stack/static-site-astro.md`
- Recommend `<ClientRouter />` for instant-feeling navigation
- Warn about `DOMContentLoaded` incompatibility — use `astro:page-load` instead
- Document `is:inline` script behavior difference

## Closes
- #116 — Warn about DOMContentLoaded with View Transitions
- #118 — Recommend View Transitions (ClientRouter)

## Test plan
- [x] Smoke tests pass (7/7)
- [ ] Verify section has [ID: astro-view-transitions] for future EXTEND/OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)