### PR TITLE
fix: consolidate duplicated testing rules in backend templates

### DIFF
--- a/templates/backend/caching.md
+++ b/templates/backend/caching.md
@@ -82,10 +82,9 @@ cache technology (Redis, Memcached, in-process).
 ---
 
 ## Testing
+[EXTEND: base-testing]
 
-- Integration tests MUST run against a real cache instance (e.g. Redis
-  in Docker) — do not mock the cache client in integration tests
-- Unit tests for cache key construction and TTL logic may use an in-memory
-  fake or mock
-- Test the fallback path: assert that a cache miss or error still returns
-  correct data from the source
+- Unit tests for cache key construction and TTL logic MAY use an
+  in-memory fake
+- Test the fallback path: assert that a cache miss or error still
+  returns correct data from the source

--- a/templates/backend/database.md
+++ b/templates/backend/database.md
@@ -57,10 +57,11 @@
 - Consider an append-only audit log table as an alternative to soft deletes
 
 ## Testing
+[EXTEND: base-testing]
 
-- Use a real database in integration tests — not an in-memory SQLite
-  substitute unless the production DB is also SQLite
 - Reset state between test runs — truncate tables or wrap each test in a
   transaction rolled back after completion
+- Do not substitute a different database engine in tests (e.g. SQLite
+  instead of PostgreSQL) — behaviour differences cause false passes
 - Never run schema migrations against a production database inside a test
   suite

--- a/templates/backend/jobs.md
+++ b/templates/backend/jobs.md
@@ -72,9 +72,11 @@ Applies regardless of technology (Celery, asynq, Sidekiq, BullMQ, etc.).
 ---
 
 ## Testing
+[EXTEND: base-testing]
 
-- Unit test the service function the job delegates to — not the job handler itself
-- Integration test at least the happy path end-to-end: enqueue → execute →
+- Unit test the service function the job delegates to — not the job
+  handler itself
+- Integration test the happy path end-to-end: enqueue → execute →
   assert side effect
 - Test the retry path: assert that a transient failure triggers a retry
 - Test the DLQ path: assert that a permanent failure ends up in the DLQ

--- a/templates/backend/messaging.md
+++ b/templates/backend/messaging.md
@@ -87,12 +87,11 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ---
 
 ## Testing
+[EXTEND: base-testing]
 
-- Unit-test consumer business logic independently of the broker — pass a
-  constructed message object directly to the handler function
-- Integration tests MUST use a real broker instance (Kafka in Docker, LocalStack
-  for SQS, RabbitMQ in Docker) — do not mock the broker client
-- Test the DLQ path: publish a message designed to fail processing and assert
-  it reaches the DLQ after the expected retry count
-- Test idempotency: publish the same message twice and assert the consumer
-  produces the same result with no unintended side effects
+- Unit-test consumer business logic independently of the broker —
+  pass a constructed message object directly to the handler function
+- Test the DLQ path: publish a message designed to fail processing
+  and assert it reaches the DLQ after the expected retry count
+- Test idempotency: publish the same message twice and assert the
+  consumer produces the same result with no unintended side effects


### PR DESCRIPTION
## Summary
- Add `[EXTEND: base-testing]` to database.md, caching.md, jobs.md, messaging.md
- Remove duplicated "use real dependencies" rule (inherited from testing.md)
- Keep only domain-specific testing guidance in each file

Closes #220

## Test plan
- [x] `py tests/run_smoke.py` — 8 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)