### PR TITLE
feat: reduce live e2e to canary test by default (#240)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,8 @@ Four files in `tests/`:
 py tests/run_smoke.py              # structural checks
 py tests/run_smoke.py SYS-01       # run one check by ID
 
-py tests/run_e2e.py                # agent-based tests (live, needs API key)
+py tests/run_e2e.py                # canary only (python-lib, needs API key)
+py tests/run_e2e.py --all          # all tests (live, needs API key)
 py tests/run_e2e.py --offline      # validate test infrastructure without API
 py tests/run_e2e.py --area=STK     # run all stack tests
 py tests/run_e2e.py STK-01 FMT-01  # run specific tests by ID

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -340,6 +340,7 @@ STK_TESTS = [
     {
         "id": "STK-15",
         "spec": "SAIT-E2E-STK-15-001A",
+        "canary": True,  # smallest chain (~12K tokens) — default live test
         "stack": "templates/stack/python-lib.md",
         "answers": {
             "Project name": "validify",
@@ -628,3 +629,4 @@ DPL_TESTS = [
 # -------------------------------------------------------------------------
 
 ALL_TESTS = STK_TESTS + FMT_TESTS + ITV_TESTS + DPL_TESTS
+CANARY_TESTS = [t for t in ALL_TESTS if t.get("canary")]

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -91,7 +91,7 @@ def write_report(run_results, started_at, runner_name, columns):
 
 
 def parse_args(argv):
-    """Parse common CLI args: filter IDs, --fail-fast, --area, --offline, --dry-run."""
+    """Parse common CLI args: filter IDs, --fail-fast, --area, --offline, --dry-run, --all."""
     flags = set()
     area = None
     filter_ids = []
@@ -103,6 +103,8 @@ def parse_args(argv):
             flags.add("offline")
         elif arg == "--dry-run":
             flags.add("dry-run")
+        elif arg == "--all":
+            flags.add("all")
         elif arg.startswith("--area="):
             area = arg.split("=", 1)[1].upper()
         elif arg.startswith("--"):

--- a/tests/run_e2e.py
+++ b/tests/run_e2e.py
@@ -9,13 +9,18 @@ Provider is selected via E2E_PROVIDER env var (default: gemini).
 See tests/providers.py for available backends.
 
 Usage:
-  py tests/run_e2e.py                    # run all non-skipped tests
+  py tests/run_e2e.py                    # run canary test only (python-lib)
+  py tests/run_e2e.py --all              # run all non-skipped tests
   py tests/run_e2e.py STK-01             # run one test by short ID
   py tests/run_e2e.py STK-01 FMT-01      # run multiple
   py tests/run_e2e.py --area=STK          # run all stack tests
   py tests/run_e2e.py --dry-run          # print prompt, skip LLM call
   py tests/run_e2e.py --offline          # validate test infrastructure without API
   py tests/run_e2e.py --fail-fast        # stop on first failure
+
+Default (no args) runs only the canary test (STK-15, python-lib) to keep
+live runs fast and token-efficient. Use --all, --area, or explicit IDs
+to run more tests.
 
 Offline mode validates:
   - All referenced template files exist and are non-empty
@@ -30,7 +35,7 @@ import sys
 import time
 
 from lib import ROOT, PASS, FAIL, SKIP, ERR, read, parse_args, load_dotenv
-from cases import ALL_TESTS
+from cases import ALL_TESTS, CANARY_TESTS
 
 load_dotenv()
 
@@ -337,8 +342,8 @@ def main():
     dry_run = "dry-run" in flags
     offline = "offline" in flags
     fail_fast = "fail-fast" in flags
+    run_all = "all" in flags
 
-    tests = ALL_TESTS
     if filter_ids:
         tests = [t for t in ALL_TESTS if t["id"] in filter_ids]
         if not tests:
@@ -349,6 +354,10 @@ def main():
         if not tests:
             print(f"No tests matched area: {area}")
             sys.exit(1)
+    elif run_all or offline:
+        tests = ALL_TESTS
+    else:
+        tests = CANARY_TESTS
 
     results = {PASS: 0, FAIL: 0, SKIP: 0, ERR: 0}
     run_results = []


### PR DESCRIPTION
## Summary

- Default `py tests/run_e2e.py` runs only STK-15 (python-lib canary)
- `--all` flag runs the full suite; `--offline` still runs all 27 tests
- `--area=STK` and explicit IDs work as before
- CLAUDE.md commands updated

Closes #240

## Test plan

- [x] Smoke tests pass (8/8)
- [x] `--offline` runs all 27 tests (27 passed)
- [x] Default `--dry-run` runs only 1 test (STK-15)
- [ ] Live canary run passes with API key

Generated with [Claude Code](https://claude.com/claude-code)