### PR TITLE
feat(360): add Tracking section for persisting audit results

### DIFF
--- a/base/360.md
+++ b/base/360.md
@@ -1,4 +1,5 @@
 # Base — 360-Degree Analysis
+
 [ID: base-360]
 
 ## Principle
@@ -11,6 +12,7 @@ marketer — to surface blind spots that single-perspective reviews miss.
 ---
 
 ## When to run
+
 [ID: 360-when]
 
 - Before a public launch or major release
@@ -22,6 +24,7 @@ marketer — to surface blind spots that single-perspective reviews miss.
 ---
 
 ## Execution model
+
 [ID: 360-execution]
 
 The four categories are independent. They SHOULD be executed as four
@@ -63,9 +66,11 @@ each category to force a perspective reset.
 ---
 
 ## Categories
+
 [ID: 360-categories]
 
 ### 1. Value (user perspective)
+
 [ID: 360-value]
 
 **Role prompt:** "You are a first-time user encountering this product.
@@ -100,68 +105,74 @@ the README is the sole source of promises.
 #### Sub-dimensions
 
 **Functional completeness**
+
 - [ ] Every capability listed in the README or landing page works
 - [ ] Every navigation item leads to a functioning section with
-  real content
+      real content
 - [ ] No placeholder content, stub pages, or dead-end links
 - [ ] Data-driven features contain substantive data — no empty
-  tables, no skeleton entries, no counts that contradict claims
+      tables, no skeleton entries, no counts that contradict claims
 - [ ] Cross-feature journeys (from `docs/user-journeys.md` or
-  inferred from navigation) work end to end without breaking
+      inferred from navigation) work end to end without breaking
 
 **Content quality**
+
 - [ ] Content is accurate — information matches reality, no
-  outdated or contradictory statements
+      outdated or contradictory statements
 - [ ] Content is deep enough to be useful — not just surface-level
-  summaries that leave the user needing another source
+      summaries that leave the user needing another source
 - [ ] Sources are cited where claims depend on external data
 - [ ] Content is current — no stale dates, broken external links,
-  or references to discontinued products
+      or references to discontinued products
 - [ ] Content covers what a user would reasonably expect given the
-  product's stated scope
+      product's stated scope
 
 **Usability**
+
 - [ ] A new user can identify what the product does and who it is
-  for within 10 seconds of landing
+      for within 10 seconds of landing
 - [ ] Navigation structure matches the user's mental model — users
-  can predict where to find what they need
+      can predict where to find what they need
 - [ ] Interactive elements (filters, sorts, toggles, search) behave
-  as their labels promise
+      as their labels promise
 - [ ] Layout is consistent across pages — same patterns, same
-  placement of controls
+      placement of controls
 - [ ] Responsive design works on mobile, tablet, and desktop
 - [ ] Error states and empty states are clear and actionable — not
-  blank screens or cryptic messages
+      blank screens or cryptic messages
 
 **Trust**
+
 - [ ] Author or organization is identified
 - [ ] The product feels maintained — no "last updated 2 years ago"
-  signals, no broken features left unfixed
+      signals, no broken features left unfixed
 - [ ] Data sources are disclosed where relevant
 - [ ] There is a way to report errors or give feedback
 - [ ] The product looks professional — consistent styling, no
-  visual glitches, no misaligned elements
+      visual glitches, no misaligned elements
 
 **Accessibility (experienced)**
+
 - [ ] All content is reachable and operable by keyboard alone
 - [ ] Text is readable without zooming on a standard screen
 - [ ] Content remains understandable at 200% zoom without
-  horizontal scrolling
+      horizontal scrolling
 - [ ] Color is never the only way to convey meaning — labels,
-  icons, or patterns provide redundancy
+      icons, or patterns provide redundancy
 - [ ] Interactive elements are visually distinguishable from static
-  content
+      content
 
 Note: technical compliance (WCAG audit, axe-core, ARIA attributes)
 is evaluated by the Quality agent, not here. This checks the
 experienced outcome, not the implementation.
 
 **Performance (perceived)**
+
 - [ ] Pages feel instant — no perceptible delay on navigation
 - [ ] No layout shifts or content flashing during load
 - [ ] Interactive elements respond immediately to input
 - [ ] Large pages (long lists, many images) remain usable — no
