### PR TITLE
chore: add .editorconfig for consistent formatting (#184)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Adds root `.editorconfig` with settings for Markdown (2-space indent), Python (4-space indent), YAML (2-space indent), and Makefile (tab indent)
- Enforces LF line endings, UTF-8 charset, trim trailing whitespace, and final newline for all files

Closes #184

## Test plan
- [ ] Smoke tests pass
- [ ] Verify editor picks up settings (open a `.md` and `.py` file, check indent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)