### PR TITLE
fix: refactor backend-quality.md and add missing DEPENDS ON headers

### DIFF
--- a/templates/backend/monitoring.md
+++ b/templates/backend/monitoring.md
@@ -1,5 +1,6 @@
 # Backend — Monitoring
 [ID: backend-monitoring]
+[DEPENDS ON: templates/backend/observability.md]
 
 ## Key metrics
 Every service MUST monitor at minimum:

--- a/templates/backend/quality.md
+++ b/templates/backend/quality.md
@@ -1,5 +1,6 @@
 # Backend — Quality Attributes
 [ID: backend-quality]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -31,11 +32,11 @@ Prefer these patterns for backend concerns:
   requirements diverge significantly; do not apply by default
 
 ## Security
-- Validate and sanitise all input at the boundary before passing it inward
-- Apply authentication and authorisation before any business logic executes
-- Set security headers on all responses (CORS, HSTS if applicable)
+[EXTEND: security-input]
+
 - Rate-limit public endpoints — never expose unbounded write operations
-- Rotate secrets regularly; invalidate compromised tokens immediately
+- Apply authentication and authorisation before any business logic
+  executes — see `templates/backend/auth.md`
 
 ## Performance
 - Prefer async I/O for network-bound operations


### PR DESCRIPTION
## Summary
- backend-quality.md: add `[DEPENDS ON]` for base-quality and base-security
- backend-quality.md: replace duplicated security rules (input validation, headers, secrets) with `[EXTEND: security-input]`, keep backend-specific rules (rate limiting)
- backend-monitoring.md: add `[DEPENDS ON]` for backend-observability

Closes #219

## Test plan
- [x] `py tests/run_smoke.py` — 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)