### PR TITLE
docs: codify release and CI lessons into templates

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -148,11 +148,8 @@ stack/
 
 Rendering rules for the generated output. Describes structure, model
 selection (inline/reference/hybrid), and formatting constraints.
-
-```
-formats/
-└── agents.md    # Output structure, models, formatting rules
-```
+Lives in `templates/base/core/agents.md` alongside the other core
+templates.
 
 ### 7. Interview template (orchestrator)
 
@@ -440,18 +437,18 @@ Resolved (17 files):
   templates/base/core/quality.md
   templates/base/workflow/quality-gates.md
   templates/base/core/testing.md
-  base/testing-patterns.md        ← full resolution
+  docs/patterns/testing.md            ← full resolution
   templates/base/language/typescript.md
-  frontend/ux.md
-  frontend/quality.md
-  frontend/patterns.md            ← full resolution
-  frontend/static-site.md
+  templates/frontend/ux.md
+  templates/frontend/quality.md
+  docs/patterns/frontend.md           ← full resolution
+  templates/frontend/static-site.md
   templates/stack/static-site-astro.md
-  base/data-quality.md            ← extra
-  base/360.md                     ← extra
-  base/issues.md                  ← extra
-  base/scope.md                   ← extra
-  platform/github.md              ← platform
+  templates/base/language/data-quality.md  ← extra
+  templates/base/workflow/360.md           ← extra
+  templates/base/workflow/issues.md        ← extra
+  templates/base/workflow/scope.md         ← extra
+  templates/platform/github.md             ← platform
 ```
 
 ### Example: python-flask (Resolution: rules)
@@ -467,20 +464,20 @@ Resolved (17 files):
   templates/base/core/git.md
   templates/base/core/docs.md
   templates/base/core/quality.md
-  stack/python-lib.md
-  backend/config.md
-  backend/http.md
-  backend/database.md
-  backend/observability.md
-  backend/quality.md
-  backend/features.md
-  backend/messaging.md
-  stack/python-service.md
-  stack/python-flask.md
-  base/scope.md                   ← extra
-  base/issues.md                  ← extra
-  platform/github.md              ← platform
-  templates/base/core/agents.md               ← output format
+  templates/stack/python-lib.md
+  templates/backend/config.md
+  templates/backend/http.md
+  templates/backend/database.md
+  templates/backend/observability.md
+  templates/backend/quality.md
+  templates/backend/features.md
+  templates/backend/messaging.md
+  templates/stack/python-service.md
+  templates/stack/python-flask.md
+  templates/base/workflow/scope.md       ← extra
+  templates/base/workflow/issues.md      ← extra
+  templates/platform/github.md           ← platform
+  templates/base/core/agents.md          ← output format
 ```
 
 ### Current vs target
@@ -502,9 +499,9 @@ templates/frontend/[concern].md           # frontend layer — UI projects only
 templates/backend/[concern].md            # backend layer — services and APIs only
 templates/stack/[framework].md            # concrete — extends base + frontend or backend
 templates/stack/[framework]-[variant].md  # variant of a framework (e.g. astro-ssr.md)
-templates/formats/[tool].md               # rendering rules for a specific output format
-templates/INTERVIEW.md          # orchestrator — always one file
-SPEC.md                         # this file
+templates/base/core/agents.md    # output format — structure, models, formatting rules
+templates/INTERVIEW.md           # orchestrator — always one file
+docs/SPEC.md                     # this file
 ```
 
 ---

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -30,6 +30,7 @@ levels. Every rule MUST use one of these words:
 | `docs/ONBOARDING.md`  | Onboarding guide for new contributors                                  |
 | `docs/PLAYBOOK.md`    | Operational reference for common tasks                                 |
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
+| `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
 ## Numbering
 

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -33,6 +33,19 @@
   git checkout main && git pull
   ```
 
+### Squash-merge safety
+
+When using squash merge, the branch commits become orphaned after
+the PR merges — only the squash commit lands on main. If a branch
+contains multiple concerns and only one is merged via PR, the
+remaining commits are silently lost.
+
+- MUST NOT mix unrelated changes on a single branch
+- MUST verify that all branch commits are accounted for before
+  deleting a branch — compare the squash diff against the branch diff
+- SHOULD enable "automatically delete head branches" in repository
+  settings to prevent stale branches from accumulating
+
 ## README
 - Every repository MUST contain a `README.md`
 - The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
@@ -46,13 +59,20 @@
 - Pre-release versions: `v1.0.0-alpha.1`, `v1.0.0-rc.1`
 
 ## Release process
-  1. `git checkout -b chore/release-vX.Y.Z`
-  2. Bump version in the project manifest (`package.json`, `pyproject.toml`,
-     `Cargo.toml`, or equivalent) to `X.Y.Z`
-  3. `git commit -m "chore: release vX.Y.Z"`
-  4. Push, open PR, merge
-  5. `git checkout main && git pull`
-  6. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  1. Check for unmerged branches: `git branch --no-merged main`
+     — investigate any results before proceeding
+  2. Check for orphaned commits: `git fsck --unreachable --no-reflogs
+     | grep commit` — verify no unique work is lost
+  3. Run a 360-degree analysis if the project uses
+     `templates/base/workflow/360.md` — the project SHOULD NOT
+     ship with critical findings unresolved
+  4. `git checkout -b chore/release-vX.Y.Z`
+  5. Bump version in the project manifest (`package.json`,
+     `pyproject.toml`, `Cargo.toml`, or equivalent) to `X.Y.Z`
+  6. `git commit -m "chore: release vX.Y.Z"`
+  7. Push, open PR, merge
+  8. `git checkout main && git pull`
+  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
 
 ## General
 - Do not commit build output, secrets, or dependency directories

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -49,6 +49,9 @@ Runs automatically before every commit. Blocks bad commits locally.
 Runs on every PR. The final gate before merge.
 
 - Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
 - CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
   with `--no-verify`
 - CI adds checks that cannot run locally: deep security analysis (SAST),


### PR DESCRIPTION
## Summary

Codifies lessons learned during the v2.0.0 pre-release audit into
the base templates so all projects using solid-ai-templates benefit.

### git.md
- **Squash-merge safety** — warns about orphaned commits when
  branches mix concerns; recommends branch auto-delete
- **Release process** — adds 3 pre-tag verification steps: check
  unmerged branches, check orphaned commits, run 360 audit

### quality-gates.md
- CI checks MUST be **required status checks** in branch protection,
  not just informational runs

### SPEC.md
- Fix stale `formats/` references (agents.md moved to `base/core/`)
- Fix paths missing `templates/` prefix in consumption model examples
- Update file naming conventions

## Test plan

- [x] `py tests/run_smoke.py` — 7/7 pass
- [x] `py tools/sync.py --check` — all in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)