### PR TITLE
fix: standardize on 3-digit SemVer and add no-build release process

### DIFF
--- a/docs/decisions/006-release-versioning.md
+++ b/docs/decisions/006-release-versioning.md
@@ -1,0 +1,45 @@
+# ADR 006 — Release Versioning and Process
+
+## Status
+
+Accepted
+
+## Context
+
+The release template (`base/infra/release.md`) prescribed a four-digit
+versioning scheme (`MAJOR.MINOR.BUILD.PATCH`). This is non-standard —
+the industry default is three-digit SemVer (`MAJOR.MINOR.PATCH`). The
+BUILD segment added complexity without solving a clear problem for most
+projects.
+
+The release process in `base/core/git.md` assumed every project has a
+version manifest to bump (`package.json`, `pyproject.toml`, etc.). For
+no-build projects (plain Markdown, documentation, templates), this
+created an awkward step with nothing to change.
+
+## Decision
+
+1. **Three-digit SemVer** — adopt standard `MAJOR.MINOR.PATCH` in
+   `release.md`, dropping the BUILD segment
+2. **Milestones map to minor bumps** — each milestone closes with a
+   minor version release (e.g. v2.1, v2.2)
+3. **No-build release variant** — projects without a version manifest
+   tag main directly and create a GitHub Release with auto-generated
+   notes, skipping the chore PR
+4. **Build projects keep the chore PR** — projects with a manifest
+   still follow the branch → bump → PR → merge → tag flow
+
+## Alternatives considered
+
+- **Keep four digits** — rejected; non-standard, confusing for
+  contributors, no tooling support
+- **CHANGELOG.md for no-build** — rejected; GitHub Releases
+  auto-generate notes from merged PRs, avoiding manual maintenance
+- **Empty commits** — rejected; some CI rejects them, and they add
+  noise to history
+
+## Consequences
+
+- `release.md` versioning section updated to three-digit SemVer
+- `git.md` release process updated with a no-build variant
+- Existing tags (v2.0.0, v2.1.0) already follow three-digit SemVer

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -59,6 +59,8 @@ remaining commits are silently lost.
 - Pre-release versions: `v1.0.0-alpha.1`, `v1.0.0-rc.1`
 
 ## Release process
+
+### Pre-release checks
   1. Check for unmerged branches: `git branch --no-merged main`
      — investigate any results before proceeding
   2. Check for orphaned commits: `git fsck --unreachable --no-reflogs
@@ -66,6 +68,8 @@ remaining commits are silently lost.
   3. Run a 360-degree analysis if the project uses
      `templates/base/workflow/360.md` — the project SHOULD NOT
      ship with critical findings unresolved
+
+### Projects with a version manifest
   4. `git checkout -b chore/release-vX.Y.Z`
   5. Bump version in the project manifest (`package.json`,
      `pyproject.toml`, `Cargo.toml`, or equivalent) to `X.Y.Z`
@@ -73,6 +77,13 @@ remaining commits are silently lost.
   7. Push, open PR, merge
   8. `git checkout main && git pull`
   9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+### Projects without a version manifest (no-build)
+  4. `git checkout main && git pull`
+  5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+  6. `git push origin vX.Y.Z`
+  7. Create a GitHub Release with auto-generated notes:
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories

--- a/templates/base/infra/release.md
+++ b/templates/base/infra/release.md
@@ -2,10 +2,9 @@
 [ID: base-release]
 
 ## Versioning
-- All packages and services MUST follow semantic versioning (`MAJOR.MINOR.BUILD.PATCH`)
+- All packages and services MUST follow semantic versioning (`MAJOR.MINOR.PATCH`)
 - MAJOR — breaking changes
 - MINOR — new backward-compatible functionality
-- BUILD - increments that belong to the next release
 - PATCH — backward-compatible bug fixes
 
 ## Version bump propagation


### PR DESCRIPTION
## Summary
- ADR 006: document versioning and release process decisions
- `release.md`: drop non-standard BUILD segment, use `MAJOR.MINOR.PATCH`
- `git.md`: split release process into manifest and no-build variants

Closes #200

## Test plan
- [ ] Smoke tests pass
- [ ] Review ADR 006 for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)