-  freezing or excessive scrolling lag
+      freezing or excessive scrolling lag
 
 Note: measured performance (Lighthouse scores, Core Web Vitals
 numbers) is evaluated by the Quality agent. This checks what the
@@ -170,6 +181,7 @@ user experiences, not what the metrics say.
 ---
 
 ### 2. Quality (engineer perspective)
+
 [ID: 360-quality]
 
 **Role prompt:** "You are a senior engineer reviewing this project
@@ -183,46 +195,51 @@ standard."
 #### Sub-dimensions
 
 **Architecture**
+
 - [ ] A fresh clone builds successfully without undocumented steps
 - [ ] Project structure matches what CLAUDE.md and README describe
 - [ ] Separation of concerns — content, code, configuration, and
-  assets are in distinct directories
+      assets are in distinct directories
 - [ ] No circular dependencies between modules
 - [ ] No dead code, unused files, or orphaned assets
 
 **Code**
+
 - [ ] Type safety enforced (strict mode, no `any` or equivalent)
 - [ ] Naming conventions followed consistently per the project's
-  own rules
+      own rules
 - [ ] No debug statements (`console.log`, `debugger`, `print`)
-  in committed code
+      in committed code
 - [ ] No commented-out code blocks — version control is the history
 - [ ] No hardcoded secrets, API keys, or credentials
 - [ ] No dangerous patterns (`eval`, `set:html`, `innerHTML` with
-  unsanitized input)
+      unsanitized input)
 - [ ] Code style consistent — linter configured, or manual rules
-  documented and followed
+      documented and followed
 
 **Testing**
+
 - [ ] Tests exist for business logic and critical paths
 - [ ] Tests pass — no skipped, ignored, or known-failing tests
-  without documented reason
+      without documented reason
 - [ ] Tests are runnable from CI without human intervention
 - [ ] Coverage is measured — threshold enforced or trending upward
 - [ ] Tests verify behavior, not implementation details
 
 **CI/CD and quality gates**
+
 - [ ] Layer 1 (editor) — lint and format on save configured
 - [ ] Layer 2 (pre-commit) — hooks block bad commits locally
 - [ ] Layer 3 (CI) — automated pipeline runs on every PR
 - [ ] Build, lint, test, and security scan stages present
 - [ ] CI is green on main — no pre-existing failures treated as
-  normal
+      normal
 - [ ] Pipeline fails fast on violations — no "allowed to fail"
-  stages
+      stages
 - [ ] Deployment automated on merge to main
 
 **Security**
+
 - [ ] SAST enabled (CodeQL, Semgrep, or equivalent)
 - [ ] Secret detection enabled (push protection, gitleaks)
 - [ ] Dependencies scanned for known vulnerabilities
@@ -231,20 +248,22 @@ standard."
 - [ ] User input validated at system boundaries
 
 **Documentation**
+
 - [ ] README accurately describes the current state of the project
 - [ ] ONBOARDING enables a new contributor to clone, build, and
-  run the project without asking questions
+      run the project without asking questions
 - [ ] PLAYBOOK covers daily operational tasks and common workflows
 - [ ] Dev journal maintained with session entries
 - [ ] Architectural decisions recorded as ADRs
 - [ ] All documentation reflects the current state of the code —
-  no stale references to removed features or old paths
+      no stale references to removed features or old paths
 - [ ] User journeys documented in `docs/user-journeys.md` if the
-  product has cross-feature paths (optional but recommended)
+      product has cross-feature paths (optional but recommended)
 
 ---
 
 ### 3. Viability (business analyst perspective)
+
 [ID: 360-viability]
 
 **Role prompt:** "You are a business analyst assessing whether this
@@ -257,50 +276,55 @@ happens if something goes wrong?"
 #### Sub-dimensions
 
 **Licensing and compliance**
+
 - [ ] License is clearly stated in the repository
 - [ ] All dependencies carry compatible licenses
 - [ ] No copyleft dependencies without explicit approval
 - [ ] License terms match the intended use (commercial, open
-  source, educational)
+      source, educational)
 - [ ] Privacy and data handling comply with applicable regulations
-  (GDPR, CCPA) — or the product collects no personal data
+      (GDPR, CCPA) — or the product collects no personal data
 
 **Cost and vendor risk**
+
 - [ ] Hosting and infrastructure costs are known and proportional
-  to the project's value
+      to the project's value
 - [ ] No paid services required without documented justification
 - [ ] No single-vendor lock-in on critical infrastructure — a
