### PR TITLE
fix: recover lost agents.md move and fix stale paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 tests/reports/
 generated/
+temp/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,6 @@ templates/          # All template source files
   frontend/         # Frontend layer — UX, accessibility, CSS, SSG
   platform/         # CI and security tool mappings per hosting platform
   stack/            # Concrete stacks — extend base + layer templates
-  formats/          # Rendering rules per AI agent tool
   INTERVIEW.md      # Agent-driven project setup interview
   manifest.yaml     # Machine-readable dependency graph
 docs/               # Onboarding, playbook, decision logs, SPEC.md

--- a/docs/360-audit.md
+++ b/docs/360-audit.md
@@ -1,0 +1,169 @@
+# 360-Degree Audit History
+
+## Audit history
+
+| Date       | Value | Quality | Viability | Discovery | Issues created            |
+| ---------- | ----- | ------- | --------- | --------- | ------------------------- |
+| 2026-05-04 | B+    | C+      | A-        | D+        | #168–#173 (pre-audit findings) |
+
+## Current bottleneck
+
+**Discovery (D+)** — The project has zero distribution: 2 GitHub
+stars, no launch post, no social card, no community presence, no
+growth mechanism. The README reads as documentation, not a pitch.
+Competitors with comparable or less content hold 200–2,200 stars.
+Until the project is actively placed where its audience gathers
+(Reddit, Twitter/X, Hacker News, awesome-lists), template quality
+is irrelevant because nobody will find them.
+
+---
+
+## 2026-05-04 — Full audit
+
+### Value — Grade: B+
+
+| #  | Sub-dimension                        | Status  | Finding                                                                                                        |
+| -- | ------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------- |
+| 1  | Functional completeness — stacks     | PASS    | All 30 stack templates listed in README exist with substantive content                                         |
+| 2  | Functional completeness — examples   | PASS    | 8 example CLAUDE.md files under examples/ with realistic content                                               |
+| 3  | Functional completeness — interview  | PASS    | templates/INTERVIEW.md has clear 4-phase guided interview                                                      |
+| 4  | Functional completeness — 360        | PASS    | templates/base/workflow/360.md contains real multi-perspective framework                                       |
+| 5  | Functional completeness — dead link  | FAIL    | README:138 references templates/base/core/agents.md (does not exist); correct: templates/base/core/agents.md     |
+| 6  | Content quality — template depth     | PASS    | Spot-checked python-fastapi.md: project structure, override/extend tags, framework-specific rules              |
+| 7  | Content quality — examples realistic | PASS    | Example files contain filled-in identity, architecture trees, stack details — not boilerplate                  |
+| 8  | Content quality — multi-agent output | PARTIAL | Claims output for Cursor/Copilot/Codex but only produces CLAUDE.md and AGENTS.md — technically defensible but could mislead |
+| 9  | Usability — 10-second comprehension  | PASS    | First three lines and bullet list clearly communicate what/who                                                 |
+| 10 | Usability — usage instructions       | PASS    | Three workflows (attach, clone+interview, submodule) clearly separated with copy-pasteable commands            |
+| 11 | Usability — navigation and links     | PARTIAL | Most links resolve; templates/base/core/agents.md link is broken                                              |
+| 12 | Trust — author identified            | PASS    | Author, organization, and GitHub profile clearly stated                                                        |
+| 13 | Trust — maintenance signals          | PASS    | Recent commits days old, active issue backlog, CC BY 4.0 license                                              |
+| 14 | Trust — feedback channel             | PARTIAL | No explicit "Report an issue" link in user-facing README                                                       |
+| 15 | Accessibility                        | PASS    | Plain Markdown — inherently keyboard-navigable, zoomable, no color-dependent meaning                          |
+| 16 | Performance                          | PASS    | Plain text files — no load time, no layout shifts                                                              |
+| 17 | Content quality — coverage gaps      | PARTIAL | 30 stacks but only 8 examples; README does not note this gap                                                   |
+
+**Summary:** The product delivers on its core promise with 30
+composable stack templates, a structured interview workflow, and
+realistic examples. Main user-facing gaps: a broken internal link,
+incomplete example coverage (8/30), and no obvious feedback channel
+in the README.
+
+---
+
+### Quality — Grade: C+
+
+| #  | Sub-dimension                   | Status  | Finding                                                                                        |
+| -- | ------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| 1  | Fresh clone builds              | PASS    | No build step needed; git clone + py tools/sync.py works                                       |
+| 2  | Structure matches docs          | PASS    | All directories in CLAUDE.md 1.2 exist and match layout                                        |
+| 3  | Separation of concerns          | PASS    | Clean: templates (content), tools/tests (code), docs, .github/workflows (CI)                   |
+| 4  | No circular dependencies        | PASS    | DAG inheritance verified by smoke tests SYS-01/SYS-02                                         |
+| 5  | Dead code / orphaned assets     | PARTIAL | .gitignore missing __pycache__/, .venv/, temp/, .claude/                                       |
+| 6  | Naming conventions              | PASS    | Stack files follow <prefix>-<name>.md; Python uses snake_case                                  |
+| 7  | No debug statements             | PASS    | All print() calls are intentional CLI output                                                   |
+| 8  | No commented-out code           | PASS    | Clean                                                                                          |
+| 9  | No hardcoded secrets            | PASS    | None found                                                                                     |
+| 10 | Code style consistent           | PASS    | Consistent across all Python files                                                             |
+| 11 | Tests exist                     | PASS    | 7 smoke + 30 e2e tests covering composition model                                             |
+| 12 | Tests pass                      | FAIL    | Smoke 7/7 pass; E2E offline 27/30 fail — paths not updated after ADR-005 restructuring (#168)  |
+| 13 | Tests runnable from CI          | PARTIAL | Smoke passes on PR; E2E fails on push to main                                                 |
+| 14 | Coverage measured               | FAIL    | No coverage tooling for Python code                                                            |
+| 15 | Tests verify behavior           | PASS    | E2E uses required/forbidden string assertions — behavioral                                     |
+| 16 | Layer 1 — editor config         | FAIL    | No .editorconfig or format-on-save configuration                                               |
+| 17 | Layer 2 — pre-commit hooks      | FAIL    | No .pre-commit-config.yaml or git hooks                                                        |
+| 18 | Layer 3 — CI pipeline           | PARTIAL | Smoke + gitleaks on PR; E2E offline on main push; but main is red                              |
+| 19 | CI green on main                | FAIL    | Last 5+ e2e runs on main all failed; team merges into broken trunk                             |
+| 20 | SAST enabled                    | FAIL    | No CodeQL/Semgrep; only gitleaks for secret detection                                          |
+| 21 | Secret detection                | PASS    | Gitleaks in smoke CI on every PR                                                               |
+| 22 | Dependency scanning             | FAIL    | No Dependabot or equivalent configured                                                         |
+| 23 | CI permissions scoped           | PASS    | Both workflows use permissions: contents: read                                                 |
+| 24 | README accurate                 | PASS    | Matches current state                                                                          |
+| 25 | ONBOARDING complete             | PASS    | Full contributor journey documented                                                            |
+| 26 | PLAYBOOK covers tasks           | PASS    | Adding stacks, renaming, generating, validation, PRs, releases                                 |
+| 27 | Dev journal maintained          | PASS    | docs/dev-journal.md current through 2026-05-04                                                 |
+| 28 | ADRs recorded                   | PASS    | 5 ADRs covering key architectural decisions                                                    |
+| 29 | Docs reflect current state      | PARTIAL | PLAYBOOK contradicts sync.py automation; stale Imbra-Ltd link in tests/INDEX.md (#172)         |
+| 30 | File corruption                 | FAIL    | templates/backend/grpc.md line 1 has stray "yes" (#169)                                        |
+
+**Summary:** Solid architecture, clean separation of concerns, and
+thorough documentation. However, E2E tests are systematically broken
+(27/30 fail due to stale paths), CI on main has been red across 5+
+merges, and the project lacks pre-commit hooks, editor config, SAST,
+dependency scanning, and coverage measurement.
+
+---
+
+### Viability — Grade: A-
+
+| #  | Sub-dimension                    | Status  | Finding                                                                                          |
+| -- | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| 1  | License clearly stated           | PASS    | CC BY 4.0 in LICENSE, referenced in README                                                       |
+| 2  | Dependency license compatibility | PASS    | Only pyyaml (MIT) for tooling                                                                    |
+| 3  | No copyleft without approval     | PASS    | No copyleft dependencies                                                                         |
+| 4  | License matches intended use     | PASS    | CC BY 4.0 appropriate for template/content library                                               |
+| 5  | Privacy and data compliance      | PASS    | No user data collected, no telemetry                                                             |
+| 6  | Hosting/infra costs              | PASS    | GitHub free tier, CI seconds per run, $0/month                                                   |
+| 7  | No unjustified paid services     | PASS    | Claude API only for optional manual live e2e tests                                               |
+| 8  | No single-vendor lock-in         | PASS    | Plain Markdown + Python; fully portable                                                          |
+| 9  | Pipeline sustainable             | PASS    | Well within free-tier limits                                                                     |
+| 10 | Onboarding from docs alone       | PASS    | ONBOARDING, PLAYBOOK, SPEC, CLAUDE.md, ADRs cover full journey                                  |
+| 11 | Bus factor documented            | PASS    | ONBOARDING.md explicitly states bus factor of 1 with mitigation                                  |
+| 12 | Backlog/roadmap                  | PARTIAL | 21 open issues with labels; no milestones or release timeline visible                            |
+| 13 | Maintenance burden proportional  | PASS    | No build, no runtime, no deployments — just Markdown editing                                     |
+| 14 | Contribution model clear         | PASS    | PLAYBOOK + CLAUDE.md document full PR workflow                                                   |
+| 15 | Sole-maintainer risk             | PARTIAL | 1 contributor (221 commits); project remains usable if abandoned (no running service)            |
+| 16 | Dependencies actively maintained | PASS    | pyyaml and gitleaks both actively maintained                                                     |
+| 17 | Dependency count minimal         | PASS    | 1 Python package; zero runtime dependencies                                                      |
+| 18 | Survives dependency abandonment  | PASS    | pyyaml trivially replaceable; templates require nothing                                          |
+| 19 | Disaster recovery from repo      | PASS    | Fully self-contained; clone and it works                                                         |
+
+**Summary:** Exceptionally low operational cost: zero hosting
+expense, one lightweight dependency, no running services. Primary
+risk is bus factor of 1, substantially mitigated by the project being
+static content with thorough documentation. Could run indefinitely
+at near-zero marginal cost.
+
+---
+
+### Discovery — Grade: D+
+
+| #  | Sub-dimension                   | Status  | Finding                                                                                                |
+| -- | ------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| 1  | Clarity of what/who             | PARTIAL | "SOLID-inspired" is jargon; someone searching "how to set up CLAUDE.md" won't connect                  |
+| 2  | Value proposition stated        | PARTIAL | Features described, not outcomes; missing "Your AI agent writes better code with good instructions"     |
+| 3  | Differentiation                 | FAIL    | Competitors at 160–2,200 stars; no comparison or "why us" anywhere                                     |
+| 4  | Name and domain                 | PARTIAL | Descriptive but not memorable; "SOLID" creates confusion; no custom domain; homepage field empty        |
+| 5  | Meta title (repo description)   | PARTIAL | Functional but not compelling; doesn't mention CLAUDE.md or AGENTS.md — the actual search terms        |
+| 6  | README as pitch                 | PARTIAL | Reads like a manual, not a pitch; no urgency or curiosity hook                                         |
+| 7  | Search intent targeting         | FAIL    | Topics include claude-md but description/H1 miss search phrases people use                             |
+| 8  | Heading hierarchy               | PASS    | Clean H1 > H2 > H3 flow; scannable in seconds                                                         |
+| 9  | URL structure                   | PASS    | Clean and predictable                                                                                  |
+| 10 | OG image                        | FAIL    | No custom social card; generic GitHub preview                                                          |
+| 11 | Social preview quality          | FAIL    | No homepage URL, no social card; invisible on social platforms                                          |
+| 12 | Shareable content               | PARTIAL | 30-stack coverage and interview workflow are interesting but nothing packaged for sharing               |
+| 13 | Social proof                    | FAIL    | 2 stars, 0 forks, 0 watchers; no testimonials or community mentions                                   |
+| 14 | Analytics configured            | PARTIAL | GitHub traffic only (119 views, 3 uniques in 14 days); no external analytics                          |
+| 15 | Success metrics defined         | FAIL    | No stated goals for stars, forks, or adoption                                                          |
+| 16 | Data informing decisions        | FAIL    | Traffic data not being acted on; no SEO iteration or distribution experiments                          |
+| 17 | Present where audience looks    | FAIL    | Not on awesome-lists, Reddit, HN, Dev.to, Twitter/X; absent from all target communities                |
+| 18 | Indexable                       | PARTIAL | GitHub indexed but no GitHub Pages site; competes against GitHub UI limitations                        |
+| 19 | Multiple discovery channels     | FAIL    | Only Google (2 uniques) and github.com (1 unique); effectively one channel                             |
+| 20 | Growth mechanism                | FAIL    | No viral loop, no badge in generated files, no referral prompt                                         |
+
+**Summary:** The project has genuine substance but is almost
+completely undiscoverable. 2 stars against competitors with 200–2,200.
+No launch post, no social card, no community presence, no growth
+mechanism. Until actively distributed where the audience gathers,
+template quality is irrelevant.
+
+---
+
+## Summary table
+
+| Category    | Grade     | Findings | Critical |
+| ----------- | --------- | -------- | -------- |
+| Value       | B+        | 17       | 1        |
+| Quality     | C+        | 30       | 7        |
+| Viability   | A-        | 19       | 0        |
+| Discovery   | D+        | 20       | 8        |
+| **Overall** | **D+**    | **86**   | **16**   |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -75,7 +75,7 @@ Then run the system end-to-end with an agent:
 
 1. Open Claude Code in any project directory
 2. Attach `templates/INTERVIEW.md` and `templates/stack/python-flask.md`
-3. Ask: "Generate a CLAUDE.md for this project using templates/formats/agents.md format"
+3. Ask: "Generate a CLAUDE.md for this project using templates/base/core/agents.md format"
 4. Review the output — this is what users get
 
 Or use the automated E2E runner:

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -143,6 +143,7 @@ check.
 ## Release a new version
 
 1. Create a release branch: `git checkout -b chore/release-vA.B.C`
-2. Commit: `git commit --allow-empty -m "chore: release vA.B.C"`
+2. Update `docs/dev-journal.md` with a release entry
+3. Commit: `git commit -m "chore: release vA.B.C"`
 4. Push, open PR, merge
 5. Tag on `main`: `git tag vA.B.C && git push origin vA.B.C`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -54,6 +54,7 @@ base/
 │   ├── quality.md      # Architecture, code style, security, testing
 │   ├── review.md       # Peer review priority, MUST/SHOULD checklists, deviation rules
 │   ├── testing.md      # Test pyramid, coverage thresholds, naming conventions
+│   ├── agents.md       # Output structure, models (inline/reference/hybrid), formatting rules
 │   └── readme.md       # README structure, badges, quick start, contribution guide
 ├── security/
 │   ├── devsecops.md    # SAST, SCA, SBOM, secret detection, license compliance
@@ -192,7 +193,7 @@ frontend/quality.md ────────────────────
                                                         │
                                              + templates/INTERVIEW.md answers
                                                         │
-                                             + templates/formats/agents.md rules
+                                             + templates/base/core/agents.md rules
                                                         │
                                                         ▼
                                                    CLAUDE.md
@@ -416,7 +417,7 @@ Output: ordered list of template files to load.
    include its companion *-patterns.md (if it exists
    in manifest.yaml with a depends_on pointing to
    the rules file)
-6. Append templates/formats/agents.md
+6. Append templates/base/core/agents.md
 7. Return the ordered file list
 ```
 
@@ -479,7 +480,7 @@ Resolved (17 files):
   base/scope.md                   ← extra
   base/issues.md                  ← extra
   platform/github.md              ← platform
-  templates/formats/agents.md               ← output format
+  templates/base/core/agents.md               ← output format
 ```
 
 ### Current vs target

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -94,7 +94,7 @@
 **Key changes:**
 - Session protocol: mandatory startup block, startup hygiene (branch/
   status/issues), build-after-change, visible sequential audit execution
-- formats/agents.md: all 3 models reference base/scope.md (no more
+- base/core/agents.md: all 3 models reference base/scope.md (no more
   incomplete inlined checklists)
 - Quality: DRY/KISS/YAGNI core principles, Fail Fast/Law of Demeter/
   High Cohesion in maintainability, duplication erosion audit check
@@ -125,7 +125,7 @@ missing priority labels to #104, #105, #106
 - Added build-after-change rule to during-work section
 - End-of-session audit now requires visible sequential execution with
   documented trigger phrases
-- `formats/agents.md` — all three models (inline, reference, hybrid)
+- `base/core/agents.md` — all three models (inline, reference, hybrid)
   now reference `base/scope.md` instead of inlining an incomplete
   6-step checklist
 - Added `examples/hybrid-astro/CLAUDE.md` — first reference/hybrid

--- a/examples/astro-portfolio/CLAUDE.md
+++ b/examples/astro-portfolio/CLAUDE.md
@@ -12,7 +12,7 @@ writing, and contact information.
 - **URL**: mariachen.design
 - **Deployment**: GitHub Pages via GitHub Actions on push to `main`
 - **Stack source**: `stack/static-site-astro.md`
-- **Output format**: `formats/agents.md`
+- **Output format**: `base/core/agents.md`
 
 ---
 

--- a/examples/fastapi-service/CLAUDE.md
+++ b/examples/fastapi-service/CLAUDE.md
@@ -11,7 +11,7 @@ REST API for managing tasks, projects, and team assignments.
 - **Repo**: github.com/acme/taskflow-api
 - **Deployment**: Docker → Railway (production), Docker Compose (local)
 - **Stack source**: `stack/python-fastapi.md` + `backend/auth.md` + `backend/caching.md`
-- **Output format**: `formats/agents.md`
+- **Output format**: `base/core/agents.md`
 
 ---
 

--- a/examples/flask-api/CLAUDE.md
+++ b/examples/flask-api/CLAUDE.md
@@ -12,7 +12,7 @@ suppliers, and purchase orders.
 - **Repo**: github.com/acme/inventory-api
 - **Deployment**: Docker → Fly.io (production), Docker Compose (local)
 - **Stack source**: `stack/python-flask.md` + `backend/auth.md` + `backend/jobs.md`
-- **Output format**: `formats/agents.md`
+- **Output format**: `base/core/agents.md`
 
 ---
 

--- a/examples/go-service/CLAUDE.md
+++ b/examples/go-service/CLAUDE.md
@@ -13,7 +13,7 @@ flushes to a PostgreSQL time-series table on a configurable interval.
 - **Repo**: github.com/acme/metricshub
 - **Deployment**: Docker → Kubernetes (production), Docker Compose (local)
 - **Stack source**: `stack/go-service.md` + `backend/caching.md` + `backend/jobs.md`
-- **Output format**: `formats/agents.md`
+- **Output format**: `base/core/agents.md`
 
 ---
 

--- a/examples/react-spa/CLAUDE.md
+++ b/examples/react-spa/CLAUDE.md
@@ -11,7 +11,7 @@ Analytics dashboard for monitoring SaaS subscription metrics and customer health
 - **Repo**: github.com/acme/adminflow
 - **Deployment**: Vercel (production + preview per PR)
 - **Stack source**: `stack/spa-react.md`
-- **Output format**: `formats/agents.md`
+- **Output format**: `base/core/agents.md`
 
 ---
 

--- a/templates/INTERVIEW.md
+++ b/templates/INTERVIEW.md
@@ -71,7 +71,7 @@ Before generating, collect any missing fields in a single question:
 
 Select the matching stack template from the table below and load its
 DEPENDS ON chain. Apply any adjustments from Phase 3.
-Generate the output file using the format rules in `templates/formats/agents.md`.
+Generate the output file using the format rules in `templates/base/core/agents.md`.
 All rules are inlined — the output file is self-contained.
 
 Also generate `docs/ONBOARDING.md` and `docs/PLAYBOOK.md` following the
@@ -101,7 +101,7 @@ required structures in `templates/base/core/docs.md`.
 
 Generate an agent file that inlines critical rules and references the
 templates for the rest. Follow the hybrid model structure in
-`templates/formats/agents.md`. The output file:
+`templates/base/core/agents.md`. The output file:
 
 1. Points to `docs/solid-ai-templates/` as a submodule
 2. Lists ALL template files in the dependency chain

--- a/templates/backend/grpc.md
+++ b/templates/backend/grpc.md
@@ -1,4 +1,3 @@
-yes
 # Backend — gRPC
 [ID: backend-grpc]
 

--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -1,5 +1,5 @@
 # Output Format
-[ID: output-agents]
+[ID: base-agents]
 
 Structure, models, and formatting rules for generating project
 context files.

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -31,6 +31,9 @@ base:
   - id: base-testing
     file: templates/base/core/testing.md
     description: Test pyramid, coverage thresholds, naming conventions
+  - id: base-agents
+    file: templates/base/core/agents.md
+    description: Output structure, models (inline/reference/hybrid), formatting rules
   - id: base-devsecops
     file: templates/base/security/devsecops.md
     description: SAST, SCA, SBOM, secret detection, license compliance
@@ -564,7 +567,3 @@ stacks:
       - base-quality
       - base-testing
 
-formats:
-  - id: output-agents
-    file: templates/formats/agents.md
-    description: Output structure, models (inline/reference/hybrid), formatting rules

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -1,7 +1,7 @@
 # Tests
 
 Procedure specifications for solid-ai-templates following the
-[Imbra Procedure Specification Standard](https://github.com/Imbra-Ltd/imbra-knowledge/blob/main/standards/PROCEDURE-SPECIFICATION.md).
+Imbra Procedure Specification Standard.
 
 Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area codes, and component group registry.
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -6,7 +6,7 @@ Each test entry has these fields:
   spec        the spec file this test implements
   stack       stack template file fed to the agent
   answers     interview answers the agent receives
-  output_file output format template (defaults to formats/agents.md)
+  output_file output format template (defaults to templates/base/core/agents.md)
   extra_files additional template files to include in the prompt
   required    strings that MUST appear in the output
   forbidden   strings that MUST NOT appear in the output
@@ -21,7 +21,7 @@ STK_TESTS = [
     {
         "id": "STK-01",
         "spec": "SAIT-E2E-STK-01-001A",
-        "stack": "stack/python-fastapi.md",
+        "stack": "templates/stack/python-fastapi.md",
         "answers": {
             "Project name": "OrderService",
             "Owner": "Platform team",
@@ -49,7 +49,7 @@ STK_TESTS = [
     {
         "id": "STK-02",
         "spec": "SAIT-E2E-STK-02-001A",
-        "stack": "stack/go-echo.md",
+        "stack": "templates/stack/go-echo.md",
         "answers": {
             "Project name": "MetricsHub",
             "Owner": "Infrastructure team",
@@ -76,7 +76,7 @@ STK_TESTS = [
     {
         "id": "STK-03",
         "spec": "SAIT-E2E-STK-03-001A",
-        "stack": "stack/python-django.md",
+        "stack": "templates/stack/python-django.md",
         "answers": {
             "Project name": "CatalogService",
             "Framework": "Django 5.x + Django REST Framework",
@@ -99,7 +99,7 @@ STK_TESTS = [
     {
         "id": "STK-04",
         "spec": "SAIT-E2E-STK-04-001A",
-        "stack": "stack/node-express.md",
+        "stack": "templates/stack/node-express.md",
         "answers": {
             "Project name": "NotificationService",
             "Language": "TypeScript",
@@ -120,7 +120,7 @@ STK_TESTS = [
     {
         "id": "STK-05",
         "spec": "SAIT-E2E-STK-05-001A",
-        "stack": "stack/spa-react.md",
+        "stack": "templates/stack/spa-react.md",
         "answers": {
             "Project name": "DashboardApp",
             "Language": "TypeScript",
@@ -141,7 +141,7 @@ STK_TESTS = [
     {
         "id": "STK-06",
         "spec": "SAIT-E2E-STK-06-001A",
-        "stack": "stack/full-nextjs.md",
+        "stack": "templates/stack/full-nextjs.md",
         "answers": {
             "Project name": "StorefrontApp",
             "Language": "TypeScript",
@@ -163,7 +163,7 @@ STK_TESTS = [
     {
         "id": "STK-07",
         "spec": "SAIT-E2E-STK-07-001A",
-        "stack": "stack/static-site-astro.md",
+        "stack": "templates/stack/static-site-astro.md",
         "answers": {
             "Project name": "TechBlog",
             "Language": "TypeScript",
@@ -184,7 +184,7 @@ STK_TESTS = [
     {
         "id": "STK-08",
         "spec": "SAIT-E2E-STK-08-001A",
-        "stack": "stack/go-grpc.md",
+        "stack": "templates/stack/go-grpc.md",
         "answers": {
             "Project name": "PaymentGateway",
             "Language": "Go",
@@ -205,7 +205,7 @@ STK_TESTS = [
     {
         "id": "STK-09",
         "spec": "SAIT-E2E-STK-09-001A",
-        "stack": "stack/mobile-flutter.md",
+        "stack": "templates/stack/mobile-flutter.md",
         "answers": {
             "Project name": "FieldSurveyApp",
             "Language": "Dart",
@@ -225,7 +225,7 @@ STK_TESTS = [
     {
         "id": "STK-10",
         "spec": "SAIT-E2E-STK-10-001A",
-        "stack": "stack/go-lib.md",
+        "stack": "templates/stack/go-lib.md",
         "answers": {
             "Project name": "retrykit",
             "Language": "Go",
@@ -247,7 +247,7 @@ STK_TESTS = [
     {
         "id": "STK-11",
         "spec": "SAIT-E2E-STK-11-001A",
-        "stack": "stack/python-flask.md",
+        "stack": "templates/stack/python-flask.md",
         "answers": {
             "Project name": "ReportingAPI",
             "Language": "Python",
@@ -269,7 +269,7 @@ STK_TESTS = [
     {
         "id": "STK-12",
         "spec": "SAIT-E2E-STK-12-001A",
-        "stack": "stack/python-service.md",
+        "stack": "templates/stack/python-service.md",
         "answers": {
             "Project name": "DataPipelineWorker",
             "Language": "Python",
@@ -290,7 +290,7 @@ STK_TESTS = [
     {
         "id": "STK-13",
         "spec": "SAIT-E2E-STK-13-001A",
-        "stack": "stack/python-grpc.md",
+        "stack": "templates/stack/python-grpc.md",
         "answers": {
             "Project name": "MLInferenceService",
             "Language": "Python",
@@ -312,7 +312,7 @@ STK_TESTS = [
     {
         "id": "STK-14",
         "spec": "SAIT-E2E-STK-14-001A",
-        "stack": "stack/python-celery-worker.md",
+        "stack": "templates/stack/python-celery-worker.md",
         "answers": {
             "Project name": "EmailDispatchWorker",
             "Language": "Python",
@@ -334,7 +334,7 @@ STK_TESTS = [
     {
         "id": "STK-15",
         "spec": "SAIT-E2E-STK-15-001A",
-        "stack": "stack/python-lib.md",
+        "stack": "templates/stack/python-lib.md",
         "answers": {
             "Project name": "validify",
             "Language": "Python",
@@ -355,7 +355,7 @@ STK_TESTS = [
     {
         "id": "STK-16",
         "spec": "SAIT-E2E-STK-16-001A",
-        "stack": "stack/go-service.md",
+        "stack": "templates/stack/go-service.md",
         "answers": {
             "Project name": "HealthCheckService",
             "Language": "Go",
@@ -376,7 +376,7 @@ STK_TESTS = [
     {
         "id": "STK-17",
         "spec": "SAIT-E2E-STK-17-001A",
-        "stack": "stack/static-site-hugo.md",
+        "stack": "templates/stack/static-site-hugo.md",
         "answers": {
             "Project name": "DocumentationSite",
             "Language": "Markdown + Go templates",
@@ -396,7 +396,7 @@ STK_TESTS = [
     {
         "id": "STK-18",
         "spec": "SAIT-E2E-STK-18-001A",
-        "stack": "stack/nodejs-lib.md",
+        "stack": "templates/stack/nodejs-lib.md",
         "answers": {
             "Project name": "parsekit",
             "Language": "TypeScript",
@@ -417,7 +417,7 @@ STK_TESTS = [
     {
         "id": "STK-19",
         "spec": "SAIT-E2E-STK-19-001A",
-        "stack": "stack/rust-lib.md",
+        "stack": "templates/stack/rust-lib.md",
         "answers": {
             "Project name": "byteparser",
             "Language": "Rust",
@@ -439,7 +439,7 @@ STK_TESTS = [
     {
         "id": "STK-20",
         "spec": "SAIT-E2E-STK-20-001A",
-        "stack": "stack/htmx.md",
+        "stack": "templates/stack/htmx.md",
         "answers": {
             "Project name": "AdminDashboard",
             "Backend language": "Python (Flask)",
@@ -469,8 +469,8 @@ FMT_TESTS = [
     {
         "id": "FMT-01",
         "spec": "SAIT-E2E-FMT-01-001A",
-        "stack": "stack/python-fastapi.md",
-        "output_file": "formats/agents.md",
+        "stack": "templates/stack/python-fastapi.md",
+        "output_file": "templates/base/core/agents.md",
         "answers": {
             "Project name": "OrderService",
             "Database": "PostgreSQL via SQLAlchemy 2",
@@ -489,8 +489,8 @@ FMT_TESTS = [
     {
         "id": "FMT-02",
         "spec": "SAIT-E2E-FMT-02-001A",
-        "stack": "stack/python-fastapi.md",
-        "output_file": "formats/agents.md",
+        "stack": "templates/stack/python-fastapi.md",
+        "output_file": "templates/base/core/agents.md",
         "answers": {
             "Project name": "OrderService",
             "Database": "PostgreSQL via SQLAlchemy 2",
@@ -520,7 +520,7 @@ ITV_TESTS = [
     {
         "id": "ITV-02",
         "spec": "SAIT-INT-ITV-02-001A",
-        "stack": "stack/python-fastapi.md",
+        "stack": "templates/stack/python-fastapi.md",
         "answers": {
             "Project name": "InventoryService",
             "Owner": "Backend team",
@@ -540,7 +540,7 @@ ITV_TESTS = [
     {
         "id": "ITV-03",
         "spec": "SAIT-INT-ITV-03-001A",
-        "stack": "stack/python-fastapi.md",
+        "stack": "templates/stack/python-fastapi.md",
         "answers": {
             "Project name": "InventoryService",
             "Owner": "Backend team",
@@ -567,8 +567,8 @@ DPL_TESTS = [
     {
         "id": "DPL-01",
         "spec": "SAIT-E2E-DPL-01-001A",
-        "stack": "stack/node-express.md",
-        "extra_files": ["base/deployment.md"],
+        "stack": "templates/stack/node-express.md",
+        "extra_files": ["templates/base/infra/deployment.md"],
         "answers": {
             "Project name": "PublicAPIService",
             "Owner": "Platform team",
@@ -586,8 +586,8 @@ DPL_TESTS = [
     {
         "id": "DPL-02",
         "spec": "SAIT-E2E-DPL-02-001A",
-        "stack": "stack/java-spring-boot.md",
-        "extra_files": ["base/deployment.md"],
+        "stack": "templates/stack/java-spring-boot.md",
+        "extra_files": ["templates/base/infra/deployment.md"],
         "answers": {
             "Project name": "InternalPlatformAPI",
             "Owner": "Platform team",
@@ -604,8 +604,8 @@ DPL_TESTS = [
     {
         "id": "DPL-03",
         "spec": "SAIT-E2E-DPL-03-001A",
-        "stack": "stack/python-fastapi.md",
-        "extra_files": ["base/deployment.md"],
+        "stack": "templates/stack/python-fastapi.md",
+        "extra_files": ["templates/base/infra/deployment.md"],
         "answers": {
             "Project name": "SecureIngestService",
             "Owner": "Platform team",

--- a/tests/run_e2e.py
+++ b/tests/run_e2e.py
@@ -34,9 +34,9 @@ from lib import ROOT, PASS, FAIL, SKIP, ERR, REPORT_TRUNCATION, read, parse_args
 from cases import ALL_TESTS
 
 
-def build_prompt(stack_file, answers, output_file="formats/agents.md",
+def build_prompt(stack_file, answers, output_file="templates/base/core/agents.md",
                  extra_files=()):
-    interview = read("INTERVIEW.md")
+    interview = read("templates/INTERVIEW.md")
     stack = read(stack_file)
     output_fmt = read(output_file)
     answers_text = "\n".join(f"- {k}: {v}" for k, v in answers.items())
@@ -100,7 +100,7 @@ def validate_test_offline(test):
     elif os.path.getsize(stack_file) == 0:
         failures.append(f"  stack file empty: {test['stack']}")
 
-    output_file = test.get("output_file", "formats/agents.md")
+    output_file = test.get("output_file", "templates/base/core/agents.md")
     out_path = os.path.join(ROOT, output_file)
     if not os.path.isfile(out_path):
         failures.append(f"  output format missing: {output_file}")
@@ -141,7 +141,7 @@ def run_test(test, dry_run=False, offline=False):
 
     prompt = build_prompt(
         test["stack"], test["answers"],
-        test.get("output_file", "formats/agents.md"),
+        test.get("output_file", "templates/base/core/agents.md"),
         test.get("extra_files", ()),
     )
 

--- a/tests/specs/SAIT-E2E-DPL-01-001A.md
+++ b/tests/specs/SAIT-E2E-DPL-01-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, deployment, cloud, certificates, dns]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/node-express.md`, `base/deployment.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/node-express.md`, `base/deployment.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: PublicAPIService
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-DPL-02-001A.md
+++ b/tests/specs/SAIT-E2E-DPL-02-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, deployment, hybrid, private-ca, pki]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/java-spring-boot.md`, `base/deployment.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/java-spring-boot.md`, `base/deployment.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: InternalPlatformAPI
    - Language: Java

--- a/tests/specs/SAIT-E2E-DPL-03-001A.md
+++ b/tests/specs/SAIT-E2E-DPL-03-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, deployment, offline, air-gapped, pki]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `base/deployment.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `base/deployment.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: SecureIngestService
    - Language: Python

--- a/tests/specs/SAIT-E2E-FMT-01-001A.md
+++ b/tests/specs/SAIT-E2E-FMT-01-001A.md
@@ -17,17 +17,17 @@ tags: [e2e, output, claude-md, claude-code]
 
 ## Short description
 
-> **Given** `INTERVIEW.md`, `stack/python-fastapi.md`, and `formats/agents.md`
+> **Given** `INTERVIEW.md`, `stack/python-fastapi.md`, and `base/core/agents.md`
 > are attached to an agent
 > **When** the agent conducts the interview and generates output
-> **Then** the result is a valid `CLAUDE.md` formatted per `formats/agents.md`
+> **Then** the result is a valid `CLAUDE.md` formatted per `base/core/agents.md`
 > containing all required sections
 
 ## Results
 
 | Result  | Condition                                                                                                    |
 |---------|--------------------------------------------------------------------------------------------------------------|
-| PASSED  | Output file is named `CLAUDE.md`; all required sections present; formatting follows `formats/agents.md` rules |
+| PASSED  | Output file is named `CLAUDE.md`; all required sections present; formatting follows `base/core/agents.md` rules |
 | FAILED  | Output uses a different format; required sections missing; wrong filename                                    |
 | SKIPPED | No agent available                                                                                           |
 | BLOCKED | `SAIT-INT-TPL-01-001A` is failing                                                                            |
@@ -44,14 +44,14 @@ tags: [e2e, output, claude-md, claude-code]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `base/core/agents.md`
 
 ### Execution
 
 1. Ask the agent:
    ```
    Using INTERVIEW.md and stack/python-fastapi.md, generate a CLAUDE.md
-   for this project. Use formats/agents.md for formatting rules.
+   for this project. Use base/core/agents.md for formatting rules.
    ```
 2. Provide the same interview answers as `SAIT-E2E-STK-01-001A`
 3. Save the generated output
@@ -59,7 +59,7 @@ tags: [e2e, output, claude-md, claude-code]
 ### Assertions
 
 1. Assert output filename is `CLAUDE.md`
-2. Assert formatting follows `formats/agents.md` rules
+2. Assert formatting follows `base/core/agents.md` rules
 3. Assert all required sections are present
 4. Assert FastAPI-specific rules are present
 5. Assert base rules from `base/git.md` and `base/quality.md` are present
@@ -71,4 +71,4 @@ tags: [e2e, output, claude-md, claude-code]
 ## Related
 
 - Related procedures: `SAIT-E2E-STK-01-001A`, `SAIT-E2E-FMT-02-001A`
-- Implements: `formats/agents.md` formatting rules
+- Implements: `base/core/agents.md` formatting rules

--- a/tests/specs/SAIT-E2E-FMT-02-001A.md
+++ b/tests/specs/SAIT-E2E-FMT-02-001A.md
@@ -17,17 +17,17 @@ tags: [e2e, output, agents-md, codex]
 
 ## Short description
 
-> **Given** `INTERVIEW.md`, `stack/python-fastapi.md`, and `formats/agents.md`
+> **Given** `INTERVIEW.md`, `stack/python-fastapi.md`, and `base/core/agents.md`
 > are attached to an agent
 > **When** the agent conducts the interview and generates output
-> **Then** the result is a valid `AGENTS.md` formatted per `formats/agents.md`
+> **Then** the result is a valid `AGENTS.md` formatted per `base/core/agents.md`
 > containing all required sections
 
 ## Results
 
 | Result  | Condition                                                                                                   |
 |---------|-------------------------------------------------------------------------------------------------------------|
-| PASSED  | Output file is named `AGENTS.md`; all required sections present; formatting follows `formats/agents.md` rules |
+| PASSED  | Output file is named `AGENTS.md`; all required sections present; formatting follows `base/core/agents.md` rules |
 | FAILED  | Output uses CLAUDE.md format; required sections missing; wrong filename                                     |
 | SKIPPED | No agent available                                                                                          |
 | BLOCKED | `SAIT-E2E-TPL-01-001A` is failing                                                                           |
@@ -44,14 +44,14 @@ tags: [e2e, output, agents-md, codex]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-fastapi.md`, `base/core/agents.md`
 
 ### Execution
 
 1. Ask the agent:
    ```
    Using INTERVIEW.md and stack/python-fastapi.md, generate an AGENTS.md
-   for this project. Use formats/agents.md for formatting rules.
+   for this project. Use base/core/agents.md for formatting rules.
    ```
 2. Provide the same interview answers as `SAIT-E2E-TPL-01-001A`
 3. Save the generated output
@@ -59,7 +59,7 @@ tags: [e2e, output, agents-md, codex]
 ### Assertions
 
 1. Assert output filename is `AGENTS.md`
-2. Assert formatting follows `formats/agents.md` rules (not CLAUDE.md rules)
+2. Assert formatting follows `base/core/agents.md` rules (not CLAUDE.md rules)
 3. Assert all required sections are present
 4. Assert FastAPI-specific rules are present
 5. Assert base rules from `base/git.md` and `base/quality.md` are present

--- a/tests/specs/SAIT-E2E-STK-01-001A.md
+++ b/tests/specs/SAIT-E2E-STK-01-001A.md
@@ -46,7 +46,7 @@ tags: [e2e, output, fastapi, claude-md]
 2. Attach the following files:
    - `INTERVIEW.md`
    - `stack/python-fastapi.md`
-   - `formats/agents.md`
+   - `base/core/agents.md`
 3. Prepare the following interview answers:
    - **Project name**: OrderService
    - **Owner**: Platform team
@@ -63,7 +63,7 @@ tags: [e2e, output, fastapi, claude-md]
 1. Ask the agent:
    ```
    Using INTERVIEW.md and stack/python-fastapi.md, generate a CLAUDE.md
-   for this project. Use formats/agents.md for formatting rules.
+   for this project. Use base/core/agents.md for formatting rules.
    ```
 2. Provide the prepared interview answers when the agent asks
 3. Save the generated output as `CLAUDE.md` in a temp directory

--- a/tests/specs/SAIT-E2E-STK-02-001A.md
+++ b/tests/specs/SAIT-E2E-STK-02-001A.md
@@ -46,7 +46,7 @@ tags: [e2e, output, go-echo, claude-md]
 2. Attach the following files:
    - `INTERVIEW.md`
    - `stack/go-echo.md`
-   - `formats/agents.md`
+   - `base/core/agents.md`
 3. Prepare the following interview answers:
    - **Project name**: MetricsHub
    - **Owner**: Infrastructure team
@@ -63,7 +63,7 @@ tags: [e2e, output, go-echo, claude-md]
 1. Ask the agent:
    ```
    Using INTERVIEW.md and stack/go-echo.md, generate a CLAUDE.md
-   for this project. Use formats/agents.md for formatting rules.
+   for this project. Use base/core/agents.md for formatting rules.
    ```
 2. Provide the prepared interview answers when the agent asks
 3. Save the generated output as `CLAUDE.md` in a temp directory

--- a/tests/specs/SAIT-E2E-STK-03-001A.md
+++ b/tests/specs/SAIT-E2E-STK-03-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, django, python]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-django.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-django.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: CatalogService
    - Framework: Django 5.x + DRF

--- a/tests/specs/SAIT-E2E-STK-04-001A.md
+++ b/tests/specs/SAIT-E2E-STK-04-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, express, nodejs]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/node-express.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/node-express.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: NotificationService
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-STK-05-001A.md
+++ b/tests/specs/SAIT-E2E-STK-05-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, react, spa, frontend]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/spa-react.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/spa-react.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: DashboardApp
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-STK-06-001A.md
+++ b/tests/specs/SAIT-E2E-STK-06-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, nextjs, fullstack, react]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/full-nextjs.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/full-nextjs.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: StorefrontApp
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-STK-07-001A.md
+++ b/tests/specs/SAIT-E2E-STK-07-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, astro, static-site]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/static-site-astro.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/static-site-astro.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: TechBlog
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-STK-08-001A.md
+++ b/tests/specs/SAIT-E2E-STK-08-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, grpc, go, protobuf]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/go-grpc.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/go-grpc.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: PaymentGateway
    - Language: Go

--- a/tests/specs/SAIT-E2E-STK-09-001A.md
+++ b/tests/specs/SAIT-E2E-STK-09-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, flutter, mobile, dart]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/mobile-flutter.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/mobile-flutter.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: FieldSurveyApp
    - Language: Dart

--- a/tests/specs/SAIT-E2E-STK-10-001A.md
+++ b/tests/specs/SAIT-E2E-STK-10-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, go, library]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/go-lib.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/go-lib.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: retrykit
    - Language: Go

--- a/tests/specs/SAIT-E2E-STK-11-001A.md
+++ b/tests/specs/SAIT-E2E-STK-11-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, flask, python]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-flask.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-flask.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: ReportingAPI
    - Language: Python

--- a/tests/specs/SAIT-E2E-STK-12-001A.md
+++ b/tests/specs/SAIT-E2E-STK-12-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, python, service]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-service.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-service.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: DataPipelineWorker
    - Language: Python

--- a/tests/specs/SAIT-E2E-STK-13-001A.md
+++ b/tests/specs/SAIT-E2E-STK-13-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, grpc, python, protobuf]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-grpc.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-grpc.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: MLInferenceService
    - Language: Python

--- a/tests/specs/SAIT-E2E-STK-14-001A.md
+++ b/tests/specs/SAIT-E2E-STK-14-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, celery, python, async, worker]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-celery-worker.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-celery-worker.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: EmailDispatchWorker
    - Language: Python

--- a/tests/specs/SAIT-E2E-STK-15-001A.md
+++ b/tests/specs/SAIT-E2E-STK-15-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, python, library]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/python-lib.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/python-lib.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: validify
    - Language: Python

--- a/tests/specs/SAIT-E2E-STK-16-001A.md
+++ b/tests/specs/SAIT-E2E-STK-16-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, go, service]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/go-service.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/go-service.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: HealthCheckService
    - Language: Go

--- a/tests/specs/SAIT-E2E-STK-17-001A.md
+++ b/tests/specs/SAIT-E2E-STK-17-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, hugo, static-site]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/static-site-hugo.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/static-site-hugo.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: DocumentationSite
    - Language: Markdown + Go templates

--- a/tests/specs/SAIT-E2E-STK-18-001A.md
+++ b/tests/specs/SAIT-E2E-STK-18-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, nodejs, library, npm]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/nodejs-lib.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/nodejs-lib.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: parsekit
    - Language: TypeScript

--- a/tests/specs/SAIT-E2E-STK-19-001A.md
+++ b/tests/specs/SAIT-E2E-STK-19-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, rust, library, crates-io]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/rust-lib.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/rust-lib.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: byteparser
    - Language: Rust

--- a/tests/specs/SAIT-E2E-STK-20-001A.md
+++ b/tests/specs/SAIT-E2E-STK-20-001A.md
@@ -42,7 +42,7 @@ tags: [e2e, output, htmx, hypermedia, server-side]
 ### Setup
 
 1. Open Claude Code
-2. Attach `INTERVIEW.md`, `stack/htmx.md`, `formats/agents.md`
+2. Attach `INTERVIEW.md`, `stack/htmx.md`, `base/core/agents.md`
 3. Interview answers:
    - Project name: AdminDashboard
    - Backend language: Python (Flask or FastAPI)


### PR DESCRIPTION
## Summary

- Recover the agents.md move (`formats/` → `base/core/`) that was
  committed on `fix/claude-md-review` but never merged to main
- Fix all stale paths across E2E tests, specs, docs, and examples
- Fix 5 additional bugs found during pre-release 360-degree audit

## Fixes

| Issue | Description |
|-------|-------------|
| #168 | E2E test paths broken after ADR-005 restructuring |
| #169 | Stray "yes" in templates/backend/grpc.md |
| #170 | Wrong path in README.md:138 |
| #171 | PLAYBOOK.md release step numbering |
| #172 | Stale Imbra-Ltd link in tests/INDEX.md |
| #173 | DPL tests reference non-existent base/deployment.md |

## Root cause

Commit `1e6af14` on branch `fix/claude-md-review` moved agents.md
and updated 36 files, but the branch was never merged. PR #164 was
squash-merged from a separate commit that only touched CLAUDE.md,
leaving the move behind.

## Test plan

- [x] `py tests/run_smoke.py` — 7/7 pass
- [x] `py tests/run_e2e.py --offline` — 27/27 pass (3 skipped)
- [x] `py tools/sync.py --check` — all files in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)