### PR TITLE
feat: add eslint-plugin-sonarjs to stack quality gates (#130)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1187,8 +1201,9 @@ files into `src/content/`.
 
 ## Code conventions
 
-- **ESLint** with `@typescript-eslint/recommended` for any `.ts` / `.tsx`
-  files — configured in `eslint.config.js`, run on save
+- **ESLint** with `@typescript-eslint/recommended` and
+  `eslint-plugin-sonarjs` for any `.ts` / `.tsx` files —
+  configured in `eslint.config.js`, run on save
 - **Prettier** owns all formatting — commit `.prettierrc`; no style debates
   in code review
 - `.astro` files formatted with the official Prettier Astro plugin

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -2123,6 +2137,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1510,6 +1524,30 @@ every project regardless of language or framework.
 - Scan uploaded files for malware if the application serves them
   to other users
 
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
 
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization
@@ -2021,7 +2059,7 @@ these conventions fill the gap.
 - Validation: [Zod / joi / express-validator]
 - ORM / query builder: [Prisma / Drizzle / Knex / pg]
 - Package manager: [npm / pnpm]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Vitest + Supertest
 - Production server: Node.js process managed by PM2 or Docker

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1116,6 +1130,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -2120,6 +2134,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1233,6 +1247,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1233,6 +1247,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1510,6 +1524,30 @@ every project regardless of language or framework.
 - Scan uploaded files for malware if the application serves them
   to other users
 
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
 
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization
@@ -2022,7 +2060,7 @@ and testing.
 - Validation: class-validator + class-transformer
 - ORM: [TypeORM / Prisma / MikroORM]
 - Package manager: [npm / pnpm]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Jest + Supertest
 - ASGI server (production): Node.js process managed by PM2 or Docker

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1087,8 +1101,9 @@ CLAUDE.md
 [ID: react-spa-typescript]
 
 - Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) — enforced by ESLint; do not suppress
-  lint errors without a documented reason
+  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
+  enforced by ESLint; do not suppress lint errors without a
+  documented reason
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
 - `strict: true` in `tsconfig.json` — no exceptions
@@ -1721,6 +1736,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -852,7 +866,7 @@ versioning, and testing.
 - Runtime: Node.js 20+ (LTS)
 - Package manager: [npm / pnpm]
 - Build tool: [tsup / tsc / esbuild]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Vitest
 - Distribution: [npm (public) / npm (private) / GitHub Packages]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1087,8 +1101,9 @@ CLAUDE.md
 [ID: react-spa-typescript]
 
 - Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) — enforced by ESLint; do not suppress
-  lint errors without a documented reason
+  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
+  enforced by ESLint; do not suppress lint errors without a
+  documented reason
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
 - `strict: true` in `tsconfig.json` — no exceptions
@@ -1514,6 +1529,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1087,8 +1101,9 @@ CLAUDE.md
 [ID: react-spa-typescript]
 
 - Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) — enforced by ESLint; do not suppress
-  lint errors without a documented reason
+  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
+  enforced by ESLint; do not suppress lint errors without a
+  documented reason
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
 - `strict: true` in `tsconfig.json` — no exceptions

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1467,6 +1481,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1715,6 +1729,30 @@ every project regardless of language or framework.
   (path traversal risk)
 - Scan uploaded files for malware if the application serves them
   to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
@@ -1187,8 +1201,9 @@ files into `src/content/`.
 
 ## Code conventions
 
-- **ESLint** with `@typescript-eslint/recommended` for any `.ts` / `.tsx`
-  files — configured in `eslint.config.js`, run on save
+- **ESLint** with `@typescript-eslint/recommended` and
+  `eslint-plugin-sonarjs` for any `.ts` / `.tsx` files —
+  configured in `eslint.config.js`, run on save
 - **Prettier** owns all formatting — commit `.prettierrc`; no style debates
   in code review
 - `.astro` files formatted with the official Prettier Astro plugin

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -116,8 +116,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -115,8 +115,22 @@ Apply SOLID at the class, module, and service level:
   read the implementation to understand what a call site does, the function
   needs a better name or needs to be split
 - Cognitive complexity ≤ 15 per function — enforced by static analysis