-  migration path exists or the cost of switching is acceptable
+      migration path exists or the cost of switching is acceptable
 - [ ] Build and deploy pipeline costs are sustainable (free tier,
-  budgeted, or self-hosted)
+      budgeted, or self-hosted)
 
 **Maintainability**
+
 - [ ] A new contributor can onboard from documentation alone —
-  no oral knowledge transfer required
+      no oral knowledge transfer required
 - [ ] Bus factor risk is documented — if the project is solo,
-  documentation and automation mitigate the risk
+      documentation and automation mitigate the risk
 - [ ] A backlog or roadmap exists — the project has a visible
-  direction, not just reactive fixes
+      direction, not just reactive fixes
 - [ ] Maintenance burden is proportional — the project does not
-  require constant attention to stay operational
+      require constant attention to stay operational
 - [ ] Contribution model is clear (who can contribute, how
-  changes get reviewed and merged)
+      changes get reviewed and merged)
 
 **Dependency and operational risk**
+
 - [ ] No critical dependency maintained by a single person with
-  no successors
+      no successors
 - [ ] Dependencies are actively maintained — last release within
-  12 months for core dependencies
+      12 months for core dependencies
 - [ ] Dependency count is minimal — no unnecessary packages that
-  increase the attack and maintenance surface
+      increase the attack and maintenance surface
 - [ ] The project can survive a key dependency being abandoned —
-  alternatives exist or the dependency is trivially replaceable
+      alternatives exist or the dependency is trivially replaceable
 - [ ] Disaster recovery: the project can be rebuilt from the
-  repository alone (no external state, no manual configuration)
+      repository alone (no external state, no manual configuration)
 
 ---
 
 ### 4. Discovery (marketing perspective)
+
 [ID: 360-discovery]
 
 **Role prompt:** "You are a marketing specialist evaluating whether
@@ -315,58 +339,64 @@ compelling and correctly targeted."
 #### Sub-dimensions
 
 **Positioning**
+
 - [ ] It is immediately clear what this product is and who it is
-  for — no jargon, no ambiguity
+      for — no jargon, no ambiguity
 - [ ] The value proposition is stated, not implied — a visitor
-  understands the benefit within seconds
+      understands the benefit within seconds
 - [ ] The product is differentiated — it is clear why someone
-  would use this instead of alternatives
+      would use this instead of alternatives
 - [ ] The name and domain (if any) are memorable and relevant to
-  the product's purpose
+      the product's purpose
 
 **SEO effectiveness**
+
 - [ ] Meta titles are compelling — they describe the page AND
-  encourage clicks, not just list keywords
+      encourage clicks, not just list keywords
 - [ ] Meta descriptions read like a pitch — they answer "why
-  should I click this?"
+      should I click this?"
 - [ ] Page content targets search intent — what would the target
-  audience actually search for?
+      audience actually search for?
 - [ ] Heading hierarchy tells a scannable story — a user skimming
-  headings alone understands the page
+      headings alone understands the page
 - [ ] URL structure is clean, human-readable, and predictable
 
 **Social shareability**
+
 - [ ] OG image is visually compelling — not a generic logo or
-  blank placeholder
+      blank placeholder
 - [ ] Shared links preview well on social platforms — title,
-  description, and image form a coherent card
+      description, and image form a coherent card
 - [ ] The product contains content worth sharing — insights, data,
-  tools, or reference material that users would send to others
+      tools, or reference material that users would send to others
 - [ ] Social proof exists or is being built — stars, testimonials,
-  user count, community activity
+      user count, community activity
 
 **Analytics and feedback**
+
 - [ ] Analytics are configured and collecting data
 - [ ] Privacy-friendly solution chosen — no consent banner
-  required, no third-party tracking
+      required, no third-party tracking
 - [ ] Success metrics are defined — the owner knows what "working"
-  looks like in numbers
+      looks like in numbers
 - [ ] Data informs decisions — there is evidence that analytics
-  have influenced at least one product or content change
+      have influenced at least one product or content change
 
 **Distribution and reach**
+
 - [ ] The product is present where its target audience already
-  looks — relevant communities, forums, directories, or platforms
+      looks — relevant communities, forums, directories, or platforms
 - [ ] Content is indexable by search engines — no accidental
-  noindex, no broken sitemap, no JavaScript-only rendering
+      noindex, no broken sitemap, no JavaScript-only rendering
 - [ ] The product can be found through at least two independent
