### PR TITLE
refactor: move testability section from quality.md to testing.md

### DIFF
--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -156,6 +156,11 @@ Apply SOLID at the class, module, and service level:
 
 ## Testability
 
+- Testability is a first-class design concern, not an afterthought
+- Code MUST be designed for testability from the start — do not write
+  code first and struggle to test later
+- If code is hard to test, treat it as a design problem, not a
+  testing problem
 - See `templates/base/core/testing.md` for testability patterns (pure
   functions, boundary architecture, SOLID), test types, coverage
   targets, and execution rules

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -156,58 +156,9 @@ Apply SOLID at the class, module, and service level:
 
 ## Testability
 
-Testability is a first-class design concern, not an afterthought. Code that
-is hard to test is hard to test because it is poorly designed — fixing the
-design fixes the testability.
-
-### Pure functions over side effects
-
-- Business logic SHOULD be implemented as pure functions — same input,
-  same output, no side effects (no I/O, no mutation of external state)
-- Side effects (database, API, filesystem, DOM) SHOULD be pushed to
-  the boundary — thin adapters that call pure logic
-- Pure functions are trivially unit-testable with no mocks, stubs, or setup
-- A function that mixes logic and side effects is a signal to split it:
-  extract the logic into a pure function, keep the side effect in a
-  thin wrapper
-
-### Architecture for testability
-
-- Push side effects to the edges:
-  `[boundary: I/O] → [pure: logic] → [boundary: I/O]`
-- The pure center is unit-testable; the thin boundaries are
-  integration-testable
-- If a function needs more than two mocks to test, it has too many
-  responsibilities — split it
-
-### SOLID enables testability
-
-- **SRP** — a function with one responsibility has one reason to test;
-  multiple responsibilities require combinatorial test cases
-- **OCP** — new behaviour via extension means existing tests stay green
-- **LSP** — subtypes that honour contracts can be tested against the base
-  type's tests
-- **ISP** — small interfaces mean fewer dependencies to mock
-- **DIP** — depend on abstractions, inject dependencies; code that
-  instantiates its own dependencies cannot be tested in isolation
-
-### Design patterns and composition
-
-- Design patterns enable testability by enforcing separation of concerns,
-  loose coupling, and clear contracts — any correctly applied pattern
-  from the Design patterns section improves testability as a side effect
-- Prefer composition over inheritance (see OOP section) — composed
-  dependencies can be injected and swapped in tests; inherited behaviour
-  drags the entire class hierarchy into every test
-
-### Rules
-
-- Design for testability from the start — do not write code first and
-  struggle to test later
-- If code is hard to test, treat it as a design problem, not a testing
-  problem
-- See `templates/base/core/testing.md` for test types, coverage targets, and execution
-  rules
+- See `templates/base/core/testing.md` for testability patterns (pure
+  functions, boundary architecture, SOLID), test types, coverage
+  targets, and execution rules
 
 ## Automated enforcement
 

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -135,11 +135,61 @@ predefined expected outcome. It is not part of any regression suite.
 
 ---
 
+## Testability
+
+Testability is a first-class design concern, not an afterthought. Code
+that is hard to test is hard to test because it is poorly designed —
+fixing the design fixes the testability.
+
+### Pure functions over side effects
+
+- Business logic SHOULD be implemented as pure functions — same input,
+  same output, no side effects (no I/O, no mutation of external state)
+- Side effects (database, API, filesystem, DOM) SHOULD be pushed to
+  the boundary — thin adapters that call pure logic
+- Pure functions are trivially unit-testable with no mocks, stubs, or
+  setup
+- A function that mixes logic and side effects is a signal to split
+  it: extract the logic into a pure function, keep the side effect
+  in a thin wrapper
+
+### Architecture for testability
+
+- Push side effects to the edges:
+  `[boundary: I/O] → [pure: logic] → [boundary: I/O]`
+- The pure center is unit-testable; the thin boundaries are
+  integration-testable
+- If a function needs more than two mocks to test, it has too many
+  responsibilities — split it
+
+### SOLID enables testability
+
+- **SRP** — one responsibility = one reason to test; multiple
+  responsibilities require combinatorial test cases
+- **OCP** — new behaviour via extension means existing tests stay
+  green
+- **LSP** — subtypes that honour contracts can be tested against the
+  base type's tests
+- **ISP** — small interfaces mean fewer dependencies to mock
+- **DIP** — depend on abstractions, inject dependencies; code that
+  instantiates its own dependencies cannot be tested in isolation
+
+### Design patterns and composition
+
+- Design patterns enable testability by enforcing separation of
+  concerns, loose coupling, and clear contracts
+- Prefer composition over inheritance — composed dependencies can be
+  injected and swapped in tests; inherited behaviour drags the entire
+  class hierarchy into every test
+
+---
+
 ## General rules
 
-- Code MUST be designed for testability from the start — see the
-  Testability section in `templates/base/core/quality.md` for architectural patterns
-  (pure functions, boundary architecture, SOLID, design patterns)
+- Design for testability from the start — do not write code first and
+  struggle to test later
+- If code is hard to test, treat it as a design problem, not a testing
+  problem
 - Test behaviour, not implementation details
 - Each test MUST be independent — no shared mutable state between tests
 - A failing test MUST trigger an investigation before any other action —


### PR DESCRIPTION
## Summary
- Move 50+ line Testability section (pure functions, boundary architecture, SOLID enables testability, design patterns) from quality.md to testing.md
- quality.md retains a one-line cross-reference to testing.md

Closes #217

## Test plan
- [x] `py tests/run_smoke.py` — 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)