### PR TITLE
docs: add resolve.py and generated/ to ONBOARDING and PLAYBOOK

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -36,6 +36,7 @@ cd solid-ai-templates
 ```
 
 No build step, no dependencies to install. All templates are plain Markdown.
+Install PyYAML for the smoke tests: `pip install pyyaml`
 
 ## Understand the structure
 
@@ -44,6 +45,8 @@ No build step, no dependencies to install. All templates are plain Markdown.
 | `docs/SPEC.md` | The full composition model — inheritance, OVERRIDE, EXTEND, IDs |
 | `CLAUDE.md` | Rules for contributing to this repo |
 | `templates/manifest.yaml` | Machine-readable dependency graph |
+| `tools/resolve.py` | Dependency resolver — resolves a stack's full template chain |
+| `generated/` | Pre-resolved template chains — one file per stack |
 | `examples/` | Complete generated CLAUDE.md files — the target output |
 
 ## How templates relate
@@ -62,6 +65,14 @@ templates/stack/python-service.md
     ↓
 templates/stack/python-flask.md
 ```
+
+To see the full resolved chain for any stack, run:
+```bash
+py tools/resolve.py stack-flask          # print file list
+py tools/resolve.py stack-flask --concat # print concatenated content
+```
+
+Or read the pre-resolved file directly: `generated/stack-flask.md`
 
 ## Validate your understanding
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -90,6 +90,15 @@ composition model.
    ```
 4. Place the generated file at the project root
 
+### Pre-resolved path (no shell access)
+
+If the agent cannot run scripts, use the pre-resolved files in
+`generated/`. Each file contains the full template chain for one stack:
+
+1. Attach `generated/stack-flask.md` (or the relevant stack)
+2. Attach `templates/base/core/agents.md` (output format)
+3. Provide your answers and ask the agent to generate the file
+
 ---
 
 ## Validate a template change
@@ -113,8 +122,9 @@ composition model.
 ## Run the test suite
 
 ```bash
-py tests/run_smoke.py              # 7 structural checks — seconds
-py tests/run_e2e.py                # 30 agent tests — ~1-2 hours
+py tests/run_smoke.py              # 11 structural checks — seconds
+py tests/run_e2e.py                # canary test (python-lib)
+py tests/run_e2e.py --all          # all agent tests
 py tests/run_e2e.py STK-01 FMT-01  # specific tests only
 py tests/run_e2e.py --dry-run      # build prompts, skip agent calls
 ```
@@ -122,6 +132,22 @@ py tests/run_e2e.py --dry-run      # build prompts, skip agent calls
 See `tests/CODIFICATION.md` for the ID scheme and `tests/INDEX.md` for the
 full list of specs. Requires `py -m pip install pyyaml` for the manifest
 check.
+
+---
+
+## Regenerate pre-resolved files
+
+After editing any template or `manifest.yaml`, regenerate the cached
+files in `generated/`:
+
+```bash
+py tools/resolve.py --generate     # regenerate all 30 files
+py tools/resolve.py --check        # verify they are up to date
+py tools/sync.py                   # also regenerates via --check
+```
+
+The `generated/` files are committed to the repo so agents without
+shell access can use them directly.
 
 ---
 


### PR DESCRIPTION
## Summary

- ONBOARDING: add tools/resolve.py and generated/ to structure table, resolution example
- PLAYBOOK: add pre-resolved path, regenerate procedure, update test commands

## Test plan

- [x] Smoke tests pass (11/11)

Generated with [Claude Code](https://claude.com/claude-code)