### PR TITLE
feat: add testing, frontend, and security pattern templates

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -53,7 +53,9 @@ base/
 ├── quality.md      # Architecture, code style, security, testing
 ├── review.md       # Peer review priority, MUST/SHOULD checklists, deviation rules
 ├── testing.md      # Test pyramid, coverage thresholds, naming conventions
+├── testing-patterns.md # Reusable test patterns — factory, AAA, builder, parameterized, fixtures, mocks
 ├── devsecops.md    # SAST, SCA, SBOM, secret detection, license compliance
+├── devsecops-patterns.md # Reusable security patterns — validation, encoding, CSRF, rate limiting, headers
 ├── release.md      # Semver, version bump propagation, backward compat, cut-over
 ├── cicd.md         # Pipeline stages, triggers, environments, IaC, deployment
 ├── cicd-patterns.md # Reusable CI/CD patterns — gate, path filter, fan-out, caching, matrix
@@ -79,6 +81,7 @@ platform/
 frontend/
 ├── ux.md           # UX principles, WCAG 2.1 AA, responsive breakpoints
 ├── quality.md      # CSS conventions, performance, SEO & analytics
+├── patterns.md     # Reusable UI patterns — error boundary, skeleton, optimistic, virtual scroll, URL state
 └── static-site.md  # Abstract SSG rules — content, assets, SEO
 ```
 

--- a/base/devsecops-patterns.md
+++ b/base/devsecops-patterns.md
@@ -1,0 +1,364 @@
+# Base — Security Patterns
+
+[ID: base-devsecops-patterns]
+[DEPENDS ON: base/devsecops.md]
+
+Reusable structural patterns for application security. Each
+pattern describes a problem, solution structure, when to use it,
+and examples.
+
+See `base/devsecops.md` for SAST, SCA, secret detection, and
+compliance rules.
+
+---
+
+## 1. Input validation at boundaries
+
+[ID: security-pattern-input-validation]
+
+**Problem:** User input flows through multiple layers (controller,
+service, repository) with validation scattered across each.
+Some paths skip validation entirely. Invalid data reaches the
+database or external service.
+
+**Solution:** Validate all external input at the system boundary —
+the first point where untrusted data enters. Internal code trusts
+validated data. No redundant validation in inner layers.
+
+```
+[boundary: validate] → [service: trust] → [repository: trust]
+         ↓ reject
+     400 Bad Request
+```
+
+**When to use:**
+
+- Every HTTP endpoint, CLI argument, message consumer, file import
+- Any point where data crosses a trust boundary
+
+**Example (TypeScript + Zod):**
+
+```typescript
+const CreateUserSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email(),
+  role: z.enum(["admin", "user"]),
+});
+
+app.post("/users", (req, res) => {
+  const result = CreateUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ errors: result.error.issues });
+  }
+  // result.data is typed and validated — trust it downstream
+  userService.create(result.data);
+});
+```
+
+**Rules:**
+
+- Validate at the boundary, trust internally — do not re-validate
+  in service or repository layers
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Reject invalid input with a clear error — do not silently coerce
+  or strip invalid fields
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+
+---
+
+## 2. Output encoding
+
+[ID: security-pattern-output-encoding]
+
+**Problem:** Data stored in the database is rendered in HTML, JSON,
+or SQL without encoding. An attacker stores `<script>alert(1)</script>`
+as a username — it executes in every user's browser (XSS).
+
+**Solution:** Encode output for its context at the point of
+rendering. HTML context gets HTML encoding. URL context gets URL
+encoding. JavaScript context gets JS encoding. Never encode on
+input — store the raw value, encode on output.
+
+```
+Store:  <script>alert(1)</script>     (raw in database)
+Render: &lt;script&gt;alert(1)&lt;/script&gt;  (HTML-encoded in page)
+```
+
+**When to use:**
+
+- Every point where dynamic data is rendered in HTML, URLs,
+  JSON, SQL, or shell commands
+- Templates, API responses, log messages
+
+**Rules:**
+
+- Encode on output, not on input — input validation rejects bad
+  data, output encoding prevents injection
+- Use framework-provided encoding — React JSX, Jinja2 autoescape,
+  Go `html/template` all encode by default
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection;
+  use the right encoding for the right context
+
+---
+
+## 3. Secret injection
+
+[ID: security-pattern-secret-injection]
+
+**Problem:** Secrets (API keys, database passwords, tokens) are
+hardcoded in source files, baked into container images, or passed
+as build-time environment variables. They end up in version
+control, logs, or container layers.
+
+**Solution:** Inject secrets at runtime from a dedicated vault.
+The application reads secrets on startup from environment
+variables or mounted files — never from source code or images.
+
+```
+Build time: no secrets — image is clean
+Runtime:    vault → env var / mounted file → application reads
+```
+
+**When to use:**
+
+- Every application that uses credentials, tokens, or API keys
+- No exceptions
+
+**Example (Kubernetes + Vault):**
+
+```yaml
+# Secret injected as env var from Kubernetes Secret
+env:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: app-secrets
+        key: database-url
+```
+
+**Example (Docker Compose):**
+
+```yaml
+services:
+  app:
+    environment:
+      - DATABASE_URL # read from host env or .env file
+    # .env file is in .gitignore — never committed
+```
+
+**Rules:**
+
+- Secrets MUST NOT appear in source code, Dockerfiles, CI logs,
+  or commit history
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- Rotate secrets regularly — automate rotation where possible
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient
+
+---
+
+## 4. CSRF token flow
+
+[ID: security-pattern-csrf]
+
+**Problem:** A malicious site submits a form to your application
+using the user's browser session. The server cannot distinguish
+between a legitimate form submission and a cross-site forgery.
+
+**Solution:** Generate a unique token per session. Embed it in
+every form as a hidden field. Verify the token on every state-
+changing request. Reject requests with missing or invalid tokens.
+
+```
+Server generates token → stored in session
+Page renders token     → hidden field in form
+Form submits token     → server verifies against session
+Mismatch               → 403 Forbidden
+```
+
+**When to use:**
+
+- Every state-changing endpoint (POST, PUT, DELETE) in
+  server-rendered applications
+- NOT needed for API-only backends using Bearer tokens — the
+  token itself prevents CSRF
+- NOT needed for SameSite=Strict cookies with no cross-origin
+  forms
+
+**Rules:**
+
+- One token per session — do not generate per request unless
+  the framework requires it
+- Token MUST be unpredictable — use a cryptographic random
+  generator
+- Verify on all state-changing methods (POST, PUT, PATCH, DELETE)
+  — never on GET
+- Use the framework's built-in CSRF protection — do not implement
+  from scratch
+- Double-submit cookie pattern is acceptable for SPAs that cannot
+  use server-side sessions
+
+---
+
+## 5. Rate limiting
+
+[ID: security-pattern-rate-limit]
+
+**Problem:** An attacker or misbehaving client sends thousands of
+requests per second. Login endpoints are brute-forced. API
+endpoints are scraped. The server is overwhelmed.
+
+**Solution:** Limit the number of requests per client per time
+window. Return `429 Too Many Requests` with a `Retry-After`
+header when the limit is exceeded.
+
+```
+Client → [rate limiter] → allowed (under limit)
+                        → 429 + Retry-After (over limit)
+```
+
+**When to use:**
+
+- All public-facing endpoints
+- Authentication endpoints (stricter limits)
+- Expensive operations (search, export, report generation)
+
+**Rules:**
+
+- Apply rate limits at the reverse proxy or API gateway — not
+  in application code
+- Use sliding window or token bucket — fixed windows allow bursts
+  at window boundaries
+- Different limits for different endpoints: auth (5/min),
+  API (100/min), static (1000/min)
+- Identify clients by IP, API key, or authenticated user — not
+  by session cookie alone
+- Return `Retry-After` header — clients need to know when to
+  retry
+- Log rate limit hits — they may indicate an attack or a client
+  bug
+
+---
+
+## 6. Dependency pinning
+
+[ID: security-pattern-dependency-pinning]
+
+**Problem:** A dependency uses a version range (`^1.2.3`). A
+compromised or buggy patch release is published. The next
+`npm install` or `pip install` pulls the bad version
+automatically. Supply chain attack succeeds.
+
+**Solution:** Pin exact versions in the lock file. Commit the lock
+file. Review dependency updates explicitly through Dependabot or
+Renovate PRs — never auto-install unknown versions.
+
+```
+package.json:     "lodash": "^4.17.0"   (range — dangerous alone)
+package-lock.json: "lodash": "4.17.21"  (pinned — safe)
+```
+
+**When to use:**
+
+- Every project with external dependencies
+- No exceptions
+
+**Rules:**
+
+- Commit the lock file (`package-lock.json`, `poetry.lock`,
+  `go.sum`, `Cargo.lock`)
+- Use `npm ci` (not `npm install`) in CI — respects the lock file
+  exactly
+- Review Dependabot/Renovate PRs — do not auto-merge major
+  updates without reading the changelog
+- Pin base images in Dockerfiles: `node:22.1.0-alpine`, not
+  `node:latest` or `node:22`
+- Audit dependencies regularly: `npm audit`, `pip-audit`,
+  `govulncheck`
+
+---
+
+## 7. Principle of least privilege
+
+[ID: security-pattern-least-privilege]
+
+**Problem:** A service account has admin access to the database.
+A CI token can push to any branch. A container runs as root.
+When one component is compromised, the attacker has full access
+to everything.
+
+**Solution:** Grant each component the minimum permissions it
+needs to function. Database accounts get access to specific
+tables. CI tokens are scoped to specific actions. Containers
+run as non-root.
+
+```
+Service A → read-only access to orders table
+Service B → read-write access to users table
+CI token  → push to feature branches only
+Container → non-root, read-only filesystem
+```
+
+**When to use:**
+
+- Every service account, CI token, API key, IAM role, container,
+  and database user
+- No exceptions
+
+**Rules:**
+
+- Start with zero permissions and add only what is needed —
+  never start with admin and try to restrict
+- Separate read and write access — most services need only read
+- Use short-lived tokens over long-lived credentials
+- Review permissions regularly — remove what is no longer used
+- Document what each credential can do and why
+
+---
+
+## 8. Security headers
+
+[ID: security-pattern-headers]
+
+**Problem:** The browser allows scripts from any origin, embeds
+the page in frames, and sends credentials with cross-origin
+requests. Default browser behavior is permissive — every missing
+header is an attack surface.
+
+**Solution:** Set security headers on every HTTP response. The
+reverse proxy or framework middleware adds them globally — no
+per-endpoint configuration needed.
+
+**Essential headers:**
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+**When to use:**
+
+- Every web application that serves HTML
+- API-only backends benefit from a subset (HSTS, nosniff)
+
+**Rules:**
+
+- Set headers at the reverse proxy or middleware level — not
+  per route
+- Start with a strict CSP and relax only as needed — document
+  every relaxation
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without
+  a written justification
+- Test headers with `securityheaders.com` or `observatory.mozilla.org`
+- HSTS MUST be enabled on all production HTTPS sites — prevents
+  SSL stripping

--- a/base/devsecops.md
+++ b/base/devsecops.md
@@ -1,29 +1,41 @@
 # Base — DevSecOps
+
 [ID: base-devsecops]
 
 ## Principle
+
 Security is not a phase — it is part of every build, review, and release.
 Vulnerabilities and legal exposure MUST be surfaced during development —
 not after deployment.
 
+## Patterns
+
+- See `base/devsecops-patterns.md` for reusable security patterns:
+  input validation, output encoding, secret injection, CSRF,
+  rate limiting, dependency pinning, least privilege, headers
+
 ## Tool selection
+
 - Specific SAST and secret detection tools are defined per platform in
   `platform/github.md` (CodeQL) and `platform/gitlab.md` (Semgrep)
 - See `base/quality-gates.md` for the three-layer enforcement model
 
 ## SAST (Static Application Security Testing)
+
 - Every pipeline run MUST include a static security analysis step
 - A failed scan MUST stop the build — the branch MUST NOT progress until
   findings are resolved or formally accepted as false positives
 - Accepted false positives MUST be documented with a written justification
 
 ## SCA (Software Composition Analysis)
+
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection
+
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
 - Sensitive values MUST NOT appear in any artefact that enters source control —
@@ -32,11 +44,13 @@ not after deployment.
   be written to disk or committed in any form
 
 ## License compliance
+
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
 
 ## DAST (Dynamic Application Security Testing)
+
 - DAST MUST run against the staging/QA environment after every deployment
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
@@ -44,6 +58,7 @@ not after deployment.
 - Lower-severity findings MUST be tracked and resolved within a defined timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
+
 - All infrastructure code (Terraform, Dockerfiles, Helm charts, Kubernetes
   manifests) MUST be scanned for security misconfigurations in CI
 - A failed IaC scan MUST fail the build — the same rule as SAST
@@ -52,6 +67,7 @@ not after deployment.
 - IaC scan results MUST be reviewed in the same PR that introduces the change
 
 ## Penetration testing
+
 - Schedule regular penetration testing by a qualified party
 - Critical findings (severity A) MUST be treated as incidents and resolved
   immediately
@@ -59,6 +75,7 @@ not after deployment.
   timeframe
 
 ## Dependency hygiene
+
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted

--- a/base/testing-patterns.md
+++ b/base/testing-patterns.md
@@ -1,0 +1,379 @@
+# Base — Testing Patterns
+
+[ID: base-testing-patterns]
+[DEPENDS ON: base/testing.md]
+
+Reusable structural patterns for test code. Each pattern describes
+a problem, solution structure, when to use it, and examples.
+
+See `base/testing.md` for test types, coverage targets, and naming.
+See `base/quality.md` for testability as a design concern.
+
+---
+
+## 1. Test factory
+
+[ID: testing-pattern-factory]
+
+**Problem:** Tests create domain objects inline with verbose
+literal syntax. When a field is added to the type, every test
+that constructs that object breaks — even tests that don't care
+about the new field.
+
+**Solution:** A factory function returns a valid default object.
+Tests override only the fields they care about.
+
+```
+makeLens()                    → valid default lens
+makeLens({ maxAperture: 1.4 }) → default lens with one override
+```
+
+**When to use:**
+
+- Domain objects have more than 3 required fields
+- Multiple test files construct the same type
+- The type evolves frequently
+
+**Example (TypeScript):**
+
+```typescript
+// src/test/factories.ts
+export function makeLens(overrides: Partial<Lens> = {}): Lens {
+  return {
+    model: "XF 35mm f/1.4",
+    mount: "X",
+    type: "prime",
+    focalLengthMin: 35,
+    focalLengthMax: 35,
+    maxAperture: 1.4,
+    weight: 187,
+    price: 750,
+    ...overrides,
+  };
+}
+```
+
+**Rules:**
+
+- One factory per domain type — co-locate in a test utilities file
+- Defaults MUST produce a valid object — no undefined required fields
+- Never use random values in defaults — deterministic factories
+  make failures reproducible
+- Use factory composition for nested types: `makeOrder({ items: [makeItem()] })`
+
+---
+
+## 2. Arrange-Act-Assert
+
+[ID: testing-pattern-aaa]
+
+**Problem:** Tests mix setup, execution, and verification into an
+unstructured block. Readers cannot tell what is being tested or
+what the expected outcome is.
+
+**Solution:** Structure every test into three visually separated
+sections: arrange (setup), act (execute), assert (verify).
+
+```
+Arrange — set up preconditions and inputs
+Act     — call the function or trigger the behavior
+Assert  — verify the outcome
+```
+
+**When to use:**
+
+- Every unit and integration test — this is the default structure
+
+**Example:**
+
+```typescript
+it("scores weather-sealed lenses higher for landscape", () => {
+  // Arrange
+  const sealed = makeLens({ isWeatherSealed: true });
+  const unsealed = makeLens({ isWeatherSealed: false });
+
+  // Act
+  const sealedScore = scoreLandscape(sealed);
+  const unsealedScore = scoreLandscape(unsealed);
+
+  // Assert
+  expect(sealedScore).toBeGreaterThan(unsealedScore);
+});
+```
+
+**Rules:**
+
+- One act per test — if you have two acts, you have two tests
+- Arrange may be shared via `beforeEach` — but only when all
+  tests in the block share the same setup
+- Assert should test one logical concept — multiple `expect`
+  calls are fine if they verify the same outcome
+
+---
+
+## 3. Builder pattern for test data
+
+[ID: testing-pattern-builder]
+
+**Problem:** Factory functions work for simple objects but become
+unwieldy when the object has many optional fields, nested
+structures, or requires sequential configuration steps.
+
+**Solution:** A fluent builder chains method calls to construct
+complex test data. The final `.build()` call returns the object.
+
+```
+aLens().withAperture(1.4).withMount("X").scored().build()
+```
+
+**When to use:**
+
+- Objects require more than 5 configuration steps
+- Tests need objects in specific states (scored, published, draft)
+- Factory overrides become deeply nested
+
+**Example:**
+
+```typescript
+class LensBuilder {
+  private data: Partial<Lens> = {};
+
+  withAperture(value: number): this {
+    this.data.maxAperture = value;
+    return this;
+  }
+
+  withMount(mount: string): this {
+    this.data.mount = mount;
+    return this;
+  }
+
+  build(): Lens {
+    return makeLens(this.data);
+  }
+}
+
+export const aLens = () => new LensBuilder();
+```
+
+**Rules:**
+
+- Builder wraps the factory — do not duplicate default logic
+- Use builders only when factories are insufficient — do not
+  over-engineer simple test data
+- Name builder entry points as articles: `aUser()`, `anOrder()`
+
+---
+
+## 4. Parameterized tests
+
+[ID: testing-pattern-parameterized]
+
+**Problem:** Multiple tests verify the same logic with different
+inputs. Each test is a copy of the others with one value changed.
+Adding a new case means duplicating the entire test body.
+
+**Solution:** Define test cases as data. A single test body runs
+once per case. The test framework provides the parameterization
+mechanism.
+
+**When to use:**
+
+- Three or more tests differ only in input and expected output
+- Boundary value testing (min, max, zero, negative)
+- Mapping or conversion functions with many valid pairs
+
+**Example (Vitest):**
+
+```typescript
+it.each([
+  { aperture: 1.4, expected: 2 },
+  { aperture: 2.8, expected: 1 },
+  { aperture: 5.6, expected: 0 },
+])("scores aperture $aperture as $expected", ({ aperture, expected }) => {
+  const lens = makeLens({ maxAperture: aperture });
+  expect(scoreAperture(lens)).toBe(expected);
+});
+```
+
+**Example (pytest):**
+
+```python
+@pytest.mark.parametrize("aperture,expected", [
+    (1.4, 2),
+    (2.8, 1),
+    (5.6, 0),
+])
+def test_score_aperture(aperture, expected):
+    assert score_aperture(aperture) == expected
+```
+
+**Rules:**
+
+- Use descriptive test names that include the varying parameter
+- Keep the case table close to the test — do not hide it in a
+  separate file unless it exceeds 20 entries
+- Each row MUST be independent — no row depends on a previous row
+
+---
+
+## 5. Fixture hierarchy
+
+[ID: testing-pattern-fixtures]
+
+**Problem:** Tests duplicate expensive setup (database seeding,
+API mocking, DOM rendering). Extracting setup into `beforeEach`
+works within one file but does not share across files.
+
+**Solution:** Define fixtures as composable setup/teardown pairs.
+Tests declare which fixtures they need. The framework handles
+lifecycle.
+
+```
+global fixture (once)
+  └→ suite fixture (per file)
+      └→ test fixture (per test)
+```
+
+**When to use:**
+
+- Shared setup across multiple test files
+- Setup has teardown requirements (close connection, reset DOM)
+- Setup is expensive and should run once per suite, not per test
+
+**Example (Vitest):**
+
+```typescript
+// src/test/setup.ts — global fixture
+beforeAll(() => {
+  // seed test database or start mock server
+});
+
+afterAll(() => {
+  // cleanup
+});
+```
+
+**Example (pytest):**
+
+```python
+@pytest.fixture(scope="session")
+def db():
+    conn = create_test_database()
+    yield conn
+    conn.close()
+
+@pytest.fixture
+def user(db):
+    return create_user(db, name="test")
+```
+
+**Rules:**
+
+- Use the narrowest scope possible — `per-test` over `per-suite`
+  over `global`
+- Fixtures MUST clean up after themselves — no test pollution
+- Never depend on test execution order — each test must work
+  in isolation
+- Name fixtures after what they provide, not what they do:
+  `user` not `createUser`
+
+---
+
+## 6. Mock boundary
+
+[ID: testing-pattern-mock-boundary]
+
+**Problem:** Tests mock internal implementation details. When the
+code is refactored, tests break even though behavior is unchanged.
+Heavy mocking obscures what is actually being tested.
+
+**Solution:** Mock only at system boundaries — external services,
+databases, file systems, clocks. Test internal logic as pure
+functions without mocks.
+
+```
+[external boundary: mock] → [internal logic: no mocks] → [external boundary: mock]
+```
+
+**When to use:**
+
+- Always — this is the default approach
+- Override only when testing integration between internal modules
+  that cannot be separated
+
+**Rules:**
+
+- If a function needs more than two mocks, it has too many
+  responsibilities — split it
+- Prefer fakes (in-memory implementations) over mocks (behavior
+  assertions) — fakes test behavior, mocks test calls
+- Never mock what you own — if you need to mock an internal
+  module, the design needs improvement
+- Mock the dependency, not the function under test
+
+---
+
+## 7. Snapshot testing
+
+[ID: testing-pattern-snapshot]
+
+**Problem:** Verifying complex output (rendered HTML, serialized
+objects, API responses) requires verbose assertions that are hard
+to write and maintain.
+
+**Solution:** Capture the output once as a snapshot file. On
+subsequent runs, compare the output against the stored snapshot.
+Review snapshot changes in code review like any other diff.
+
+**When to use:**
+
+- Rendered component output (HTML, JSX)
+- Serialized data structures with many fields
+- Error message formatting
+- NOT for business logic — use explicit assertions instead
+
+**Rules:**
+
+- Review snapshot diffs carefully — auto-updating masks bugs
+- Keep snapshots small — snapshot a component, not a full page
+- Use inline snapshots for short output (under 10 lines)
+- Never snapshot non-deterministic output (timestamps, random IDs)
+  — stabilize the output first (mock clocks, seed randomness)
+
+---
+
+## 8. Contract testing
+
+[ID: testing-pattern-contract]
+
+**Problem:** Service A depends on Service B's API. Integration
+tests that call Service B are slow, flaky, and require both
+services to be running. Mocking B's responses risks drift —
+the mock may not match B's actual behavior.
+
+**Solution:** Define a contract (schema) for the interaction.
+The consumer (A) tests against the contract. The provider (B)
+verifies it produces responses matching the contract. Neither
+service needs the other running.
+
+```
+Consumer tests: "I expect this shape from B"
+Provider tests: "I produce this shape for A"
+Contract:       shared schema both sides verify against
+```
+
+**When to use:**
+
+- Microservices or distributed systems with API dependencies
+- Teams that own different services
+- APIs that evolve independently
+
+**Rules:**
+
+- Consumer writes the contract — the consumer knows what it needs
+- Provider verifies the contract in CI — a breaking change fails
+  the provider's build
+- Version contracts alongside the services
+- Use established tools: Pact, Spring Cloud Contract, or
+  OpenAPI-driven testing

--- a/base/testing.md
+++ b/base/testing.md
@@ -1,18 +1,25 @@
 # Base — Testing
+
 [ID: base-testing]
+
+## Patterns
+
+- See `base/testing-patterns.md` for reusable test patterns:
+  factory, AAA, builder, parameterized, fixtures, mock boundary,
+  snapshot, contract testing
 
 ## Taxonomy
 
 Test types are classified by the **boundary crossed during execution** — not by
 who runs them, what tools are used, or what assets drive the test content.
 
-| Type | Boundary crossed | Primary focus |
-|------|-----------------|---------------|
-| **Unit** | None — single component in isolation | Correctness of individual functions and classes |
-| **Integration** | Process or component boundary | Behaviour and interaction across components |
-| **System** | System boundary | End-to-end behaviour from a user perspective |
-| **Regression** | Any — reuses existing tests | Protection against unintended change |
-| **Exploratory** | Any — unscripted | Discovery of unexpected behaviour |
+| Type            | Boundary crossed                     | Primary focus                                   |
+| --------------- | ------------------------------------ | ----------------------------------------------- |
+| **Unit**        | None — single component in isolation | Correctness of individual functions and classes |
+| **Integration** | Process or component boundary        | Behaviour and interaction across components     |
+| **System**      | System boundary                      | End-to-end behaviour from a user perspective    |
+| **Regression**  | Any — reuses existing tests          | Protection against unintended change            |
+| **Exploratory** | Any — unscripted                     | Discovery of unexpected behaviour               |
 
 ---
 
@@ -103,11 +110,11 @@ and system tests — they are not a separate test type.
 
 Regression suites are divided by scope and execution time:
 
-| Variant | Scope | Trigger | Target duration |
-|---------|-------|---------|----------------|
-| **Smoke** | Critical paths only | Every commit | < 15 minutes |
-| **Quick** | Core functionality | Every merge request | < 60 minutes |
-| **Full** | Complete suite | Release candidate | Unrestricted |
+| Variant   | Scope               | Trigger             | Target duration |
+| --------- | ------------------- | ------------------- | --------------- |
+| **Smoke** | Critical paths only | Every commit        | < 15 minutes    |
+| **Quick** | Core functionality  | Every merge request | < 60 minutes    |
+| **Full**  | Complete suite      | Release candidate   | Unrestricted    |
 
 - Smoke and Quick regression MUST be fully automated
 - Full regression SHOULD be fully automated; manual steps MUST be documented

--- a/frontend/patterns.md
+++ b/frontend/patterns.md
@@ -1,0 +1,339 @@
+# Frontend — UI Patterns
+
+[ID: frontend-patterns]
+[DEPENDS ON: frontend/quality.md, frontend/ux.md]
+
+Reusable structural patterns for frontend applications. Each
+pattern describes a problem, solution structure, when to use it,
+and examples.
+
+See `frontend/quality.md` for design patterns and state management.
+See `frontend/ux.md` for accessibility and responsive design.
+
+---
+
+## 1. Error boundary
+
+[ID: frontend-pattern-error-boundary]
+
+**Problem:** A runtime error in one component crashes the entire
+application. Users see a blank screen with no way to recover.
+
+**Solution:** Wrap component subtrees in an error boundary that
+catches rendering errors and displays a fallback UI. The rest of
+the application continues to function.
+
+```
+App
+├→ ErrorBoundary → Header (continues working)
+├→ ErrorBoundary → MainContent (crashes → shows fallback)
+└→ ErrorBoundary → Footer (continues working)
+```
+
+**When to use:**
+
+- Around independent sections of the page (sidebar, main, widgets)
+- Around third-party components that may throw
+- NOT around the entire app — that gives you one giant fallback
+
+**Example (React):**
+
+```tsx
+class ErrorBoundary extends React.Component<Props, State> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    logError(error, info);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+```
+
+**Rules:**
+
+- Error boundaries catch rendering errors only — not event
+  handlers, async code, or server-side rendering
+- Log the error before showing the fallback — silent failures
+  are worse than crashes
+- Provide a recovery action in the fallback (retry button,
+  link to home)
+- Place boundaries at natural isolation points — not around
+  every component
+
+---
+
+## 2. Skeleton loading
+
+[ID: frontend-pattern-skeleton]
+
+**Problem:** Content loads asynchronously. The page shows a blank
+area or a spinner until data arrives. Layout shifts when content
+appears — CLS increases, perceived performance drops.
+
+**Solution:** Render placeholder shapes that match the layout of
+the incoming content. When data arrives, replace skeletons with
+real content. No layout shift because the skeleton reserves the
+exact space.
+
+```
+Loading:  [████████]  [████]  [██████████]
+Loaded:   John Smith  Admin   john@example.com
+```
+
+**When to use:**
+
+- Content loaded asynchronously (API calls, lazy loading)
+- Above-the-fold content where a spinner feels slow
+- Lists and tables with known structure but unknown data
+
+**Rules:**
+
+- Skeleton shape MUST match the real content layout — same height,
+  same width, same spacing
+- Use CSS animation (pulse or wave) to indicate loading — static
+  grey boxes look broken
+- Do not show skeletons for content that loads in under 200ms —
+  the flash is worse than a brief wait
+- Prefer skeletons over spinners for structured content; use
+  spinners only for actions (form submit, navigation)
+
+---
+
+## 3. Optimistic update
+
+[ID: frontend-pattern-optimistic]
+
+**Problem:** After a user action (like, save, delete), the UI
+waits for the server response before updating. The delay makes
+the interface feel sluggish — especially on slow networks.
+
+**Solution:** Apply the expected result immediately in the UI.
+Send the request in the background. If the request fails, roll
+back to the previous state and notify the user.
+
+```
+User clicks "Like" → UI shows liked (instant)
+                   → API call in background
+                   → Success: done
+                   → Failure: roll back, show error
+```
+
+**When to use:**
+
+- Actions with a high success rate (> 99%)
+- Actions where the expected outcome is predictable
+- Low-stakes operations (likes, bookmarks, toggles)
+- NOT for payments, destructive operations, or actions with
+  unpredictable outcomes
+
+**Rules:**
+
+- Always implement the rollback path — optimistic without rollback
+  is a data integrity bug
+- Show a non-intrusive error on failure — do not silently revert
+- Store the previous state before applying the update
+- Do not use optimistic updates for operations that affect other
+  users' data in real time
+
+---
+
+## 4. Infinite scroll with virtualization
+
+[ID: frontend-pattern-virtual-scroll]
+
+**Problem:** Rendering thousands of DOM elements for a long list
+freezes the browser. Pagination breaks the browsing flow. Loading
+all items at once wastes bandwidth.
+
+**Solution:** Render only the items visible in the viewport plus
+a small buffer. As the user scrolls, swap items in and out of the
+DOM. Fetch more data when approaching the end of the loaded set.
+
+```
+[buffer]
+[visible viewport — 20 items rendered]
+[buffer]
+... 10,000 items total, only ~30 in DOM
+```
+
+**When to use:**
+
+- Lists with more than 100 items
+- Items have a consistent or estimable height
+- The user needs to browse, not search or filter (for search, use
+  server-side filtering with pagination)
+
+**Rules:**
+
+- Measure or estimate item height — variable heights require a
+  measuring step or estimated height with correction
+- Keep a buffer of 5-10 items above and below the viewport to
+  prevent flashing during fast scrolling
+- Show a loading indicator at the bottom when fetching more data
+- Provide a "back to top" button for long lists
+- Use established libraries: `react-window`, `@tanstack/virtual`,
+  `vue-virtual-scroller`
+
+---
+
+## 5. Debounced search
+
+[ID: frontend-pattern-debounced-search]
+
+**Problem:** A search input fires an API call on every keystroke.
+Typing "camera" sends 6 requests, 5 of which are immediately
+obsolete. The server is overloaded, responses arrive out of order,
+and the UI flickers.
+
+**Solution:** Debounce the input — wait until the user stops
+typing for a short delay before sending the request. Cancel any
+in-flight request when a new one starts.
+
+```
+Keystroke: c-a-m-e-r-a
+Requests:  ............→ "camera" (one request after 300ms pause)
+```
+
+**When to use:**
+
+- Search inputs that trigger API calls
+- Filter controls that cause expensive recomputation
+- Auto-save features
+
+**Rules:**
+
+- Debounce delay: 200-400ms — shorter feels responsive, longer
+  reduces server load
+- Cancel previous requests (AbortController) — stale responses
+  must not overwrite fresh results
+- Show a loading indicator after the debounce fires, not on
+  keystroke — avoids flicker
+- Provide immediate local filtering when possible, defer API
+  calls for server-side search
+
+---
+
+## 6. Form validation pattern
+
+[ID: frontend-pattern-form-validation]
+
+**Problem:** Validation logic is scattered across event handlers,
+submit functions, and inline checks. Error messages appear
+inconsistently — some on blur, some on submit, some never.
+
+**Solution:** Centralize validation rules per field. Validate on
+blur (field level) and on submit (form level). Display errors
+consistently next to the field they belong to.
+
+```
+Field blur  → validate field → show/clear field error
+Form submit → validate all   → show all errors, focus first
+```
+
+**When to use:**
+
+- Any form with more than 2 fields
+- Forms with cross-field validation (password confirmation,
+  date ranges)
+
+**Rules:**
+
+- Validate on blur for immediate feedback — do not wait for submit
+- Validate on submit as a safety net — blur validation alone
+  misses untouched fields
+- Show errors below the field, not in a summary at the top —
+  users should not scroll to find what is wrong
+- Focus the first invalid field on submit
+- Use a validation library for complex forms: Zod, Yup,
+  React Hook Form, VeeValidate
+- Never rely on client-side validation alone — always validate
+  on the server
+
+---
+
+## 7. Responsive layout switch
+
+[ID: frontend-pattern-responsive-switch]
+
+**Problem:** A data table works on desktop but is unusable on
+mobile. Hiding columns loses information. Horizontal scrolling
+is awkward. The same data needs two fundamentally different
+presentations.
+
+**Solution:** Render both layouts. Use CSS to show the appropriate
+one based on viewport width. No JavaScript media queries needed —
+the HTML is server-rendered, CSS handles visibility.
+
+```
+Desktop (> 640px): table with sortable columns
+Mobile  (≤ 640px): card stack with key fields
+```
+
+**When to use:**
+
+- Data tables with 5+ columns
+- Content that requires fundamentally different layouts per
+  breakpoint — not just reflowing
+- Static sites where JavaScript-based responsive switching adds
+  unnecessary complexity
+
+**Rules:**
+
+- Render both layouts in the HTML — CSS controls visibility
+- Mobile-first: design the card layout first, add the table as
+  a desktop enhancement
+- Both layouts MUST show the same data — do not hide information
+  on mobile
+- Use a single data source — do not duplicate data fetching or
+  state between layouts
+- Test both layouts — queries like `getAllByText` verify content
+  exists in both views
+
+---
+
+## 8. URL state synchronization
+
+[ID: frontend-pattern-url-state]
+
+**Problem:** Users apply filters, sort a table, and select a tab.
+When they share the URL or refresh the page, all state is lost.
+The page resets to its default view.
+
+**Solution:** Synchronize UI state with URL search parameters.
+Read initial state from the URL on mount. Update the URL when
+state changes. The URL becomes a shareable, bookmarkable
+representation of the current view.
+
+```
+User applies filters → URL updates: ?mount=X&sort=price&dir=asc
+User shares URL      → recipient sees the same filtered view
+User refreshes       → state restored from URL
+```
+
+**When to use:**
+
+- Filter, sort, and pagination controls
+- Tab or view selection
+- Any state the user would want to share or bookmark
+
+**Rules:**
+
+- Use `replaceState` for filter changes — do not pollute browser
+  history with every keystroke
+- Use `pushState` for navigation-like changes (tab switch, page)
+- Parse URL params on mount — the URL is the source of truth,
+  not component state
+- Validate URL params — malformed or injected values must fall
+  back to defaults, not crash
+- Keep param names short but readable: `sort`, `dir`, `page`,
+  not `sortColumn`, `sortDirection`, `currentPage`

--- a/frontend/quality.md
+++ b/frontend/quality.md
@@ -1,5 +1,13 @@
 # Frontend — Quality Attributes
+
 [ID: frontend-quality]
+
+## Patterns
+
+- See `frontend/patterns.md` for reusable UI patterns:
+  error boundary, skeleton loading, optimistic update, virtual
+  scroll, debounced search, form validation, responsive switch,
+  URL state sync
 
 ## Design patterns
 
@@ -23,6 +31,7 @@ Prefer these patterns for frontend concerns:
   in the UI and roll back on failure; document the rollback path
 
 Avoid:
+
 - **Mediator / Event Bus** between components — use shared state or lifting
   state up instead; an event bus between components creates invisible coupling
 
@@ -32,15 +41,16 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type | Tool | When to use |
-|------------|------|-------------|
-| **Local UI state** | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters |
-| **Shared UI state** | Zustand / Redux Toolkit | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state** | TanStack Query / SWR | Data fetched from an API — lists, detail views, paginated results |
-| **Form state** | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows |
-| **URL state** | Router search params | Shareable or bookmarkable UI state — filters, pagination, selected tab |
+| State type          | Tool                     | When to use                                                                          |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
+| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
+| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
+| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
+| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
 
 Rules:
+
 - Never duplicate server state in a global store — TanStack Query or SWR is
   the cache; the store holds only client-owned state
 - Never put derived state in the store — compute it from existing state with
@@ -50,6 +60,7 @@ Rules:
   not one slice for everything
 
 ## Linting and formatting
+
 - A linter MUST be configured for all JS/TS code
 - Linter and formatter SHOULD run on save in the IDE — never rely on CI
   alone to catch style issues
@@ -58,6 +69,7 @@ Rules:
 - Lint error count SHOULD go down over time — never increase it
 
 ## CSS
+
 - All CSS in a single stylesheet — no inline styles except dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
@@ -65,6 +77,7 @@ Rules:
 - Maximum line length: 80 characters (exempt: prose strings, third-party URLs)
 
 ## Performance
+
 - Preload critical above-the-fold assets
 - Keep client-side JS minimal — every dependency adds to bundle size
 - Avoid unnecessary dependencies
@@ -72,6 +85,7 @@ Rules:
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
 ## SEO & analytics
+
 - `robots.txt`, Open Graph, and Twitter Card meta tags required
 - Canonical URLs required
 - Privacy-friendly analytics only — no consent banner required

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -29,9 +29,17 @@ base:
   - id: base-testing
     file: base/testing.md
     description: Test pyramid, coverage thresholds, naming conventions
+  - id: base-testing-patterns
+    file: base/testing-patterns.md
+    description: Reusable test patterns — factory, AAA, builder, parameterized, fixtures, mocks
+    depends_on: [base-testing]
   - id: base-devsecops
     file: base/devsecops.md
     description: SAST, SCA, SBOM, secret detection, license compliance
+  - id: base-devsecops-patterns
+    file: base/devsecops-patterns.md
+    description: Reusable security patterns — validation, encoding, CSRF, rate limiting, headers
+    depends_on: [base-devsecops]
   - id: base-release
     file: base/release.md
     description: Semver, version bump propagation, backward compat, cut-over
@@ -95,6 +103,10 @@ frontend:
     file: frontend/quality.md
     description: CSS conventions, performance, SEO & analytics
     depends_on: [base-quality]
+  - id: frontend-patterns
+    file: frontend/patterns.md
+    description: Reusable UI patterns — error boundary, skeleton, optimistic, virtual scroll, URL state
+    depends_on: [frontend-quality, frontend-ux]
   - id: frontend-static-site
     file: frontend/static-site.md
     description: Abstract SSG rules — content, assets, SEO


### PR DESCRIPTION
## Summary
- **base/testing-patterns.md** — 8 patterns: factory, AAA, builder, parameterized, fixtures, mock boundary, snapshot, contract testing
- **frontend/patterns.md** — 8 patterns: error boundary, skeleton, optimistic update, virtual scroll, debounced search, form validation, responsive switch, URL state sync
- **base/devsecops-patterns.md** — 8 patterns: input validation, output encoding, secret injection, CSRF, rate limiting, dependency pinning, least privilege, security headers
- Cross-references added to `base/testing.md`, `base/devsecops.md`, `frontend/quality.md`
- All registered in `manifest.yaml`, SPEC.md synced

Together with `base/cicd-patterns.md` (#143), pattern coverage is now:

| Area | Patterns | Template |
|------|----------|----------|
| CI/CD | 8 | `base/cicd-patterns.md` |
| Testing | 8 | `base/testing-patterns.md` |
| Frontend | 8 | `frontend/patterns.md` |
| Security | 8 | `base/devsecops-patterns.md` |

## Test plan
- [x] Smoke tests pass (7/7)
- [x] `sync.py` ran — SPEC.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)