### PR TITLE
fix: add base-security and base-containers to backend-quality deps (#268)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1181,10 +1181,324 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 - Test idempotency: publish the same message twice and assert the
   consumer produces the same result with no unintended side effects
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1153,10 +1153,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1897,270 +2211,6 @@ Sunset: <HTTP-date>
 - Collection endpoints MUST be paginated — never return unbounded lists
 - Use `limit` and `offset` (or cursor-based) pagination
 - Include navigation links (`next`, `prev`) in the response per HATEOAS
-
-
-<!-- templates/base/security/security.md -->
-# Base — Application Security
-
-[ID: base-security]
-
-Cross-cutting security rules for application code. Applies to
-every project regardless of language or framework.
-
-
----
-
-## Input validation
-
-[ID: security-input]
-
-- Validate all external input at the system boundary — the first
-  point where untrusted data enters the application
-- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
-  — never hand-write validation for complex inputs
-- Allowlist, not blocklist — define what is valid, reject everything
-  else
-- Reject invalid input with a clear error — do not silently coerce
-  or strip fields
-- Internal code trusts validated data — do not re-validate in
-  service or repository layers
-
----
-
-## Output encoding
-
-[ID: security-output]
-
-- Encode dynamic data for its rendering context at the point of
-  output — HTML, URL, JavaScript, SQL, shell
-- Encode on output, not on input — store the raw value, encode
-  when rendering
-- Use framework-provided encoding: React JSX, Jinja2 autoescape,
-  Go `html/template`, Astro `{expression}`
-- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
-  or `| safe` with user-supplied data
-- Context matters — HTML encoding does not prevent URL injection
-
----
-
-## Injection prevention
-
-[ID: security-injection]
-
-- Use parameterized queries for all database access — never
-  concatenate user input into SQL strings
-- Use prepared statements or ORM query builders — raw SQL with
-  string interpolation is a SQL injection vulnerability
-- Escape shell arguments when invoking external commands — or
-  use API alternatives that do not invoke a shell
-- Never pass user input to `eval()`, `exec()`, `Function()`,
-  or equivalent dynamic code execution
-
----
-
-## Authentication
-
-[ID: security-authn]
-
-- Hash passwords with a modern algorithm: bcrypt, scrypt, or
-  Argon2 — never MD5, SHA-1, or plain SHA-256
-- Enforce minimum password complexity at the boundary
-- Use constant-time comparison for secrets and tokens — timing
-  attacks leak information through response time
-- Support multi-factor authentication for privileged operations
-- Lock accounts or throttle after repeated failed attempts
-
----
-
-## Session management
-
-[ID: security-sessions]
-
-- Generate session IDs with a cryptographic random generator
-- Regenerate the session ID after login — prevents session fixation
-- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
-  `Strict` for sensitive applications)
-- Expire sessions after a reasonable idle period — 30 minutes
-  for sensitive applications, configurable otherwise
-- Invalidate sessions on logout — do not rely on cookie expiry
-  alone
-
----
-
-## Secrets in code
-
-[ID: security-secrets]
-
-- Never hardcode secrets, API keys, tokens, or credentials in
-  source files
-- Never commit secrets to version control — even in test files
-  or example configurations
-- Use `.env` files for local development — add to `.gitignore`
-- Provide `.env.example` with placeholder values — never real
-  secrets
-- If a secret is accidentally committed, rotate it immediately —
-  removing from git history is not sufficient; the secret is
-  compromised
-
----
-
-## Transport security
-
-[ID: security-transport]
-
-- HTTPS everywhere — no exceptions for production traffic
-- HSTS MUST be enabled on all production sites with
-  `includeSubDomains` and a minimum `max-age` of one year
-- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
-- Use strong cipher suites — disable known-weak ciphers
-- Internal service-to-service traffic SHOULD use mTLS via a
-  service mesh or explicit certificate configuration
-
----
-
-## Security headers
-
-[ID: security-headers]
-
-- Set security headers on every HTTP response at the reverse proxy
-  or middleware level — not per route
-- Required headers:
-  - `Content-Security-Policy` — start strict, relax only as needed
-  - `X-Content-Type-Options: nosniff`
-  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
-  - `Strict-Transport-Security` (see Transport security)
-  - `Referrer-Policy: strict-origin-when-cross-origin`
-  - `Permissions-Policy` — disable unused browser APIs
-- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
-  written justification
-- Do not expose server version or technology stack in headers —
-  remove `X-Powered-By`, `Server` version strings
-
----
-
-## Error handling
-
-[ID: security-errors]
-
-- Never expose stack traces, internal paths, or database errors
-  to end users — return generic error messages externally
-- Log full error details server-side for debugging
-- Use consistent error response formats — do not leak internal
-  structure through varying error shapes
-- Return appropriate HTTP status codes — do not use 200 for errors
-- Do not reveal whether a resource exists via error messages —
-  login errors should say "invalid credentials", not "user not
-  found" vs "wrong password"
-
----
-
-## Logging
-
-[ID: security-logging]
-
-- Never log secrets, tokens, passwords, or personally identifiable
-  information (PII)
-- Sanitize log output — user-supplied data in logs can enable
-  log injection attacks
-- Log security-relevant events: authentication attempts, access
-  denials, privilege changes, configuration changes
-- Include enough context for investigation: timestamp, user ID,
-  IP, action, result
-- Retain security logs for a defined period — compliance may
-  require 90 days to 7 years
-
----
-
-## CORS
-
-[ID: security-cors]
-
-- Restrict `Access-Control-Allow-Origin` to specific known
-  origins — never use `*` for authenticated endpoints
-- Do not reflect the `Origin` header back as
-  `Access-Control-Allow-Origin` without validation
-- Restrict allowed methods and headers to what the API actually
-  needs
-- Set `Access-Control-Max-Age` to cache preflight responses —
-  reduces latency and server load
-
----
-
-## Deserialization and data integrity
-
-[ID: security-integrity]
-
-- Never deserialize untrusted data with native serialization
-  formats (Python `pickle`, Java `ObjectInputStream`, PHP
-  `unserialize`) — use safe formats (JSON, Protocol Buffers)
-- Validate the structure and types of deserialized data before
-  use — treat it as untrusted input
-- Verify integrity of downloaded artifacts, updates, and
-  dependencies — use checksums or digital signatures
-- Pin dependency versions and verify checksums in lockfiles —
-  do not trust upstream registries blindly
-- CI/CD pipelines MUST use pinned, verified actions and images —
-  never pull `latest` tags in production pipelines
-
----
-
-## Server-Side Request Forgery (SSRF)
-
-[ID: security-ssrf]
-
-- Never pass user-supplied URLs directly to server-side HTTP
-  clients — validate and sanitize first
-- Allowlist permitted destination hosts and schemes — reject
-  anything not on the list
-- Block requests to internal networks (`127.0.0.0/8`,
-  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
-  `::1`, `fc00::/7`) — even after DNS resolution
-- Resolve the hostname and validate the IP before making the
-  request — prevents DNS rebinding attacks
-- Disable HTTP redirects in server-side HTTP clients, or
-  re-validate the destination after each redirect
-- Limit response size and timeout for outbound requests to
-  prevent resource exhaustion
-
----
-
-## File uploads
-
-[ID: security-uploads]
-
-- Validate file type by content (magic bytes), not by extension
-  or MIME type — both are trivially spoofed
-- Enforce maximum file size at the boundary
-- Store uploads outside the web root — never serve user uploads
-  from the same domain without sanitization
-- Generate random filenames — do not use the original filename
-  (path traversal risk)
-- Scan uploaded files for malware if the application serves them
-  to other users
-
----
-
-## Agent secrets handling
-
-[ID: security-agent-secrets]
-
-- MUST NOT read, print, or cat files that may contain secrets:
-  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
-  `serviceaccount.json`, `secrets.yaml`
-- MUST NOT echo, log, or display environment variable values —
-  use `printenv | grep -c KEY` to check presence without
-  revealing the value
-- MUST NOT include secret values in commit messages, PR
-  descriptions, or conversation output
-- MUST warn the user before committing files that commonly
-  contain secrets (`.env`, `credentials.json`, private keys)
-- Use targeted commands to verify secret presence without
-  exposure: `grep -c PATTERN file` (count matches),
-  `test -f .env && echo exists` (check file existence)
-- If secrets are accidentally exposed in a session, immediately
-  flag to the user: name the exposed secret, recommend
-  immediate rotation, and note that session history may be
-  cached or logged
 
 
 <!-- templates/backend/auth.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1639,10 +1639,60 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1153,10 +1153,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1153,10 +1153,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1266,10 +1266,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1266,10 +1266,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1266,10 +1266,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1895,270 +2209,6 @@ goimports -w .            # format imports
 make migrate-up           # apply DB migrations
 docker build -t [name] .  # build container image
 ```
-
-<!-- templates/base/security/security.md -->
-# Base — Application Security
-
-[ID: base-security]
-
-Cross-cutting security rules for application code. Applies to
-every project regardless of language or framework.
-
-
----
-
-## Input validation
-
-[ID: security-input]
-
-- Validate all external input at the system boundary — the first
-  point where untrusted data enters the application
-- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
-  — never hand-write validation for complex inputs
-- Allowlist, not blocklist — define what is valid, reject everything
-  else
-- Reject invalid input with a clear error — do not silently coerce
-  or strip fields
-- Internal code trusts validated data — do not re-validate in
-  service or repository layers
-
----
-
-## Output encoding
-
-[ID: security-output]
-
-- Encode dynamic data for its rendering context at the point of
-  output — HTML, URL, JavaScript, SQL, shell
-- Encode on output, not on input — store the raw value, encode
-  when rendering
-- Use framework-provided encoding: React JSX, Jinja2 autoescape,
-  Go `html/template`, Astro `{expression}`
-- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
-  or `| safe` with user-supplied data
-- Context matters — HTML encoding does not prevent URL injection
-
----
-
-## Injection prevention
-
-[ID: security-injection]
-
-- Use parameterized queries for all database access — never
-  concatenate user input into SQL strings
-- Use prepared statements or ORM query builders — raw SQL with
-  string interpolation is a SQL injection vulnerability
-- Escape shell arguments when invoking external commands — or
-  use API alternatives that do not invoke a shell
-- Never pass user input to `eval()`, `exec()`, `Function()`,
-  or equivalent dynamic code execution
-
----
-
-## Authentication
-
-[ID: security-authn]
-
-- Hash passwords with a modern algorithm: bcrypt, scrypt, or
-  Argon2 — never MD5, SHA-1, or plain SHA-256
-- Enforce minimum password complexity at the boundary
-- Use constant-time comparison for secrets and tokens — timing
-  attacks leak information through response time
-- Support multi-factor authentication for privileged operations
-- Lock accounts or throttle after repeated failed attempts
-
----
-
-## Session management
-
-[ID: security-sessions]
-
-- Generate session IDs with a cryptographic random generator
-- Regenerate the session ID after login — prevents session fixation
-- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
-  `Strict` for sensitive applications)
-- Expire sessions after a reasonable idle period — 30 minutes
-  for sensitive applications, configurable otherwise
-- Invalidate sessions on logout — do not rely on cookie expiry
-  alone
-
----
-
-## Secrets in code
-
-[ID: security-secrets]
-
-- Never hardcode secrets, API keys, tokens, or credentials in
-  source files
-- Never commit secrets to version control — even in test files
-  or example configurations
-- Use `.env` files for local development — add to `.gitignore`
-- Provide `.env.example` with placeholder values — never real
-  secrets
-- If a secret is accidentally committed, rotate it immediately —
-  removing from git history is not sufficient; the secret is
-  compromised
-
----
-
-## Transport security
-
-[ID: security-transport]
-
-- HTTPS everywhere — no exceptions for production traffic
-- HSTS MUST be enabled on all production sites with
-  `includeSubDomains` and a minimum `max-age` of one year
-- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
-- Use strong cipher suites — disable known-weak ciphers
-- Internal service-to-service traffic SHOULD use mTLS via a
-  service mesh or explicit certificate configuration
-
----
-
-## Security headers
-
-[ID: security-headers]
-
-- Set security headers on every HTTP response at the reverse proxy
-  or middleware level — not per route
-- Required headers:
-  - `Content-Security-Policy` — start strict, relax only as needed
-  - `X-Content-Type-Options: nosniff`
-  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
-  - `Strict-Transport-Security` (see Transport security)
-  - `Referrer-Policy: strict-origin-when-cross-origin`
-  - `Permissions-Policy` — disable unused browser APIs
-- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
-  written justification
-- Do not expose server version or technology stack in headers —
-  remove `X-Powered-By`, `Server` version strings
-
----
-
-## Error handling
-
-[ID: security-errors]
-
-- Never expose stack traces, internal paths, or database errors
-  to end users — return generic error messages externally
-- Log full error details server-side for debugging
-- Use consistent error response formats — do not leak internal
-  structure through varying error shapes
-- Return appropriate HTTP status codes — do not use 200 for errors
-- Do not reveal whether a resource exists via error messages —
-  login errors should say "invalid credentials", not "user not
-  found" vs "wrong password"
-
----
-
-## Logging
-
-[ID: security-logging]
-
-- Never log secrets, tokens, passwords, or personally identifiable
-  information (PII)
-- Sanitize log output — user-supplied data in logs can enable
-  log injection attacks
-- Log security-relevant events: authentication attempts, access
-  denials, privilege changes, configuration changes
-- Include enough context for investigation: timestamp, user ID,
-  IP, action, result
-- Retain security logs for a defined period — compliance may
-  require 90 days to 7 years
-
----
-
-## CORS
-
-[ID: security-cors]
-
-- Restrict `Access-Control-Allow-Origin` to specific known
-  origins — never use `*` for authenticated endpoints
-- Do not reflect the `Origin` header back as
-  `Access-Control-Allow-Origin` without validation
-- Restrict allowed methods and headers to what the API actually
-  needs
-- Set `Access-Control-Max-Age` to cache preflight responses —
-  reduces latency and server load
-
----
-
-## Deserialization and data integrity
-
-[ID: security-integrity]
-
-- Never deserialize untrusted data with native serialization
-  formats (Python `pickle`, Java `ObjectInputStream`, PHP
-  `unserialize`) — use safe formats (JSON, Protocol Buffers)
-- Validate the structure and types of deserialized data before
-  use — treat it as untrusted input
-- Verify integrity of downloaded artifacts, updates, and
-  dependencies — use checksums or digital signatures
-- Pin dependency versions and verify checksums in lockfiles —
-  do not trust upstream registries blindly
-- CI/CD pipelines MUST use pinned, verified actions and images —
-  never pull `latest` tags in production pipelines
-
----
-
-## Server-Side Request Forgery (SSRF)
-
-[ID: security-ssrf]
-
-- Never pass user-supplied URLs directly to server-side HTTP
-  clients — validate and sanitize first
-- Allowlist permitted destination hosts and schemes — reject
-  anything not on the list
-- Block requests to internal networks (`127.0.0.0/8`,
-  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
-  `::1`, `fc00::/7`) — even after DNS resolution
-- Resolve the hostname and validate the IP before making the
-  request — prevents DNS rebinding attacks
-- Disable HTTP redirects in server-side HTTP clients, or
-  re-validate the destination after each redirect
-- Limit response size and timeout for outbound requests to
-  prevent resource exhaustion
-
----
-
-## File uploads
-
-[ID: security-uploads]
-
-- Validate file type by content (magic bytes), not by extension
-  or MIME type — both are trivially spoofed
-- Enforce maximum file size at the boundary
-- Store uploads outside the web root — never serve user uploads
-  from the same domain without sanitization
-- Generate random filenames — do not use the original filename
-  (path traversal risk)
-- Scan uploaded files for malware if the application serves them
-  to other users
-
----
-
-## Agent secrets handling
-
-[ID: security-agent-secrets]
-
-- MUST NOT read, print, or cat files that may contain secrets:
-  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
-  `serviceaccount.json`, `secrets.yaml`
-- MUST NOT echo, log, or display environment variable values —
-  use `printenv | grep -c KEY` to check presence without
-  revealing the value
-- MUST NOT include secret values in commit messages, PR
-  descriptions, or conversation output
-- MUST warn the user before committing files that commonly
-  contain secrets (`.env`, `credentials.json`, private keys)
-- Use targeted commands to verify secret presence without
-  exposure: `grep -c PATTERN file` (count matches),
-  `test -f .env && echo exists` (check file existence)
-- If secrets are accidentally exposed in a session, immediately
-  flag to the user: name the exposed secret, recommend
-  immediate rotation, and note that session history may be
-  cached or logged
-
 
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1639,10 +1639,60 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1153,10 +1153,324 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1597,10 +1597,60 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/infra/containers.md -->
+# Base — Containers
+[ID: base-containers]
+
+## Dockerfile conventions
+- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
+- Pin base images to a specific version tag — never use `latest`
+- Use multi-stage builds: build in one stage, copy only the final artifact
+  into a minimal runtime image
+- Exclude dev dependencies, build tools, and test files from the final image
+- Each `RUN` instruction should do one logical thing — chain related commands
+  with `&&` to minimise layers
+- Copy only what is needed — use `.dockerignore` to exclude everything else
+
+## Runtime security
+- MUST run containers as a non-root user — create and switch to a dedicated
+  application user in the Dockerfile
+- Set the filesystem to read-only where possible (`--read-only`)
+- Never run containers in privileged mode unless absolutely required and
+  explicitly justified
+- Drop all Linux capabilities and add back only those required
+- Do not store secrets in environment variables baked into the image — inject
+  at runtime from a secret vault
+
+## Resource management
+- MUST define CPU and memory requests and limits for every container
+- Set requests to the typical workload; set limits to the safe maximum
+- Never set memory limit lower than memory request
+- Monitor resource usage and adjust limits based on observed behaviour —
+  do not guess
+
+## Image hygiene
+- Scan all images for vulnerabilities in CI before pushing to a registry
+- Never push an image with critical or high vulnerabilities to staging or
+  production
+- Tag images with the git commit SHA or release version — never rely on
+  mutable tags in staging or production
+- Remove unused images from the registry regularly
+
+## Orchestration (Kubernetes)
+- Define all Kubernetes resources as code — no `kubectl apply` from a local
+  machine in production
+- Use namespaces to separate environments and teams
+- MUST run at least two replicas of every service in staging and production
+- Use liveness and readiness probes — readiness probe MUST pass before a pod
+  receives traffic
+- Use `PodDisruptionBudget` to guarantee availability during rolling updates
+- Never store configuration or secrets in ConfigMaps as plain text — use
+  secret management integration (e.g. external secrets operator)
+
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/templates/backend/quality.md
+++ b/templates/backend/quality.md
@@ -1,6 +1,6 @@
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -168,7 +168,7 @@ backend:
   - id: backend-quality
     file: templates/backend/quality.md
     description: Layered architecture, security, performance, API stability
-    depends_on: [base-quality]
+    depends_on: [base-quality, base-security, base-containers]
   - id: backend-templating
     file: templates/backend/templating.md
     description: Server-side rendering, partials, escaping, caching, forms, testing


### PR DESCRIPTION
## Summary
- `backend-quality` manifest entry was missing `base-security` (header had it, manifest didn't)
- `base-containers` was absent entirely from all service stacks
- Added both to `backend-quality` deps — fixes the gap for all 6 service stacks at once

Closes #268

## Test plan
- [x] `py tests/run_smoke.py` — 11/11 pass
- [x] `py tools/resolve.py stack-go-service` includes `security.md` and `containers.md`
- [x] `py tools/resolve.py --generate` — all 30 stacks regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)