### PR TITLE
fix: fix stale references and manifest dependency mismatches

### DIFF
--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -80,7 +80,7 @@ base:
   - id: base-quality-gates
     file: templates/base/workflow/quality-gates.md
     description: Three-layer gate model (editor, pre-commit, CI), thresholds
-    depends_on: [base-quality, base-git, base-testing]
+    depends_on: [base-quality, base-git, base-testing, base-config]
   - id: base-ai-workflow
     file: templates/base/workflow/ai-workflow.md
     description: AI-assisted development lifecycle, work item hierarchy
@@ -92,7 +92,7 @@ platform:
   - id: platform-github
     file: templates/platform/github.md
     description: CodeQL, GitHub Actions, gitleaks action, push protection
-    depends_on: [base-quality-gates]
+    depends_on: [base-quality-gates, base-issues]
   - id: platform-gitlab
     file: templates/platform/gitlab.md
     description: Semgrep OSS, GitLab CI/CD, gitleaks CLI
@@ -133,7 +133,7 @@ backend:
   - id: backend-auth
     file: templates/backend/auth.md
     description: Authn/authz, JWT, RBAC, sessions, API keys
-    depends_on: [backend-http]
+    depends_on: [backend-http, base-security]
   - id: backend-jobs
     file: templates/backend/jobs.md
     description: Background jobs, idempotency, retry, DLQ, scheduling

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -60,8 +60,8 @@ gate categories to GitHub Actions workflows and GitHub-native features.
           dependency-type: development
   ```
 - Group related dependencies to reduce PR noise
-- Combine with the auto-merge pattern (`base/cicd-patterns.md`)
-  for patch and minor updates
+- Combine with auto-merge for patch and minor updates: a GitHub
+  Actions workflow that merges passing `dependabot/` branches
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove stale `cicd-patterns.md` reference from github.md
- Add `base-issues` to platform-github depends_on
- Add `base-security` to backend-auth depends_on
- Add `base-config` to base-quality-gates depends_on

Closes #218

## Test plan
- [x] `py tests/run_smoke.py` — 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)