-  channels (search, social, community, word of mouth, directory)
+      channels (search, social, community, word of mouth, directory)
 - [ ] Growth mechanism exists — even if organic, there is a
-  reason new users would discover this over time
+      reason new users would discover this over time
 
 ---
 
 ## Output format
+
 [ID: 360-output]
 
 ### Per-category report
@@ -378,13 +408,14 @@ Each subagent returns:
 
 ### Findings
 
-| # | Sub-dimension | Status | Finding |
-|---|---------------|--------|---------|
-| 1 | [name]        | PASS   | —       |
-| 2 | [name]        | FAIL   | [what]  |
-| 3 | [name]        | PARTIAL| [what]  |
+| #   | Sub-dimension | Status  | Finding |
+| --- | ------------- | ------- | ------- |
+| 1   | [name]        | PASS    | —       |
+| 2   | [name]        | FAIL    | [what]  |
+| 3   | [name]        | PARTIAL | [what]  |
 
 ### Summary
+
 [2–3 sentences from the role's perspective]
 ```
 
@@ -393,31 +424,66 @@ Each subagent returns:
 The parent agent merges into:
 
 ```markdown
-| Category | Grade | Findings | Critical |
-|----------|-------|----------|----------|
-| Value    | [A–F] | [n]      | [n]      |
-| Quality  | [A–F] | [n]      | [n]      |
-| Viability| [A–F] | [n]      | [n]      |
-| Discovery| [A–F] | [n]      | [n]      |
-| **Overall** | **[A–F]** | **[n]** | **[n]** |
+| Category    | Grade     | Findings | Critical |
+| ----------- | --------- | -------- | -------- |
+| Value       | [A–F]     | [n]      | [n]      |
+| Quality     | [A–F]     | [n]      | [n]      |
+| Viability   | [A–F]     | [n]      | [n]      |
+| Discovery   | [A–F]     | [n]      | [n]      |
+| **Overall** | **[A–F]** | **[n]**  | **[n]**  |
 ```
 
 ### Grading scale
 
-| Grade | Meaning |
-|-------|---------|
-| A | All checks pass, no findings |
-| B | Minor findings only, no blockers |
-| C | Some findings, one or more gaps to address |
-| D | Significant gaps, not ready for the stated goal |
-| F | Critical failures, immediate action required |
+| Grade | Meaning                                         |
+| ----- | ----------------------------------------------- |
+| A     | All checks pass, no findings                    |
+| B     | Minor findings only, no blockers                |
+| C     | Some findings, one or more gaps to address      |
+| D     | Significant gaps, not ready for the stated goal |
+| F     | Critical failures, immediate action required    |
 
 The overall grade is the lowest category grade — the project is
 only as strong as its weakest perspective.
 
 ---
 
+## Tracking
+
+[ID: 360-tracking]
+
+Audit results MUST be persisted in the repository — agent memory is
+ephemeral and invisible to other contributors.
+
+- Projects MUST maintain a `docs/360-audit.md` file with a score
+  history table
+- Each row MUST include: date, grade per category, and issue
+  references spawned by that audit
+- A "Current bottleneck" section SHOULD identify the weakest
+  category and list its key gaps
+- The end-of-session checklist SHOULD include updating
+  `docs/360-audit.md` after running an audit
+
+### Minimum file structure
+
+```markdown
+# 360-Degree Audit History
+
+## Audit history
+
+| Date       | Value | Quality | Viability | Discovery | Issues created |
+| ---------- | ----- | ------- | --------- | --------- | -------------- |
+| YYYY-MM-DD | [A–F] | [A–F]   | [A–F]     | [A–F]     | #N, #M, ...    |
+
+## Current bottleneck
+
+**[Category] ([Grade])** — [key gaps]
+```
+
+---
+
 ## Relationship to other templates
+
 [ID: 360-relationships]
 
 - `base/review.md` — peer review checks changed files in a PR;


### PR DESCRIPTION
## Summary
- Add Tracking section (`[ID: 360-tracking]`) to `base/360.md`
- Projects MUST maintain `docs/360-audit.md` with score history table
- Each row includes date, grades, and issue references
- Includes minimum file structure template

Addresses the gap where audit results lived only in agent memory and were invisible to other contributors.

## Test plan
- [x] Smoke tests pass (7/7)
- [ ] Verify section placement and ID are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)