### PR TITLE
feat: add standard npm scripts and testability quality attribute

### DIFF
--- a/base/quality.md
+++ b/base/quality.md
@@ -129,6 +129,57 @@ Apply SOLID at the class, module, and service level:
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
 
+## Testability
+
+Testability is a first-class design concern, not an afterthought. Code that
+is hard to test is hard to test because it is poorly designed — fixing the
+design fixes the testability.
+
+### Pure functions over side effects
+- Business logic SHOULD be implemented as pure functions — same input,
+  same output, no side effects (no I/O, no mutation of external state)
+- Side effects (database, API, filesystem, DOM) SHOULD be pushed to
+  the boundary — thin adapters that call pure logic
+- Pure functions are trivially unit-testable with no mocks, stubs, or setup
+- A function that mixes logic and side effects is a signal to split it:
+  extract the logic into a pure function, keep the side effect in a
+  thin wrapper
+
+### Architecture for testability
+- Push side effects to the edges:
+  `[boundary: I/O] → [pure: logic] → [boundary: I/O]`
+- The pure center is unit-testable; the thin boundaries are
+  integration-testable
+- If a function needs more than two mocks to test, it has too many
+  responsibilities — split it
+
+### SOLID enables testability
+- **SRP** — a function with one responsibility has one reason to test;
+  multiple responsibilities require combinatorial test cases
+- **OCP** — new behaviour via extension means existing tests stay green
+- **LSP** — subtypes that honour contracts can be tested against the base
+  type's tests
+- **ISP** — small interfaces mean fewer dependencies to mock
+- **DIP** — depend on abstractions, inject dependencies; code that
+  instantiates its own dependencies cannot be tested in isolation
+
+### Design patterns for testability
+- **Strategy** — swap algorithms in tests without modifying the caller
+- **Factory** — isolate object creation; test factories return predictable
+  instances
+- **Adapter / Facade** — wrap third-party dependencies behind a
+  project-owned interface; mock the interface, not the library
+- **Observer** — decouple event producers from consumers; test each side
+  independently
+
+### Rules
+- Design for testability from the start — do not write code first and
+  struggle to test later
+- If code is hard to test, treat it as a design problem, not a testing
+  problem
+- See `base/testing.md` for test types, coverage targets, and execution
+  rules
+
 ## Automated enforcement
 - Quality conventions in this document are enforced automatically via
   quality gates — see `base/quality-gates.md` for the three-layer model

--- a/base/testing.md
+++ b/base/testing.md
@@ -131,6 +131,9 @@ predefined expected outcome. It is not part of any regression suite.
 
 ## General rules
 
+- Code MUST be designed for testability from the start — see the
+  Testability section in `base/quality.md` for architectural patterns
+  (pure functions, boundary architecture, SOLID, design patterns)
 - Test behaviour, not implementation details
 - Each test MUST be independent — no shared mutable state between tests
 - A failing test MUST trigger an investigation before any other action —

--- a/stack/static-site-astro.md
+++ b/stack/static-site-astro.md
@@ -220,11 +220,35 @@ files into `src/content/`.
 ---
 
 ## Commands
+
+### Core (MUST)
 ```
-npm run dev      # develop — hot reload at localhost:4321
-npm run build    # compile — production build to dist/
-npm run preview  # verify — preview the production build locally
+npm run dev      # astro dev — hot reload at localhost:4321
+npm run build    # astro build — production build to dist/
+npm run preview  # astro preview — serve production build locally
+npm run prepare  # husky — auto-installs git hooks on npm install
 ```
+
+### Quality (SHOULD — omit if the tool is not in the stack)
+```
+npm run lint     # eslint .
+npm run format   # prettier --check .
+npm run check    # astro check — validate .astro files, types, content schemas
+npm test         # test runner in single-run mode (e.g. vitest run)
+npm run validate # lint + format + check + test + build — full quality gate
+```
+
+### Development (MAY)
+```
+npm run test:watch  # test runner in watch mode (e.g. vitest)
+```
+
+Rules:
+- `validate` SHOULD compose named scripts: each step callable individually
+  and as part of the full gate
+- `test` MUST run in single-run mode (exit after completion) — watch mode
+  belongs in `test:watch`
+- `prepare` is an npm lifecycle hook — runs automatically after `npm install`
 ---
 
 ## Quality gates


### PR DESCRIPTION
## Summary
- **static-site-astro.md**: Add full standard script set with MUST/SHOULD/MAY classification — `dev`, `build`, `preview`, `prepare` (MUST), `lint`, `format`, `check`, `test`, `validate` (SHOULD), `test:watch` (MAY)
- **base/quality.md**: Add Testability section — pure functions vs side effects, boundary architecture, SOLID principles connected to test design, design patterns for testability
- **base/testing.md**: Cross-reference to new Testability section

Closes #126, closes #127

## Test plan
- [ ] Verify `base/quality.md` Testability section reads correctly after SOLID and before Automated enforcement
- [ ] Verify `base/testing.md` cross-reference resolves
- [ ] Verify `static-site-astro.md` Commands section lists all scripts with classification
- [ ] Run `py tests/run_smoke.py` to check structural integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)