### PR TITLE
fix: remove stale security-patterns ref and add EXTEND links to auth.md

### DIFF
--- a/templates/backend/auth.md
+++ b/templates/backend/auth.md
@@ -1,8 +1,11 @@
 # Backend — Authentication and Authorization
 [ID: backend-auth]
+[DEPENDS ON: templates/base/security/security.md]
 
 Rules for identity verification (authn) and access control (authz).
 Applies to any backend service that has protected resources.
+Extends `security-authn` and `security-sessions` from the base
+security template with backend-specific depth.
 
 ---
 
@@ -17,6 +20,7 @@ Applies to any backend service that has protected resources.
 ---
 
 ## Authentication
+[EXTEND: security-authn]
 
 - Prefer delegating authentication to an identity provider (IdP) via
   OAuth 2.0 / OIDC (e.g. Auth0, Keycloak, Cognito) over rolling your own
@@ -57,6 +61,7 @@ Applies to any backend service that has protected resources.
 ---
 
 ## Session management (if using sessions instead of tokens)
+[EXTEND: security-sessions]
 
 - Use cryptographically random session IDs (≥ 128 bits)
 - Regenerate session ID on privilege escalation (login, sudo-style elevation)

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -240,7 +240,8 @@ design fixes the testability.
 - See `templates/base/security/security.md` for comprehensive application security rules
   (input validation, output encoding, injection prevention, auth,
   sessions, TLS, headers, error handling, logging, CORS, uploads)
-- See `base/security-patterns.md` for reusable security patterns
+- See `templates/base/security/devsecops.md` for pipeline security
+  (SAST, SCA, DAST, secret detection)
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Remove dead `security-patterns.md` reference from quality.md, replace with devsecops.md
- Add `[DEPENDS ON]` and `[EXTEND]` links from backend/auth.md to base security template
- Formalizes the inheritance: security.md (base) → auth.md (backend extension)

Closes #213

## Test plan
- [x] `py tests/run_smoke.py` — 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)