### PR TITLE
fix: clarify multi-agent output claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ consistent context files for any stack and any agent.
 
 - Generate `CLAUDE.md` or `AGENTS.md` from reusable layers — base, backend/frontend, stack
 - Cover Python, Go, Java, Node, Rust, mobile, and DevOps stacks
-- Output for any agent — Claude Code, Cursor, Copilot, Codex CLI
+- Output `CLAUDE.md` for Claude Code or `AGENTS.md` for Cursor, Copilot, Codex CLI
 - Run a 360-degree project assessment across four perspectives
 - Enforce standardized issue labels, quality gates, and review processes
 


### PR DESCRIPTION
## Summary
- Clarify that output is `CLAUDE.md` or `AGENTS.md`, not separate files per tool

Closes #187

## Test plan
- [ ] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)