-  (SonarQube, Codacy, or equivalent); each nesting level and decision point
-  increases the score
+  (SonarQube, Codacy, or `eslint-plugin-sonarjs` for ESLint); each
+  nesting level and decision point increases the score
+
+### eslint-plugin-sonarjs rules (if applicable)
+
+| sonarjs rule | Enforces |
+|---|---|
+| `cognitive-complexity` | Cognitive complexity ≤ 15 per function |
+| `no-nested-conditional` | Maximum nesting depth |
+| `no-duplicated-branches` | DRY — identical branches in if/switch |
+| `no-identical-expressions` | DRY — same expression on both sides of operator |
+| `no-identical-functions` | DRY — duplicated function bodies |
+| `no-collapsible-if` | KISS — collapse nested ifs |
+| `no-redundant-jump` | No dead code — unnecessary return/continue/break |
+| `no-unused-collection` | No dead code — collection populated but never read |
+| `no-inverted-boolean-check` | Readability — avoid negative conditions |
 - Maximum nesting depth of three levels — use early returns and guard clauses
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation

--- a/templates/stack/node-express.md
+++ b/templates/stack/node-express.md
@@ -16,7 +16,7 @@ these conventions fill the gap.
 - Validation: [Zod / joi / express-validator]
 - ORM / query builder: [Prisma / Drizzle / Knex / pg]
 - Package manager: [npm / pnpm]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Vitest + Supertest
 - Production server: Node.js process managed by PM2 or Docker

--- a/templates/stack/node-nestjs.md
+++ b/templates/stack/node-nestjs.md
@@ -17,7 +17,7 @@ and testing.
 - Validation: class-validator + class-transformer
 - ORM: [TypeORM / Prisma / MikroORM]
 - Package manager: [npm / pnpm]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Jest + Supertest
 - ASGI server (production): Node.js process managed by PM2 or Docker

--- a/templates/stack/nodejs-lib.md
+++ b/templates/stack/nodejs-lib.md
@@ -15,7 +15,7 @@ versioning, and testing.
 - Runtime: Node.js 20+ (LTS)
 - Package manager: [npm / pnpm]
 - Build tool: [tsup / tsc / esbuild]
-- Linter: ESLint (`@typescript-eslint/recommended`)
+- Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Vitest
 - Distribution: [npm (public) / npm (private) / GitHub Packages]

--- a/templates/stack/spa-react.md
+++ b/templates/stack/spa-react.md
@@ -54,8 +54,9 @@ CLAUDE.md
 [ID: react-spa-typescript]
 
 - Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) — enforced by ESLint; do not suppress
-  lint errors without a documented reason
+  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
+  enforced by ESLint; do not suppress lint errors without a
+  documented reason
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
 - `strict: true` in `tsconfig.json` — no exceptions

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -201,8 +201,9 @@ files into `src/content/`.
 
 ## Code conventions
 
-- **ESLint** with `@typescript-eslint/recommended` for any `.ts` / `.tsx`
-  files — configured in `eslint.config.js`, run on save
+- **ESLint** with `@typescript-eslint/recommended` and
+  `eslint-plugin-sonarjs` for any `.ts` / `.tsx` files —
+  configured in `eslint.config.js`, run on save
 - **Prettier** owns all formatting — commit `.prettierrc`; no style debates
   in code review
 - `.astro` files formatted with the official Prettier Astro plugin


### PR DESCRIPTION
## Summary
- Updates `base/quality.md` to mention `eslint-plugin-sonarjs` as the ESLint-based option for cognitive complexity enforcement
- Adds sonarjs rule mapping table to `base/quality.md`
- Adds `eslint-plugin-sonarjs` to ESLint references in node-express, node-nestjs, nodejs-lib, spa-react, and static-site-astro stacks
- Regenerates all 30 pre-resolved files

Closes #130

## Test plan
- [ ] Smoke tests pass
- [ ] Verify `eslint-plugin-sonarjs` appears in resolved output for affected stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)