### PR TITLE
feat: expand smoke tests with resolution and prompt checks (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,9 @@ Run `py tests/run_smoke.py` before every PR. It checks:
 - All manifest entries point to existing files
 - All template files have a manifest entry
 - No duplicate IDs across layers
+- All stacks resolve to valid, non-empty file lists
+- All resolved chains include core tier files
+- Prompt builds for all stacks
 
 ## 6. Session protocol
 

--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -82,6 +82,9 @@ reused for a different component within the same area.
 | Number | Component |
 |--------|-----------|
 | `01` | Manifest entries — file paths, IDs, depends_on references |
+| `02` | Resolution — all stacks resolve to valid, non-empty file lists |
+| `03` | Core tier — resolved chains include core tier files |
+| `04` | Prompt assembly — prompt builds for all stacks |
 
 ### STK - Stack
 
@@ -160,6 +163,9 @@ corrected prerequisites where test intent is unchanged.
 | `SAIT-INT-TPL-03-001A` | Integration — composition — OVERRIDE directive — spec 1, version A |
 | `SAIT-INT-TPL-05-001A` | Integration — composition — conflict resolution — spec 1, version A |
 | `SAIT-INT-MNF-01-001A` | Integration — manifest — manifest entries — spec 1, version A |
+| `SAIT-INT-MNF-02-001A` | Integration — manifest — resolution — spec 1, version A |
+| `SAIT-INT-MNF-03-001A` | Integration — manifest — core tier — spec 1, version A |
+| `SAIT-INT-MNF-04-001A` | Integration — manifest — prompt assembly — spec 1, version A |
 | `SAIT-INT-ITV-01-001A` | Integration — interview — required questions — spec 1, version A |
 | `SAIT-INT-ITV-02-001A` | Integration — interview — default sections — spec 1, version A |
 | `SAIT-INT-ITV-03-001A` | Integration — interview — answer precedence — spec 1, version A |

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -17,6 +17,9 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-INT-TPL-03-001A` | INT | P1 | OVERRIDE replaces parent section entirely |
 | `SAIT-INT-TPL-05-001A` | INT | P1 | Conflicting OVERRIDEs on the same ID are flagged or resolved |
 | `SAIT-INT-MNF-01-001A` | INT | P0 | All manifest entries reference valid paths and IDs |
+| `SAIT-INT-MNF-02-001A` | INT | P0 | All stacks resolve to valid, non-empty file lists |
+| `SAIT-INT-MNF-03-001A` | INT | P0 | All resolved chains include core tier files |
+| `SAIT-INT-MNF-04-001A` | INT | P1 | Prompt builds for all stacks |
 | `SAIT-INT-ITV-01-001A` | INT | P0 | All REQUIRED interview questions are asked before output is generated |
 | `SAIT-INT-ITV-02-001A` | INT | P1 | DEFAULTED sections are pre-filled from the selected stack template |
 | `SAIT-INT-ITV-03-001A` | INT | P0 | Interview answers override stack and base template rules in the output |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -29,6 +29,58 @@ try:
 except ImportError:
     HAS_YAML = False
 
+
+# ---------------------------------------------------------------------------
+# Manifest resolution helpers (shared by MNF-02, MNF-03, MNF-04)
+# ---------------------------------------------------------------------------
+
+def _load_manifest():
+    """Load manifest.yaml and return (core_ids, entries, file_to_id)."""
+    manifest_path = os.path.join(ROOT, "templates", "manifest.yaml")
+    with io.open(manifest_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    entries = {}
+    for section in ("base", "platform", "frontend", "backend", "stacks"):
+        for entry in data.get(section, []):
+            entries[entry["id"]] = entry
+
+    file_to_id = {e["file"]: e["id"] for e in entries.values()}
+    return data.get("core", []), entries, file_to_id
+
+
+def _resolve_stack(stack_id, core_ids, entries):
+    """Resolve full dependency chain for a stack.
+
+    Returns (ordered_files, resolved_ids).
+    """
+    resolved = set()
+    files = []
+
+    def add(eid):
+        if eid in resolved:
+            return
+        resolved.add(eid)
+        entry = entries.get(eid)
+        if entry:
+            files.append(entry["file"])
+
+    def resolve(eid):
+        if eid in resolved:
+            return
+        entry = entries.get(eid)
+        if not entry:
+            return
+        for dep in entry.get("depends_on", []):
+            resolve(dep)
+        add(eid)
+
+    for cid in core_ids:
+        add(cid)
+
+    resolve(stack_id)
+    return files, resolved
+
 TEMPLATE_DIRS = [
     os.path.join("templates", "base", "core"),
     os.path.join("templates", "base", "security"),
@@ -302,6 +354,109 @@ def check_tpl_03():
 
 
 # ---------------------------------------------------------------------------
+# MNF-02 — all stacks resolve to valid, non-empty file lists
+# ---------------------------------------------------------------------------
+
+def check_mnf_02():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    core_ids, entries, _ = _load_manifest()
+    failures = []
+
+    stacks = [e for e in entries.values()
+              if e["file"].startswith("templates/stack/")]
+
+    for stack in stacks:
+        sid = stack["id"]
+        files, _ = _resolve_stack(sid, core_ids, entries)
+
+        if not files:
+            failures.append(f"  {sid}: resolution produced empty file list")
+            continue
+
+        for f in files:
+            path = os.path.join(ROOT, f)
+            if not os.path.isfile(path):
+                failures.append(f"  {sid}: resolved file missing: {f}")
+            elif os.path.getsize(path) == 0:
+                failures.append(f"  {sid}: resolved file empty: {f}")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# MNF-03 — all resolved chains include core tier files
+# ---------------------------------------------------------------------------
+
+def check_mnf_03():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    core_ids, entries, _ = _load_manifest()
+    failures = []
+
+    stacks = [e for e in entries.values()
+              if e["file"].startswith("templates/stack/")]
+
+    for stack in stacks:
+        sid = stack["id"]
+        _, resolved_ids = _resolve_stack(sid, core_ids, entries)
+
+        for cid in core_ids:
+            if cid not in resolved_ids:
+                failures.append(
+                    f"  {sid}: core ID '{cid}' missing from "
+                    f"resolved chain"
+                )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# MNF-04 — prompt builds for all stacks
+# ---------------------------------------------------------------------------
+
+def check_mnf_04():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    core_ids, entries, _ = _load_manifest()
+    failures = []
+
+    output_file = "templates/base/core/agents.md"
+    output_path = os.path.join(ROOT, output_file)
+    if not os.path.isfile(output_path):
+        return [f"  output format missing: {output_file}"]
+
+    output_fmt = read(output_path)
+
+    stacks = [e for e in entries.values()
+              if e["file"].startswith("templates/stack/")]
+
+    for stack in stacks:
+        sid = stack["id"]
+        files, _ = _resolve_stack(sid, core_ids, entries)
+
+        try:
+            parts = []
+            for f in files:
+                parts.append(read(os.path.join(ROOT, f)))
+            prompt = "\n\n".join(parts) + "\n\n" + output_fmt
+        except Exception as e:
+            failures.append(f"  {sid}: prompt build failed: {e}")
+            continue
+
+        if len(prompt) < 500:
+            failures.append(
+                f"  {sid}: prompt suspiciously short "
+                f"({len(prompt)} chars)"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # E2E-01 — all cases.py paths resolve to existing files
 # ---------------------------------------------------------------------------
 
@@ -350,6 +505,12 @@ CHECKS = [
      "title": "All EXTEND/OVERRIDE refs point to existing IDs", "fn": check_tpl_04},
     {"id": "MNF-01", "spec": "SAIT-INT-MNF-01-001A",
      "title": "Manifest entries reference valid paths and IDs", "fn": check_mnf_01},
+    {"id": "MNF-02", "spec": "SAIT-INT-MNF-02-001A",
+     "title": "All stacks resolve to valid, non-empty file lists", "fn": check_mnf_02},
+    {"id": "MNF-03", "spec": "SAIT-INT-MNF-03-001A",
+     "title": "All resolved chains include core tier files", "fn": check_mnf_03},
+    {"id": "MNF-04", "spec": "SAIT-INT-MNF-04-001A",
+     "title": "Prompt builds for all stacks", "fn": check_mnf_04},
     {"id": "TPL-01", "spec": "SAIT-INT-TPL-01-001A",
      "title": "DEPENDS ON chain from python-fastapi.md is complete", "fn": check_tpl_01},
     {"id": "TPL-02", "spec": "SAIT-INT-TPL-02-001A",

--- a/tests/specs/SAIT-INT-MNF-02-001A.md
+++ b/tests/specs/SAIT-INT-MNF-02-001A.md
@@ -1,0 +1,63 @@
+---
+id: SAIT-INT-MNF-02-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567820
+title: All stacks resolve to valid, non-empty file lists
+product: sait
+type: int
+area: MANIF
+priority: p0
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-05-06
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [manifest, resolution, dependency-graph]
+---
+
+## Short description
+
+> **Given** the repository is cloned and `manifest.yaml` is present
+> **When** every stack entry in the manifest is resolved via the
+> dependency algorithm (core tier + recursive deps)
+> **Then** every resolved file path exists and is non-empty
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every stack resolves to a non-empty file list; all files exist and are non-empty |
+| FAILED | One or more stacks resolve to an empty list, or a resolved file is missing or empty |
+| SKIPPED | `manifest.yaml` is absent or PyYAML is not installed |
+| BLOCKED | `SAIT-INT-MNF-01-001A` is failing |
+| ERROR | YAML parser fails; file system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Python 3 with PyYAML installed
+
+### Execution
+
+1. Load `manifest.yaml` and build the entry lookup
+2. For each stack entry, resolve the full dependency chain:
+   a. Add all core tier IDs
+   b. Recursively resolve the stack's `depends_on` tree
+3. For each resolved file, verify it exists and is non-empty
+
+### Assertions
+
+1. Assert every stack produces a non-empty file list
+2. Assert every resolved file path exists on disk
+3. Assert every resolved file has size > 0
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-MNF-01-001A`, `SAIT-INT-MNF-03-001A`
+- Implements: SPEC.md §Inheritance model, manifest.yaml

--- a/tests/specs/SAIT-INT-MNF-03-001A.md
+++ b/tests/specs/SAIT-INT-MNF-03-001A.md
@@ -1,0 +1,59 @@
+---
+id: SAIT-INT-MNF-03-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567821
+title: All resolved chains include core tier files
+product: sait
+type: int
+area: MANIF
+priority: p0
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-05-06
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [manifest, resolution, core-tier]
+---
+
+## Short description
+
+> **Given** the repository is cloned and `manifest.yaml` is present
+> **When** every stack entry is resolved via the dependency algorithm
+> **Then** every core tier ID appears in the resolved set
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every stack's resolved chain includes all core tier IDs |
+| FAILED | One or more core IDs are missing from a stack's resolved chain |
+| SKIPPED | `manifest.yaml` is absent or PyYAML is not installed |
+| BLOCKED | `SAIT-INT-MNF-02-001A` is failing |
+| ERROR | YAML parser fails; file system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Python 3 with PyYAML installed
+
+### Execution
+
+1. Load `manifest.yaml` and extract the `core:` list
+2. For each stack, resolve the full dependency chain
+3. Verify every core ID appears in the resolved set
+
+### Assertions
+
+1. Assert every core ID from `manifest.yaml` is present in
+   every stack's resolved chain
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-MNF-02-001A`, `SAIT-INT-MNF-04-001A`
+- Implements: SPEC.md §Core tier

--- a/tests/specs/SAIT-INT-MNF-04-001A.md
+++ b/tests/specs/SAIT-INT-MNF-04-001A.md
@@ -1,0 +1,62 @@
+---
+id: SAIT-INT-MNF-04-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567822
+title: Prompt builds for all stacks
+product: sait
+type: int
+area: MANIF
+priority: p1
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-05-06
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [manifest, resolution, prompt-assembly]
+---
+
+## Short description
+
+> **Given** the repository is cloned and `manifest.yaml` is present
+> **When** every stack's resolved file chain is read and concatenated
+> with the output format template
+> **Then** the assembled prompt is non-empty and above a minimum
+> character threshold
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every stack produces a prompt above 500 characters |
+| FAILED | One or more stacks produce a prompt below 500 characters or a file read fails |
+| SKIPPED | `manifest.yaml` is absent or PyYAML is not installed |
+| BLOCKED | `SAIT-INT-MNF-02-001A` is failing |
+| ERROR | YAML parser fails; file system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Python 3 with PyYAML installed
+
+### Execution
+
+1. Load `manifest.yaml` and resolve deps for each stack
+2. Read every resolved file and the output format template
+3. Concatenate into a prompt string
+4. Verify the prompt length exceeds 500 characters
+
+### Assertions
+
+1. Assert no file read raises an exception
+2. Assert every assembled prompt is at least 500 characters
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-MNF-02-001A`, `SAIT-INT-MNF-03-001A`
+- Implements: ADR-007 §E2e tests validate templates, not generation


### PR DESCRIPTION
## Summary

- Add 3 new smoke checks: MNF-02 (resolution), MNF-03 (core tier), MNF-04 (prompt build)
- All stacks in manifest are validated — not just those with e2e test cases
- Add spec files, update CODIFICATION.md, INDEX.md, CLAUDE.md
- Smoke suite: 8 → 11 checks

Closes #239

## Test plan

- [x] All 11 smoke tests pass
- [ ] Verify new checks catch issues (e.g. remove a core ID from manifest temporarily)

Generated with [Claude Code](https://claude.com/claude-code)