### PR TITLE
fix: add report-an-issue link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ See `templates/base/core/agents.md` for structure, models, and formatting rules.
 - [Onboarding guide](docs/ONBOARDING.md)
 - [Operational playbook](docs/PLAYBOOK.md)
 - [Architecture decision records](docs/decisions/)
+- [Report an issue](https://github.com/braboj/solid-ai-templates/issues)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add "Report an issue" link to the Links section of README

Closes #183

## Test plan
- [ ] Link renders correctly and points to issues page

🤖 Generated with [Claude Code](https://claude.com/claude-code)