### PR TITLE
chore: enable Dependabot security updates (#186)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for automated dependency update PRs
- Covers github-actions and pip ecosystems, weekly schedule

Closes #186

## Test plan
- [ ] Smoke tests pass
- [ ] Dependabot tab appears in repo Settings > Code security after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)