### PR TITLE
chore: add pre-commit hooks (#185)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -38,6 +38,12 @@ cd solid-ai-templates
 No build step, no dependencies to install. All templates are plain Markdown.
 Install PyYAML for the smoke tests: `pip install pyyaml`
 
+Set up pre-commit hooks for local validation:
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ## Understand the structure
 
 | File / folder | Read this to understand |


### PR DESCRIPTION
## Summary
- Adds `.pre-commit-config.yaml` with trailing-whitespace, end-of-file-fixer, check-yaml, and gitleaks hooks
- Gitleaks pinned to v8.21.2 (matches CI)
- Updates ONBOARDING.md with `pre-commit install` setup step

Closes #185

## Test plan
- [ ] Smoke tests pass
- [ ] `pre-commit install && pre-commit run --all-files` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)