### PR TITLE
fix(360): expand grading scale to include plus/minus modifiers

### DIFF
--- a/base/360.md
+++ b/base/360.md
@@ -435,13 +435,17 @@ The parent agent merges into:
 
 ### Grading scale
 
-| Grade | Meaning                                         |
-| ----- | ----------------------------------------------- |
-| A     | All checks pass, no findings                    |
-| B     | Minor findings only, no blockers                |
-| C     | Some findings, one or more gaps to address      |
-| D     | Significant gaps, not ready for the stated goal |
-| F     | Critical failures, immediate action required    |
+Use plus/minus modifiers to express where a category falls within
+a letter band (e.g. B+ is strong B, B- is weak B). Plain letters
+are acceptable when finer granularity is not needed.
+
+| Grade       | Meaning                                      |
+| ----------- | -------------------------------------------- |
+| A / A-      | All checks pass, minor polish at most        |
+| B+ / B / B- | Minor findings only, no blockers             |
+| C+ / C / C- | Some findings, clear gaps to address         |
+| D+ / D / D- | Significant gaps, not ready for stated goal  |
+| F           | Critical failures, immediate action required |
 
 The overall grade is the lowest category grade — the project is
 only as strong as its weakest perspective.


### PR DESCRIPTION
## Summary
- Expand grading scale from plain A–F to include +/- modifiers
- Aligns template with actual audit output (B+, A-, D+, etc.)

## Test plan
- [x] Smoke tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)