### PR TITLE
fix: correct dependency chains across stacks (#271, #274)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -809,7 +809,7 @@ fixing the design fixes the testability.
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site
 [ID: frontend-static-site]
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 Abstract rules for any static site generated at build time and served as
 plain HTML, CSS, and minimal JavaScript. Never used directly — always

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1082,105 +1082,6 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
-<!-- templates/backend/messaging.md -->
-# Backend — Messaging
-[ID: backend-messaging]
-
-Cross-cutting rules for asynchronous messaging in backend services.
-Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
-
----
-
-## When to use async messaging
-
-- Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
-  with durability
-- Use messaging to decouple services that scale independently
-- Do NOT use messaging when the caller needs a synchronous result — use HTTP or
-  gRPC instead
-- Do NOT replace a simple job queue within one service with a broker — use
-  `templates/backend/jobs.md` instead
-
-### Broker selection guide
-
-| Broker | Best for |
-|--------|----------|
-| **Kafka** | High-throughput event streaming, ordered logs, replay, analytics pipelines |
-| **RabbitMQ** | Task queues, work distribution, complex routing, RPC-over-messaging |
-| **SQS** | AWS-native workloads, simple queues, no broker management overhead |
-| **SQS + SNS** | Fan-out from one publisher to multiple independent consumers |
-
----
-
-## Producer rules
-
-- Validate message schema before publishing — the producer is responsible for
-  schema correctness; the consumer should not be the first line of defence
-- Every message MUST carry a correlation ID (trace ID or request ID) in its
-  headers so consumers can link it to the originating request
-- Use deterministic message IDs where the broker supports them — allows
-  broker-level deduplication on producer retry
-- Do not publish inside a database transaction without the transactional outbox
-  pattern — a commit/publish race will cause lost or phantom messages
-- Outbox pattern: write the message to an `outbox` table in the same transaction
-  as the domain write; a relay process publishes from the outbox asynchronously
-
----
-
-## Consumer rules
-
-- Design all consumers to be **idempotent** — at-least-once delivery is the
-  default; the same message will arrive more than once under failure conditions
-- ACK only after the message has been fully processed — never ACK at receipt
-- On processing failure: NACK or leave unacknowledged so the broker requeues
-  or routes to the dead-letter queue (DLQ); never silently discard
-- Apply exponential backoff on retries — tight retry loops amplify downstream
-  failures
-- Move messages to the DLQ after a configurable maximum retry count —
-  the DLQ is the primary alerting surface for consumer failures
-- Keep consumer handlers thin — delegate logic to a service function, exactly
-  as HTTP handlers delegate to services
-
----
-
-## Schema and contracts
-
-- Define message schemas explicitly — JSON Schema, Avro, or Protobuf
-- Schema changes MUST be backward-compatible: add fields, never remove or
-  rename required fields without a versioning strategy
-- Use a schema registry (Confluent Schema Registry, AWS Glue, or equivalent)
-  for Kafka-based systems — prevents schema drift across teams
-- Version the schema on breaking changes: encode the version in the topic name
-  (`orders.v2`) or as a `schema_version` field in the payload
-
----
-
-## Observability
-
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
-- Log at consumer exit: processing duration, outcome (success / retry / DLQ)
-- Track per topic/queue:
-  - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
-  - Processing time (p50 / p95 / p99)
-  - Error rate and DLQ depth
-- Alert when:
-  - Consumer lag grows continuously for > N minutes
-  - DLQ depth exceeds a threshold
-  - Consumer processing time exceeds the defined SLA
-
----
-
-## Testing
-[EXTEND: base-testing]
-
-- Unit-test consumer business logic independently of the broker —
-  pass a constructed message object directly to the handler function
-- Test the DLQ path: publish a message designed to fail processing
-  and assert it reaches the DLQ after the expected retry count
-- Test idempotency: publish the same message twice and assert the
-  consumer produces the same result with no unintended side effects
-
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1844,7 +1745,7 @@ python -m build           # build distribution
 
 <!-- templates/stack/python-celery-worker.md -->
 # Stack — Celery Worker
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/jobs.md, templates/backend/observability.md, templates/backend/messaging.md, templates/backend/quality.md, templates/stack/python-lib.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/jobs.md, templates/backend/observability.md, templates/backend/quality.md, templates/stack/python-lib.md]
 
 A standalone Celery worker process. No HTTP layer — purely a background task
 processor. Covers task design, retry/backoff, scheduling, observability,

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -808,7 +808,7 @@ fixing the design fixes the testability.
 
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `templates/stack/go-service.md`.

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -808,7 +808,7 @@ fixing the design fixes the testability.
 
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `templates/stack/go-service.md`.

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -808,7 +808,7 @@ fixing the design fixes the testability.
 
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `templates/stack/go-service.md`.

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -808,7 +808,7 @@ fixing the design fixes the testability.
 
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `templates/stack/go-service.md`.
@@ -1122,150 +1122,6 @@ DEBUG=false
 - Internal API endpoints SHOULD require authentication at minimum
 - Write endpoints MUST NOT be accessible without a valid authenticated identity
 
-<!-- templates/backend/database.md -->
-# Backend — Database Conventions
-[ID: backend-database]
-
-## Schema changes
-
-- All schema changes via migrations — never edit the database manually
-- Migrations are committed to source control
-- Never regenerate or modify a migration that is already merged
-- One migration per logical change — do not batch unrelated schema changes
-- Migrations must be reversible — provide a `down` migration for every `up`
-
-## Queries
-
-- No raw SQL strings — use an ORM or query builder
-- Use parameterised queries if raw SQL is unavoidable — never string
-  interpolation
-- No unbounded queries — always apply a limit or filter
-- Avoid `SELECT *` — select only the columns actually needed
-- Detect and eliminate N+1 queries — use eager loading (`joinedload`,
-  `preload`, `WITH` clauses, `DataLoader`) for related data fetched in a loop
-- Prefer indexed columns in `WHERE`, `JOIN ON`, and `ORDER BY` clauses
-- Review slow query logs in staging before releasing schema changes
-
-## Indexing
-
-- Add an index for every foreign key — most ORMs do not do this automatically
-- Add composite indexes for common multi-column filter + sort combinations
-- Avoid over-indexing write-heavy tables — each index adds write overhead
-- Use partial indexes for filtered queries on large tables
-  (e.g. `WHERE deleted_at IS NULL`)
-- Drop unused indexes — check `pg_stat_user_indexes` or equivalent regularly
-
-## Transactions
-
-- Wrap multi-step writes in a transaction — commit only after all writes
-  succeed
-- Never leave a transaction open across an HTTP request boundary
-- Keep transactions short — do not call external services inside a transaction
-- Use serialisable isolation only when genuinely required; prefer read
-  committed for OLTP workloads
-
-## Connections
-
-- Use a connection pool — never open a new connection per request
-- Inject the database session/connection as a dependency — no global DB
-  handles
-- Set explicit pool size limits appropriate to the deployment
-  (e.g. `pool_size=10`, `max_overflow=5` for a single-instance service)
-- Monitor pool exhaustion — alert when pool wait time exceeds threshold
-
-## Soft deletes
-
-- Use soft deletes (`deleted_at` timestamp) only when audit history is
-  required; otherwise use hard deletes
-- If using soft deletes, add a partial index on `deleted_at IS NULL` and
-  filter all queries by default — never return deleted rows to callers
-- Consider an append-only audit log table as an alternative to soft deletes
-
-## Testing
-[EXTEND: base-testing]
-
-- Reset state between test runs — truncate tables or wrap each test in a
-  transaction rolled back after completion
-- Do not substitute a different database engine in tests (e.g. SQLite
-  instead of PostgreSQL) — behaviour differences cause false passes
-- Never run schema migrations against a production database inside a test
-  suite
-
-<!-- templates/backend/observability.md -->
-# Backend — Observability
-[ID: backend-observability]
-
-## Logging
-
-### Log levels
-Use the correct level — do not elevate debug information to INFO:
-
-| Level | When to use | Examples |
-|-------|-------------|---------|
-| FATAL | App cannot continue — imminent shutdown | Out of memory, missing critical dependency at startup, DB schema mismatch |
-| ERROR | Operation failed — normal flow disrupted | Failed DB write, file not found, unhandled exception in request handler |
-| WARN | Unexpected but recoverable — may lead to error | Low disk space, slow response, retry attempt, deprecated endpoint accessed |
-| INFO | Normal operation — confirm correct functioning | Order accepted, service started, payment processed, scheduled job completed |
-| DEBUG | Technical detail for debugging — not for production | Query results, data mapping steps, connection established |
-| TRACE | Most verbose — step-by-step tracing, development only | Function parameters, pipeline steps, request/response payloads |
-
-- Default log level in all environments: **INFO**
-- DEBUG and TRACE MUST NOT be enabled in production by default
-- INFO MUST NOT contain debug or trace information — keep it operational
-
-### Log format
-- Use structured logging in all environments: JSON in production,
-  human-readable in development
-- Every log entry MUST include: timestamp, level, message, properties
-- Include a request ID in all log entries for a given request lifecycle
-- Minimum JSON structure:
-  ```json
-  {
-    "Timestamp": "2024-01-15T12:34:56.789Z",
-    "Level": "Information",
-    "MessageTemplate": "Order ({orderId}) accepted.",
-    "Message": "Order (ORD-78901) accepted.",
-    "Properties": { "orderId": "ORD-78901" }
-  }
-  ```
-
-### Rules
-- Log errors once — at the top of the call stack, not at every level
-- Never log sensitive data: passwords, tokens, API keys, PII
-- Client errors (4xx) — log at INFO
-- Server errors (5xx) — log at ERROR
-- All unhandled errors MUST be logged with enough context to reproduce the issue
-
-## Distributed tracing
-
-- Assign a unique **trace ID** to every inbound request at the service boundary
-- Propagate the trace ID in all outbound calls (HTTP headers, message queue
-  metadata) using the W3C `traceparent` header or OpenTelemetry context
-- Include the trace ID in every log entry for that request — use the same
-  field name across all services (`trace_id`)
-- Use OpenTelemetry as the instrumentation standard — avoid vendor-specific
-  SDKs in application code; export to the backend of choice (Jaeger, Tempo,
-  Datadog, etc.) via the OTel collector
-- Create spans for: inbound HTTP requests, outbound HTTP calls, DB queries,
-  cache operations, and background job execution
-- Span names MUST be low-cardinality — use route templates, not URLs with IDs
-  (e.g. `GET /users/{id}`, not `GET /users/42`)
-- Return the trace ID in error responses (`X-Trace-Id` header) so clients
-  can report it to support
-
-## Health check
-- Expose a health check endpoint: `/health` or `/healthz`
-- Return HTTP 200 when the service is ready to handle traffic
-- Return HTTP 503 when a critical dependency (DB, cache) is unavailable
-- Health check MUST NOT require authentication
-- Health check MUST be the first thing that passes before traffic is routed
-  to a new instance
-
-## Error visibility
-- Distinguish between client errors (4xx) and server errors (5xx) in logs
-- Include correlation/request IDs in error responses to enable log tracing
-- Never expose internal state, stack traces, or file paths in error responses
-
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1530,107 +1386,291 @@ every project regardless of language or framework.
   cached or logged
 
 
-<!-- templates/base/infra/containers.md -->
-# Base — Containers
-[ID: base-containers]
+<!-- templates/backend/auth.md -->
+# Backend — Authentication and Authorization
+[ID: backend-auth]
+[DEPENDS ON: templates/base/security/security.md]
 
-## Dockerfile conventions
-- Use official, minimal base images (e.g. `alpine`, `slim`, `distroless`)
-- Pin base images to a specific version tag — never use `latest`
-- Use multi-stage builds: build in one stage, copy only the final artifact
-  into a minimal runtime image
-- Exclude dev dependencies, build tools, and test files from the final image
-- Each `RUN` instruction should do one logical thing — chain related commands
-  with `&&` to minimise layers
-- Copy only what is needed — use `.dockerignore` to exclude everything else
+Rules for identity verification (authn) and access control (authz).
+Applies to any backend service that has protected resources.
+Extends `security-authn` and `security-sessions` from the base
+security template with backend-specific depth.
 
-## Runtime security
-- MUST run containers as a non-root user — create and switch to a dedicated
-  application user in the Dockerfile
-- Set the filesystem to read-only where possible (`--read-only`)
-- Never run containers in privileged mode unless absolutely required and
-  explicitly justified
-- Drop all Linux capabilities and add back only those required
-- Do not store secrets in environment variables baked into the image — inject
-  at runtime from a secret vault
+---
 
-## Resource management
-- MUST define CPU and memory requests and limits for every container
-- Set requests to the typical workload; set limits to the safe maximum
-- Never set memory limit lower than memory request
-- Monitor resource usage and adjust limits based on observed behaviour —
-  do not guess
+## General principles
 
-## Image hygiene
-- Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
-- Tag images with the git commit SHA or release version — never rely on
-  mutable tags in staging or production
-- Remove unused images from the registry regularly
+- Authentication (who are you?) and authorization (what can you do?) are
+  separate concerns — keep them in separate layers
+- Never implement your own cryptographic primitives — use well-audited libraries
+- Fail closed: deny access by default; grant explicitly
+- Centralise auth logic — no scattered permission checks across route handlers
 
-## Orchestration (Kubernetes)
-- Define all Kubernetes resources as code — no `kubectl apply` from a local
-  machine in production
-- Use namespaces to separate environments and teams
-- MUST run at least two replicas of every service in staging and production
-- Use liveness and readiness probes — readiness probe MUST pass before a pod
-  receives traffic
-- Use `PodDisruptionBudget` to guarantee availability during rolling updates
-- Never store configuration or secrets in ConfigMaps as plain text — use
-  secret management integration (e.g. external secrets operator)
+---
 
-<!-- templates/backend/quality.md -->
-# Backend — Quality Attributes
-[ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+## Authentication
+[EXTEND: security-authn]
 
-## Layered architecture
-- Enforce a strict handler → service → repository separation
-- No database access in handlers — always go through the service layer
-- No HTTP concerns in the service layer — services are framework-agnostic
-- Domain logic lives in the service layer, not in models or schemas
+- Prefer delegating authentication to an identity provider (IdP) via
+  OAuth 2.0 / OIDC (e.g. Auth0, Keycloak, Cognito) over rolling your own
+- If issuing tokens directly, use short-lived JWTs (access token ≤ 15 minutes)
+  with a separate refresh token (≤ 7 days, rotated on use)
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens missing
+  any required claim
+- Store refresh tokens server-side (database or cache) so they can be revoked —
+  stateless refresh tokens cannot be invalidated before expiry
 
-## Design patterns
+---
 
-Prefer these patterns for backend concerns:
+## Token transport
 
-- **Repository** — abstract all data access behind a repository interface;
-  the service layer never constructs queries directly
-- **Service layer** — encapsulate business logic in stateless service objects;
-  one service per domain aggregate
-- **Unit of Work** — coordinate multiple repository operations in a single
-  transaction; commit or roll back as one atomic unit
-- **Factory / Factory Method** — centralise object construction, especially
-  for domain objects with complex invariants
-- **Strategy** — swap algorithms or business rules (pricing, validation,
-  export format) at runtime without modifying the caller
-- **Observer / Event** — decouple producers from consumers for domain events
-  (user registered, order placed); use an internal event bus or message queue
-- **Circuit Breaker** — wrap all outbound calls to external services;
-  fail fast and recover gracefully rather than cascading timeouts
-- **Outbox** — when publishing an event must be atomic with a DB write,
-  write to an outbox table in the same transaction and relay asynchronously
-- **CQRS** — separate read models from write models when query and command
-  requirements diverge significantly; do not apply by default
+- Access tokens MUST be sent in the `Authorization: Bearer <token>` header
+- Do NOT accept tokens in query parameters — they appear in server logs and
+  browser history
+- Refresh tokens MUST be stored in `httpOnly`, `Secure`, `SameSite=Strict`
+  cookies — never in `localStorage` or JavaScript-accessible memory
+- HTTPS required for all authenticated endpoints — no exceptions
 
-## Security
-[EXTEND: security-input]
+---
 
-- Rate-limit public endpoints — never expose unbounded write operations
-- Apply authentication and authorisation before any business logic
-  executes
+## Authorization
 
-## Performance
-- Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
-- Avoid N+1 queries — use eager loading or batch fetching
-- Set timeouts on all outbound calls (HTTP clients, DB queries)
+- Use role-based access control (RBAC) as the baseline:
+  assign permissions to roles, assign roles to users
+- For fine-grained needs, layer attribute-based access control (ABAC) on top
+  of RBAC — do not replace RBAC entirely
+- Authorise at the service layer, not only at the route layer:
+  a route that passes auth may call a service that operates on another user's data
+- Never trust client-supplied IDs for ownership checks — always verify that
+  the authenticated user owns or has access to the requested resource
 
-## API stability
-- Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
-- Document deprecated endpoints; set a removal date before retiring them
+---
+
+## API keys (service-to-service)
+
+- Issue API keys with the minimum required scope
+- Hash API keys before storing — treat them like passwords
+- Rotate API keys on a schedule and immediately on suspected compromise
+- Log every API key usage with the key ID (not the key value) and the
+  calling service identity
+
+---
+
+## Observability
+
+- Log authentication failures at WARN with IP, user agent, and username
+  (never the attempted password)
+- Log authorization failures at WARN with user ID, resource, and action
+- Alert on a spike in auth failures — may indicate a credential stuffing attack
+- Never log tokens, passwords, or secrets — even at DEBUG level
+
+---
+
+## Testing
+
+- Unit test permission logic with all role combinations including edge cases
+  (no role, multiple roles, deprecated role)
+- Integration test that protected endpoints return 401 for unauthenticated
+  requests and 403 for authenticated requests with insufficient permissions
+- Test token expiry: assert that an expired token is rejected
+- Test token revocation: assert that a revoked refresh token cannot obtain
+  a new access token
+
+<!-- templates/backend/observability.md -->
+# Backend — Observability
+[ID: backend-observability]
+
+## Logging
+
+### Log levels
+Use the correct level — do not elevate debug information to INFO:
+
+| Level | When to use | Examples |
+|-------|-------------|---------|
+| FATAL | App cannot continue — imminent shutdown | Out of memory, missing critical dependency at startup, DB schema mismatch |
+| ERROR | Operation failed — normal flow disrupted | Failed DB write, file not found, unhandled exception in request handler |
+| WARN | Unexpected but recoverable — may lead to error | Low disk space, slow response, retry attempt, deprecated endpoint accessed |
+| INFO | Normal operation — confirm correct functioning | Order accepted, service started, payment processed, scheduled job completed |
+| DEBUG | Technical detail for debugging — not for production | Query results, data mapping steps, connection established |
+| TRACE | Most verbose — step-by-step tracing, development only | Function parameters, pipeline steps, request/response payloads |
+
+- Default log level in all environments: **INFO**
+- DEBUG and TRACE MUST NOT be enabled in production by default
+- INFO MUST NOT contain debug or trace information — keep it operational
+
+### Log format
+- Use structured logging in all environments: JSON in production,
+  human-readable in development
+- Every log entry MUST include: timestamp, level, message, properties
+- Include a request ID in all log entries for a given request lifecycle
+- Minimum JSON structure:
+  ```json
+  {
+    "Timestamp": "2024-01-15T12:34:56.789Z",
+    "Level": "Information",
+    "MessageTemplate": "Order ({orderId}) accepted.",
+    "Message": "Order (ORD-78901) accepted.",
+    "Properties": { "orderId": "ORD-78901" }
+  }
+  ```
+
+### Rules
+- Log errors once — at the top of the call stack, not at every level
+- Never log sensitive data: passwords, tokens, API keys, PII
+- Client errors (4xx) — log at INFO
+- Server errors (5xx) — log at ERROR
+- All unhandled errors MUST be logged with enough context to reproduce the issue
+
+## Distributed tracing
+
+- Assign a unique **trace ID** to every inbound request at the service boundary
+- Propagate the trace ID in all outbound calls (HTTP headers, message queue
+  metadata) using the W3C `traceparent` header or OpenTelemetry context
+- Include the trace ID in every log entry for that request — use the same
+  field name across all services (`trace_id`)
+- Use OpenTelemetry as the instrumentation standard — avoid vendor-specific
+  SDKs in application code; export to the backend of choice (Jaeger, Tempo,
+  Datadog, etc.) via the OTel collector
+- Create spans for: inbound HTTP requests, outbound HTTP calls, DB queries,
+  cache operations, and background job execution
+- Span names MUST be low-cardinality — use route templates, not URLs with IDs
+  (e.g. `GET /users/{id}`, not `GET /users/42`)
+- Return the trace ID in error responses (`X-Trace-Id` header) so clients
+  can report it to support
+
+## Health check
+- Expose a health check endpoint: `/health` or `/healthz`
+- Return HTTP 200 when the service is ready to handle traffic
+- Return HTTP 503 when a critical dependency (DB, cache) is unavailable
+- Health check MUST NOT require authentication
+- Health check MUST be the first thing that passes before traffic is routed
+  to a new instance
+
+## Error visibility
+- Distinguish between client errors (4xx) and server errors (5xx) in logs
+- Include correlation/request IDs in error responses to enable log tracing
+- Never expose internal state, stack traces, or file paths in error responses
+
+<!-- templates/backend/grpc.md -->
+# Backend — gRPC
+[ID: backend-grpc]
+
+Cross-cutting rules for gRPC services backed by Protocol Buffers. Applies
+regardless of implementation language. Language-specific stacks extend this
+file with runtime conventions, project structure, and tooling.
+
+---
+
+## When to use gRPC
+
+- Use gRPC for synchronous service-to-service communication where performance,
+  strong typing, or streaming are required
+- Use gRPC when a shared proto schema across multiple language runtimes is
+  preferable to maintaining multiple OpenAPI specs
+- Do NOT use gRPC as the primary API for browser clients — use REST or GraphQL
+  at the edge and gRPC internally
+
+---
+
+## Proto design
+[ID: grpc-proto]
+
+- Package all protos under a versioned namespace: `package [org].[service].v1`
+- One proto file per service — do not mix unrelated services in one file
+- Field names in `snake_case` — generated code adapts to each language's conventions
+- Use `google.protobuf.Timestamp` for all timestamps — never raw integers
+- Use `google.protobuf.FieldMask` for partial update (patch) operations
+- Never remove or renumber existing fields — mark deprecated fields with
+  `[deprecated = true]` and reserve the number: `reserved 4;`
+- Breaking changes require a new package version (`v2`) — serve the old
+  version until all consumers have migrated
+
+---
+
+## Service implementation
+[ID: grpc-implementation]
+
+- Service handlers are thin — decode the request, call a domain service
+  function, encode the response; no business logic in the handler
+- Domain service functions have no gRPC imports — independently testable
+- Validate request messages at the handler entry point; return
+  `INVALID_ARGUMENT` for missing or malformed fields
+
+### Status codes
+
+| Situation | Code |
+|-----------|------|
+| Missing or invalid field | `INVALID_ARGUMENT` |
+| Resource not found | `NOT_FOUND` |
+| Caller not authenticated | `UNAUTHENTICATED` |
+| Caller lacks permission | `PERMISSION_DENIED` |
+| Conflicting state | `ALREADY_EXISTS` / `ABORTED` |
+| Transient infrastructure error | `UNAVAILABLE` |
+| Unexpected error | `INTERNAL` |
+
+---
+
+## Interceptors
+[ID: grpc-interceptors]
+
+- **Auth**: validate token on every call — reject with `UNAUTHENTICATED`
+  before the handler runs
+- **Logging**: log method name, request ID, caller identity, duration, and
+  status code for every call
+- **Tracing**: propagate W3C `traceparent` via gRPC metadata using
+  OpenTelemetry gRPC instrumentation
+- **Recovery**: catch unhandled panics or exceptions — return `INTERNAL`,
+  never crash the server process
+- Register all interceptors as a chain at server startup — not inside handlers
+
+---
+
+## Authentication
+[EXTEND: backend-auth]
+
+- Pass credentials via gRPC metadata: key `authorization`, value `Bearer <token>`
+- Validate in the auth interceptor — not in service handlers
+- Mutual TLS (mTLS) for service-to-service calls in production — certificate
+  rotation managed at the infrastructure layer (cert-manager, Vault)
+- Plaintext only in local development — never in staging or production
+
+---
+
+## Observability
+[EXTEND: backend-observability]
+
+- Expose Prometheus metrics on a separate HTTP port (`/metrics`):
+  - `grpc_server_handled_total` — labelled by method and status code
+  - `grpc_server_handling_seconds` — histogram, labelled by method
+- Implement the standard gRPC Health Checking Protocol
+  (`grpc.health.v1.Health`) — required for Kubernetes probes
+- Propagate trace context through gRPC metadata for distributed tracing
+
+---
+
+## Testing
+[ID: grpc-testing]
+[EXTEND: base-testing]
+
+- Unit-test domain service functions independently of gRPC — pass plain
+  request structs/objects, assert plain response structs/objects
+- Integration tests: start an in-process gRPC server and call it with a
+  real client — test each method for success, invalid argument, and auth failure
+- Test naming: `<MethodName>_<state>_<expected>`
+  e.g. `GetUser_UserNotFound_ReturnsNotFoundStatus`
+
+---
+
+## Proto tooling
+[ID: grpc-tooling]
+
+- Lint protos with `buf lint` in CI — enforce naming, field numbering, and
+  style consistency
+- Detect breaking changes with `buf breaking --against` in CI — reject PRs
+  that introduce wire-incompatible changes without a version bump
+- Generate stubs in CI — if generated code is committed, regenerate and commit
+  in the same PR as the proto change; never let protos and stubs diverge
+
 
 <!-- templates/backend/concurrency.md -->
 # Backend — Concurrency
@@ -1714,195 +1754,6 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   threads concurrently and assert invariants hold
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
-
-<!-- templates/backend/features.md -->
-# Backend — Feature Flags
-[ID: backend-features]
-
-## Purpose
-
-Feature flags decouple deployment from release. Code ships to production
-disabled; the flag controls when and for whom it activates. Use them for:
-
-- Rolling out a new feature progressively (canary, percentage, cohort)
-- Running A/B experiments without a separate deployment
-- Providing a kill switch for a risky change without a rollback
-- Hiding incomplete work that must be deployed incrementally
-
-Do not use feature flags as a permanent configuration system — they are a
-temporary release mechanism.
-
----
-
-## Rules
-
-- Every flag has an owner and a removal date set at creation time — flags
-  without a removal date are not allowed to merge
-- Remove the flag and its dead branch as soon as the rollout is complete —
-  stale flags are technical debt
-- Never nest feature flags — a flag that only activates when another flag
-  is also active creates untestable combinations
-- Keep the flagged code path as small as possible — wrap the decision point,
-  not the entire function
-- Flags are evaluated at runtime, not at startup — never cache a flag value
-  for longer than one request lifecycle unless the evaluation cost is measured
-  and justified
-
----
-
-## Flag types
-
-| Type | Controls | Example |
-|------|----------|---------|
-| **Release** | Whether a feature is visible at all | New checkout flow for 0% → 100% of users |
-| **Experiment** | Which variant a user sees | Button colour A vs B |
-| **Ops / kill switch** | Emergency disable of a subsystem | Disable background sync |
-| **Permission** | Access for a specific user, role, or tenant | Beta access for select accounts |
-
----
-
-## Targeting and rollout strategy
-
-- **Percentage rollout**: enable for N% of requests or users; increase
-  gradually while monitoring error rate and latency
-- **Cohort targeting**: enable for specific user IDs, tenant IDs, or roles
-  before a general rollout
-- **Canary**: enable for one instance or region before expanding
-- Stick users to their assigned variant for the duration of an experiment —
-  use a consistent hash on user ID, not a random value per request
-
----
-
-## Evaluation
-
-- Evaluate flags at the entry point of the feature — handler or service layer,
-  never deep inside domain logic
-- Return the same response shape for both flag states — diverging response
-  shapes on a flag boundary creates API instability
-- Treat the flag-off path as the production default until the rollout is
-  complete and the flag is removed
-
----
-
-## Observability
-
-- Log which variant was evaluated for every flagged request — include the
-  flag name and variant in the structured log properties
-- Emit a metric per flag variant — track error rate and latency separately
-  for each variant to detect regressions introduced by the new path
-- Alert if flag evaluation fails — a broken flag service must not silently
-  default to the wrong variant; fail to the safe default and alert
-
----
-
-## Tooling
-
-- Use a dedicated flag service or SDK (LaunchDarkly, Unleash, Flagsmith,
-  GrowthBook, or equivalent) — never implement flag storage in the application
-  database
-- Flags are not secrets — store targeting rules in the flag service, not in
-  environment variables or config files
-- The flag service must be available before the application can serve traffic
-  — treat it as a required dependency, not an optional one
-
-<!-- templates/backend/messaging.md -->
-# Backend — Messaging
-[ID: backend-messaging]
-
-Cross-cutting rules for asynchronous messaging in backend services.
-Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
-
----
-
-## When to use async messaging
-
-- Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
-  with durability
-- Use messaging to decouple services that scale independently
-- Do NOT use messaging when the caller needs a synchronous result — use HTTP or
-  gRPC instead
-- Do NOT replace a simple job queue within one service with a broker — use
-  `templates/backend/jobs.md` instead
-
-### Broker selection guide
-
-| Broker | Best for |
-|--------|----------|
-| **Kafka** | High-throughput event streaming, ordered logs, replay, analytics pipelines |
-| **RabbitMQ** | Task queues, work distribution, complex routing, RPC-over-messaging |
-| **SQS** | AWS-native workloads, simple queues, no broker management overhead |
-| **SQS + SNS** | Fan-out from one publisher to multiple independent consumers |
-
----
-
-## Producer rules
-
-- Validate message schema before publishing — the producer is responsible for
-  schema correctness; the consumer should not be the first line of defence
-- Every message MUST carry a correlation ID (trace ID or request ID) in its
-  headers so consumers can link it to the originating request
-- Use deterministic message IDs where the broker supports them — allows
-  broker-level deduplication on producer retry
-- Do not publish inside a database transaction without the transactional outbox
-  pattern — a commit/publish race will cause lost or phantom messages
-- Outbox pattern: write the message to an `outbox` table in the same transaction
-  as the domain write; a relay process publishes from the outbox asynchronously
-
----
-
-## Consumer rules
-
-- Design all consumers to be **idempotent** — at-least-once delivery is the
-  default; the same message will arrive more than once under failure conditions
-- ACK only after the message has been fully processed — never ACK at receipt
-- On processing failure: NACK or leave unacknowledged so the broker requeues
-  or routes to the dead-letter queue (DLQ); never silently discard
-- Apply exponential backoff on retries — tight retry loops amplify downstream
-  failures
-- Move messages to the DLQ after a configurable maximum retry count —
-  the DLQ is the primary alerting surface for consumer failures
-- Keep consumer handlers thin — delegate logic to a service function, exactly
-  as HTTP handlers delegate to services
-
----
-
-## Schema and contracts
-
-- Define message schemas explicitly — JSON Schema, Avro, or Protobuf
-- Schema changes MUST be backward-compatible: add fields, never remove or
-  rename required fields without a versioning strategy
-- Use a schema registry (Confluent Schema Registry, AWS Glue, or equivalent)
-  for Kafka-based systems — prevents schema drift across teams
-- Version the schema on breaking changes: encode the version in the topic name
-  (`orders.v2`) or as a `schema_version` field in the payload
-
----
-
-## Observability
-
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
-- Log at consumer exit: processing duration, outcome (success / retry / DLQ)
-- Track per topic/queue:
-  - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
-  - Processing time (p50 / p95 / p99)
-  - Error rate and DLQ depth
-- Alert when:
-  - Consumer lag grows continuously for > N minutes
-  - DLQ depth exceeds a threshold
-  - Consumer processing time exceeds the defined SLA
-
----
-
-## Testing
-[EXTEND: base-testing]
-
-- Unit-test consumer business logic independently of the broker —
-  pass a constructed message object directly to the handler function
-- Test the DLQ path: publish a message designed to fail processing
-  and assert it reaches the DLQ after the expected retry count
-- Test idempotency: publish the same message twice and assert the
-  consumer produces the same result with no unintended side effects
 
 <!-- templates/base/infra/cicd.md -->
 # Base — CI/CD and Delivery
@@ -2064,368 +1915,11 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
-<!-- templates/stack/go-service.md -->
-# Stack — Go Service
-[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
-
-Extends the Go library stack with service-specific rules. Covers project
-structure, HTTP handlers, configuration, concurrency, graceful shutdown,
-and deployment.
-
----
-
-## Stack
-[ID: go-service-stack]
-[OVERRIDE: go-lib-stack]
-
-- Language: Go 1.22+
-- HTTP router: [net/http (stdlib) / chi / gin / echo]
-- Database: [database/sql + pgx / sqlc / GORM]
-- Config: [github.com/caarlos0/env / viper / godotenv]
-- Test runner: go test (stdlib)
-- Containerisation: Docker
-- Distribution: [binary / Docker image / GitHub Releases]
-
----
-
-## Project structure
-[ID: go-service-structure]
-
-```
-cmd/
-  [service]/
-    main.go              # entry point — wires dependencies, starts server
-internal/
-  [feature]/
-    handler.go           # HTTP handlers (thin)
-    service.go           # business logic
-    repository.go        # data access
-    model.go             # domain types
-  config/
-    config.go
-  server/
-    server.go            # HTTP server setup, middleware, routing
-pkg/                     # code safe to import by external packages (if any)
-migrations/              # SQL migration files
-Dockerfile
-Makefile
-go.mod
-go.sum
-README.md
-CLAUDE.md
-```
-
-- `internal/` enforces encapsulation — external packages cannot import it
-- `cmd/` is thin — no business logic, only wiring
-
----
-
-## HTTP handlers
-[ID: go-service-http]
-[EXTEND: backend-http]
-
-- Decode request body explicitly — never trust unvalidated input
-- Use `http.Error()` or a JSON encoder for all error responses
-- Handlers are thin — delegate all logic to service functions
-
----
-
-## Configuration
-[EXTEND: base-config]
-
-- One `Config` struct in `internal/config/config.go` — loaded from env
-  vars at startup; passed explicitly through the dependency graph
-- Never read `os.Getenv` directly in application code outside of
-  the config loader
-
----
-
-## Concurrency
-[EXTEND: backend-concurrency]
-
-- Protect shared state with `sync.Mutex` or `sync.RWMutex` — document
-  which fields are guarded and by which lock
-- Always use `context.Context` as the first argument in functions that may block
-- Use `errgroup` for structured concurrency — all goroutines started in
-  `main.go` under one group, stopped cleanly on context cancellation
-- Never start a goroutine without a clear owner and a clear way to stop it
-- Graceful shutdown: listen for `SIGTERM`, call server shutdown, drain
-  in-flight requests, then cancel the root context
-
----
-
-## Testing
-[ID: go-service-testing]
-[EXTEND: go-lib-testing]
-
-- Integration tests in `internal/[feature]/*_integration_test.go`
-  behind a build tag: `//go:build integration`
-- Performance tests with k6 — colocated in `tests/performance/`
-- Run before every commit: `go test ./... && go vet ./...`
-
----
-
-## Feature flags (if applicable)
-[EXTEND: backend-features]
-
-- Use the OpenFeature Go SDK or a provider SDK (LaunchDarkly, Unleash) —
-  wrap behind an interface so the provider can be swapped in tests
-- Pass the flag client through the dependency graph — constructor argument,
-  not a package-level singleton
-- In tests, use the in-memory OpenFeature provider
-
----
-
-## Messaging (if applicable)
-[EXTEND: backend-messaging]
-
-- Use `confluent-kafka-go` for Kafka, `amqp091-go` for RabbitMQ, or the
-  AWS SDK v2 `sqs` package for SQS
-- Run consumers as goroutines under an `errgroup` — stop cleanly on
-  context cancellation
-- Define a `Message` struct per topic/queue — decode at the entry point,
-  never pass raw `[]byte` to business logic
-
----
-
-## Git conventions
-[EXTEND: go-lib-git]
-
-- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless
-  vendoring intentionally)
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
-
----
-
-## Commands
-```
-go run ./cmd/[service]    # develop
-go build ./cmd/[service]  # build binary
-go test ./...             # run all tests
-go test -tags integration ./...  # run integration tests
-go vet ./...              # static analysis
-goimports -w .            # format imports
-make migrate-up           # apply DB migrations
-docker build -t [name] .  # build container image
-```
-
-<!-- templates/backend/auth.md -->
-# Backend — Authentication and Authorization
-[ID: backend-auth]
-[DEPENDS ON: templates/base/security/security.md]
-
-Rules for identity verification (authn) and access control (authz).
-Applies to any backend service that has protected resources.
-Extends `security-authn` and `security-sessions` from the base
-security template with backend-specific depth.
-
----
-
-## General principles
-
-- Authentication (who are you?) and authorization (what can you do?) are
-  separate concerns — keep them in separate layers
-- Never implement your own cryptographic primitives — use well-audited libraries
-- Fail closed: deny access by default; grant explicitly
-- Centralise auth logic — no scattered permission checks across route handlers
-
----
-
-## Authentication
-[EXTEND: security-authn]
-
-- Prefer delegating authentication to an identity provider (IdP) via
-  OAuth 2.0 / OIDC (e.g. Auth0, Keycloak, Cognito) over rolling your own
-- If issuing tokens directly, use short-lived JWTs (access token ≤ 15 minutes)
-  with a separate refresh token (≤ 7 days, rotated on use)
-- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens missing
-  any required claim
-- Store refresh tokens server-side (database or cache) so they can be revoked —
-  stateless refresh tokens cannot be invalidated before expiry
-
----
-
-## Token transport
-
-- Access tokens MUST be sent in the `Authorization: Bearer <token>` header
-- Do NOT accept tokens in query parameters — they appear in server logs and
-  browser history
-- Refresh tokens MUST be stored in `httpOnly`, `Secure`, `SameSite=Strict`
-  cookies — never in `localStorage` or JavaScript-accessible memory
-- HTTPS required for all authenticated endpoints — no exceptions
-
----
-
-## Authorization
-
-- Use role-based access control (RBAC) as the baseline:
-  assign permissions to roles, assign roles to users
-- For fine-grained needs, layer attribute-based access control (ABAC) on top
-  of RBAC — do not replace RBAC entirely
-- Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
-- Never trust client-supplied IDs for ownership checks — always verify that
-  the authenticated user owns or has access to the requested resource
-
----
-
-## API keys (service-to-service)
-
-- Issue API keys with the minimum required scope
-- Hash API keys before storing — treat them like passwords
-- Rotate API keys on a schedule and immediately on suspected compromise
-- Log every API key usage with the key ID (not the key value) and the
-  calling service identity
-
----
-
-## Observability
-
-- Log authentication failures at WARN with IP, user agent, and username
-  (never the attempted password)
-- Log authorization failures at WARN with user ID, resource, and action
-- Alert on a spike in auth failures — may indicate a credential stuffing attack
-- Never log tokens, passwords, or secrets — even at DEBUG level
-
----
-
-## Testing
-
-- Unit test permission logic with all role combinations including edge cases
-  (no role, multiple roles, deprecated role)
-- Integration test that protected endpoints return 401 for unauthenticated
-  requests and 403 for authenticated requests with insufficient permissions
-- Test token expiry: assert that an expired token is rejected
-- Test token revocation: assert that a revoked refresh token cannot obtain
-  a new access token
-
-<!-- templates/backend/grpc.md -->
-# Backend — gRPC
-[ID: backend-grpc]
-
-Cross-cutting rules for gRPC services backed by Protocol Buffers. Applies
-regardless of implementation language. Language-specific stacks extend this
-file with runtime conventions, project structure, and tooling.
-
----
-
-## When to use gRPC
-
-- Use gRPC for synchronous service-to-service communication where performance,
-  strong typing, or streaming are required
-- Use gRPC when a shared proto schema across multiple language runtimes is
-  preferable to maintaining multiple OpenAPI specs
-- Do NOT use gRPC as the primary API for browser clients — use REST or GraphQL
-  at the edge and gRPC internally
-
----
-
-## Proto design
-[ID: grpc-proto]
-
-- Package all protos under a versioned namespace: `package [org].[service].v1`
-- One proto file per service — do not mix unrelated services in one file
-- Field names in `snake_case` — generated code adapts to each language's conventions
-- Use `google.protobuf.Timestamp` for all timestamps — never raw integers
-- Use `google.protobuf.FieldMask` for partial update (patch) operations
-- Never remove or renumber existing fields — mark deprecated fields with
-  `[deprecated = true]` and reserve the number: `reserved 4;`
-- Breaking changes require a new package version (`v2`) — serve the old
-  version until all consumers have migrated
-
----
-
-## Service implementation
-[ID: grpc-implementation]
-
-- Service handlers are thin — decode the request, call a domain service
-  function, encode the response; no business logic in the handler
-- Domain service functions have no gRPC imports — independently testable
-- Validate request messages at the handler entry point; return
-  `INVALID_ARGUMENT` for missing or malformed fields
-
-### Status codes
-
-| Situation | Code |
-|-----------|------|
-| Missing or invalid field | `INVALID_ARGUMENT` |
-| Resource not found | `NOT_FOUND` |
-| Caller not authenticated | `UNAUTHENTICATED` |
-| Caller lacks permission | `PERMISSION_DENIED` |
-| Conflicting state | `ALREADY_EXISTS` / `ABORTED` |
-| Transient infrastructure error | `UNAVAILABLE` |
-| Unexpected error | `INTERNAL` |
-
----
-
-## Interceptors
-[ID: grpc-interceptors]
-
-- **Auth**: validate token on every call — reject with `UNAUTHENTICATED`
-  before the handler runs
-- **Logging**: log method name, request ID, caller identity, duration, and
-  status code for every call
-- **Tracing**: propagate W3C `traceparent` via gRPC metadata using
-  OpenTelemetry gRPC instrumentation
-- **Recovery**: catch unhandled panics or exceptions — return `INTERNAL`,
-  never crash the server process
-- Register all interceptors as a chain at server startup — not inside handlers
-
----
-
-## Authentication
-[EXTEND: backend-auth]
-
-- Pass credentials via gRPC metadata: key `authorization`, value `Bearer <token>`
-- Validate in the auth interceptor — not in service handlers
-- Mutual TLS (mTLS) for service-to-service calls in production — certificate
-  rotation managed at the infrastructure layer (cert-manager, Vault)
-- Plaintext only in local development — never in staging or production
-
----
-
-## Observability
-[EXTEND: backend-observability]
-
-- Expose Prometheus metrics on a separate HTTP port (`/metrics`):
-  - `grpc_server_handled_total` — labelled by method and status code
-  - `grpc_server_handling_seconds` — histogram, labelled by method
-- Implement the standard gRPC Health Checking Protocol
-  (`grpc.health.v1.Health`) — required for Kubernetes probes
-- Propagate trace context through gRPC metadata for distributed tracing
-
----
-
-## Testing
-[ID: grpc-testing]
-[EXTEND: base-testing]
-
-- Unit-test domain service functions independently of gRPC — pass plain
-  request structs/objects, assert plain response structs/objects
-- Integration tests: start an in-process gRPC server and call it with a
-  real client — test each method for success, invalid argument, and auth failure
-- Test naming: `<MethodName>_<state>_<expected>`
-  e.g. `GetUser_UserNotFound_ReturnsNotFoundStatus`
-
----
-
-## Proto tooling
-[ID: grpc-tooling]
-
-- Lint protos with `buf lint` in CI — enforce naming, field numbering, and
-  style consistency
-- Detect breaking changes with `buf breaking --against` in CI — reject PRs
-  that introduce wire-incompatible changes without a version bump
-- Generate stubs in CI — if generated code is committed, regenerate and commit
-  in the same PR as the proto change; never let protos and stubs diverge
-
-
 <!-- templates/stack/go-grpc.md -->
 # Stack — gRPC Service (Go)
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md, templates/stack/go-service.md]
+[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
 
-Extends the Go service stack and the gRPC backend layer with Go-specific
+Extends the Go library stack and the gRPC backend layer with Go-specific
 conventions for implementing gRPC servers and clients.
 
 ---
@@ -2444,7 +1938,7 @@ conventions for implementing gRPC servers and clients.
 ---
 
 ## Project structure
-[OVERRIDE: go-service-structure]
+[ID: grpc-go-structure]
 
 ```
 cmd/

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1804,7 +1804,7 @@ not after deployment.
 
 <!-- templates/stack/java-grpc.md -->
 # Stack — gRPC Service (Java / Kotlin)
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md]
 
 Extends the gRPC backend layer with Java/Kotlin-specific conventions for
 implementing gRPC servers and clients using grpc-java.

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -806,6 +806,123 @@ fixing the design fixes the testability.
   smell that can silently break sorting, filtering, and UI logic
 
 
+<!-- templates/base/core/config.md -->
+# Base — Configuration
+[ID: base-config]
+
+Follows the [12-factor app](https://12factor.net/config) principle:
+store config in the environment, not in code.
+
+## Rules
+
+- All configuration from environment variables — no hardcoded values
+  in source
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in
+  `.gitignore`
+- Separate configuration per environment (development, testing,
+  production)
+- Pass config explicitly to components — no global config objects
+  accessed from arbitrary locations
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+
+## Naming conventions
+
+- Use `SCREAMING_SNAKE_CASE` for all environment variables
+- Prefix with the app or service name to avoid collisions
+  (e.g. `MYAPP_DATABASE_URL`, not `DATABASE_URL`)
+- Group related variables with a common prefix
+  (e.g. `MYAPP_DB_HOST`, `MYAPP_DB_PORT`, `MYAPP_DB_NAME`)
+- Boolean variables use `ENABLE_` or `DISABLE_` prefix
+  (e.g. `MYAPP_ENABLE_CACHE`)
+
+## Config precedence
+
+Sources override in this order (highest wins):
+
+1. **Hardcoded defaults** — in code, lowest priority
+2. **Config file** — `config.yaml`, `appsettings.json`, etc.
+3. **Environment variables** — override file values
+4. **CLI flags / arguments** — override everything
+
+- Document the precedence model for the project
+- Never let a lower-priority source silently override a
+  higher-priority one
+
+## Build-time vs runtime config
+
+- **Build-time** — values baked into the artifact at build (API base
+  URLs, feature flags, public keys). Changing them requires a rebuild.
+- **Runtime** — values read when the process starts or on each
+  request (secrets, database URLs, log levels). Changing them
+  requires a restart or hot-reload.
+- Never put secrets in build-time config — they end up in the
+  artifact and are visible to anyone who inspects it
+- Document which variables are build-time and which are runtime
+
+## Validation
+
+- Validate types, ranges, and formats at load time — not at first use
+- Use a typed config object or schema — never scatter raw environment
+  variable reads across the codebase
+- Provide sensible defaults only for optional, non-sensitive settings
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys
+
+## Secrets management
+
+- In production, source secrets from a dedicated secrets manager or
+  CI/CD secret store — not from flat `.env` files
+- Design secret loading to support rotation without a full
+  redeployment
+- Never log config values — redact or omit secrets from logs and
+  diagnostic output
+- Reference secrets by name or path, not by embedding them in config
+  files
+
+## Environment separation
+
+| Environment | Purpose           | Secrets source       |
+|-------------|-------------------|----------------------|
+| development | local work        | `.env` file          |
+| testing     | automated tests   | hardcoded stubs      |
+| staging     | pre-production    | secrets manager / CI |
+| production  | live              | secrets manager      |
+
+## Dependencies
+
+- Declare all dependencies explicitly in a manifest (`package.json`,
+  `pyproject.toml`, `go.mod`, `Cargo.toml`, `requirements.txt`)
+- Commit the lockfile (`package-lock.json`, `poetry.lock`, `go.sum`,
+  `Cargo.lock`) — it pins exact versions for reproducible builds
+- Never rely on system-wide packages — the app MUST run with only
+  its declared dependencies installed
+- Separate production dependencies from dev/test dependencies
+
+## Port binding
+
+- The application exposes its service by binding to a port — it does
+  not depend on an external web server injecting itself at runtime
+- The port MUST be configurable via environment variable
+  (e.g. `PORT=8080`)
+- Do not hardcode port numbers in source code
+- In development, use a well-known default; in production, the
+  platform assigns the port
+
+## `.env.example` structure
+
+```
+# Required
+API_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me
+
+# Optional — defaults shown
+LOG_LEVEL=info
+DEBUG=false
+```
+
+
 <!-- templates/backend/templating.md -->
 # Backend — Server-Side Templating
 [ID: backend-templating]
@@ -915,7 +1032,7 @@ templates/
 
 <!-- templates/stack/htmx.md -->
 # Stack — HTMX
-[DEPENDS ON: templates/backend/templating.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/templating.md]
 
 Extends server-side templating with HTMX hypermedia conventions. Covers swap
 strategies, triggers, out-of-band updates, server-sent events, Alpine.js

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -809,7 +809,7 @@ fixing the design fixes the testability.
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site
 [ID: frontend-static-site]
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 Abstract rules for any static site generated at build time and served as
 plain HTML, CSS, and minimal JavaScript. Never used directly — always

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1044,9 +1044,273 @@ Rules:
 - No third-party tracking scripts without explicit user consent
 
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
 <!-- templates/stack/spa-react.md -->
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.
@@ -1498,270 +1762,6 @@ Sunset: <HTTP-date>
 - Include navigation links (`next`, `prev`) in the response per HATEOAS
 
 
-<!-- templates/base/security/security.md -->
-# Base — Application Security
-
-[ID: base-security]
-
-Cross-cutting security rules for application code. Applies to
-every project regardless of language or framework.
-
-
----
-
-## Input validation
-
-[ID: security-input]
-
-- Validate all external input at the system boundary — the first
-  point where untrusted data enters the application
-- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
-  — never hand-write validation for complex inputs
-- Allowlist, not blocklist — define what is valid, reject everything
-  else
-- Reject invalid input with a clear error — do not silently coerce
-  or strip fields
-- Internal code trusts validated data — do not re-validate in
-  service or repository layers
-
----
-
-## Output encoding
-
-[ID: security-output]
-
-- Encode dynamic data for its rendering context at the point of
-  output — HTML, URL, JavaScript, SQL, shell
-- Encode on output, not on input — store the raw value, encode
-  when rendering
-- Use framework-provided encoding: React JSX, Jinja2 autoescape,
-  Go `html/template`, Astro `{expression}`
-- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
-  or `| safe` with user-supplied data
-- Context matters — HTML encoding does not prevent URL injection
-
----
-
-## Injection prevention
-
-[ID: security-injection]
-
-- Use parameterized queries for all database access — never
-  concatenate user input into SQL strings
-- Use prepared statements or ORM query builders — raw SQL with
-  string interpolation is a SQL injection vulnerability
-- Escape shell arguments when invoking external commands — or
-  use API alternatives that do not invoke a shell
-- Never pass user input to `eval()`, `exec()`, `Function()`,
-  or equivalent dynamic code execution
-
----
-
-## Authentication
-
-[ID: security-authn]
-
-- Hash passwords with a modern algorithm: bcrypt, scrypt, or
-  Argon2 — never MD5, SHA-1, or plain SHA-256
-- Enforce minimum password complexity at the boundary
-- Use constant-time comparison for secrets and tokens — timing
-  attacks leak information through response time
-- Support multi-factor authentication for privileged operations
-- Lock accounts or throttle after repeated failed attempts
-
----
-
-## Session management
-
-[ID: security-sessions]
-
-- Generate session IDs with a cryptographic random generator
-- Regenerate the session ID after login — prevents session fixation
-- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
-  `Strict` for sensitive applications)
-- Expire sessions after a reasonable idle period — 30 minutes
-  for sensitive applications, configurable otherwise
-- Invalidate sessions on logout — do not rely on cookie expiry
-  alone
-
----
-
-## Secrets in code
-
-[ID: security-secrets]
-
-- Never hardcode secrets, API keys, tokens, or credentials in
-  source files
-- Never commit secrets to version control — even in test files
-  or example configurations
-- Use `.env` files for local development — add to `.gitignore`
-- Provide `.env.example` with placeholder values — never real
-  secrets
-- If a secret is accidentally committed, rotate it immediately —
-  removing from git history is not sufficient; the secret is
-  compromised
-
----
-
-## Transport security
-
-[ID: security-transport]
-
-- HTTPS everywhere — no exceptions for production traffic
-- HSTS MUST be enabled on all production sites with
-  `includeSubDomains` and a minimum `max-age` of one year
-- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
-- Use strong cipher suites — disable known-weak ciphers
-- Internal service-to-service traffic SHOULD use mTLS via a
-  service mesh or explicit certificate configuration
-
----
-
-## Security headers
-
-[ID: security-headers]
-
-- Set security headers on every HTTP response at the reverse proxy
-  or middleware level — not per route
-- Required headers:
-  - `Content-Security-Policy` — start strict, relax only as needed
-  - `X-Content-Type-Options: nosniff`
-  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
-  - `Strict-Transport-Security` (see Transport security)
-  - `Referrer-Policy: strict-origin-when-cross-origin`
-  - `Permissions-Policy` — disable unused browser APIs
-- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
-  written justification
-- Do not expose server version or technology stack in headers —
-  remove `X-Powered-By`, `Server` version strings
-
----
-
-## Error handling
-
-[ID: security-errors]
-
-- Never expose stack traces, internal paths, or database errors
-  to end users — return generic error messages externally
-- Log full error details server-side for debugging
-- Use consistent error response formats — do not leak internal
-  structure through varying error shapes
-- Return appropriate HTTP status codes — do not use 200 for errors
-- Do not reveal whether a resource exists via error messages —
-  login errors should say "invalid credentials", not "user not
-  found" vs "wrong password"
-
----
-
-## Logging
-
-[ID: security-logging]
-
-- Never log secrets, tokens, passwords, or personally identifiable
-  information (PII)
-- Sanitize log output — user-supplied data in logs can enable
-  log injection attacks
-- Log security-relevant events: authentication attempts, access
-  denials, privilege changes, configuration changes
-- Include enough context for investigation: timestamp, user ID,
-  IP, action, result
-- Retain security logs for a defined period — compliance may
-  require 90 days to 7 years
-
----
-
-## CORS
-
-[ID: security-cors]
-
-- Restrict `Access-Control-Allow-Origin` to specific known
-  origins — never use `*` for authenticated endpoints
-- Do not reflect the `Origin` header back as
-  `Access-Control-Allow-Origin` without validation
-- Restrict allowed methods and headers to what the API actually
-  needs
-- Set `Access-Control-Max-Age` to cache preflight responses —
-  reduces latency and server load
-
----
-
-## Deserialization and data integrity
-
-[ID: security-integrity]
-
-- Never deserialize untrusted data with native serialization
-  formats (Python `pickle`, Java `ObjectInputStream`, PHP
-  `unserialize`) — use safe formats (JSON, Protocol Buffers)
-- Validate the structure and types of deserialized data before
-  use — treat it as untrusted input
-- Verify integrity of downloaded artifacts, updates, and
-  dependencies — use checksums or digital signatures
-- Pin dependency versions and verify checksums in lockfiles —
-  do not trust upstream registries blindly
-- CI/CD pipelines MUST use pinned, verified actions and images —
-  never pull `latest` tags in production pipelines
-
----
-
-## Server-Side Request Forgery (SSRF)
-
-[ID: security-ssrf]
-
-- Never pass user-supplied URLs directly to server-side HTTP
-  clients — validate and sanitize first
-- Allowlist permitted destination hosts and schemes — reject
-  anything not on the list
-- Block requests to internal networks (`127.0.0.0/8`,
-  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
-  `::1`, `fc00::/7`) — even after DNS resolution
-- Resolve the hostname and validate the IP before making the
-  request — prevents DNS rebinding attacks
-- Disable HTTP redirects in server-side HTTP clients, or
-  re-validate the destination after each redirect
-- Limit response size and timeout for outbound requests to
-  prevent resource exhaustion
-
----
-
-## File uploads
-
-[ID: security-uploads]
-
-- Validate file type by content (magic bytes), not by extension
-  or MIME type — both are trivially spoofed
-- Enforce maximum file size at the boundary
-- Store uploads outside the web root — never serve user uploads
-  from the same domain without sanitization
-- Generate random filenames — do not use the original filename
-  (path traversal risk)
-- Scan uploaded files for malware if the application serves them
-  to other users
-
----
-
-## Agent secrets handling
-
-[ID: security-agent-secrets]
-
-- MUST NOT read, print, or cat files that may contain secrets:
-  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
-  `serviceaccount.json`, `secrets.yaml`
-- MUST NOT echo, log, or display environment variable values —
-  use `printenv | grep -c KEY` to check presence without
-  revealing the value
-- MUST NOT include secret values in commit messages, PR
-  descriptions, or conversation output
-- MUST warn the user before committing files that commonly
-  contain secrets (`.env`, `credentials.json`, private keys)
-- Use targeted commands to verify secret presence without
-  exposure: `grep -c PATTERN file` (count matches),
-  `test -f .env && echo exists` (check file existence)
-- If secrets are accidentally exposed in a session, immediately
-  flag to the user: name the exposed secret, recommend
-  immediate rotation, and note that session history may be
-  cached or logged
-
-
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization
 [ID: backend-auth]
@@ -1851,6 +1851,150 @@ security template with backend-specific depth.
 - Test token expiry: assert that an expired token is rejected
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
+
+<!-- templates/backend/database.md -->
+# Backend — Database Conventions
+[ID: backend-database]
+
+## Schema changes
+
+- All schema changes via migrations — never edit the database manually
+- Migrations are committed to source control
+- Never regenerate or modify a migration that is already merged
+- One migration per logical change — do not batch unrelated schema changes
+- Migrations must be reversible — provide a `down` migration for every `up`
+
+## Queries
+
+- No raw SQL strings — use an ORM or query builder
+- Use parameterised queries if raw SQL is unavoidable — never string
+  interpolation
+- No unbounded queries — always apply a limit or filter
+- Avoid `SELECT *` — select only the columns actually needed
+- Detect and eliminate N+1 queries — use eager loading (`joinedload`,
+  `preload`, `WITH` clauses, `DataLoader`) for related data fetched in a loop
+- Prefer indexed columns in `WHERE`, `JOIN ON`, and `ORDER BY` clauses
+- Review slow query logs in staging before releasing schema changes
+
+## Indexing
+
+- Add an index for every foreign key — most ORMs do not do this automatically
+- Add composite indexes for common multi-column filter + sort combinations
+- Avoid over-indexing write-heavy tables — each index adds write overhead
+- Use partial indexes for filtered queries on large tables
+  (e.g. `WHERE deleted_at IS NULL`)
+- Drop unused indexes — check `pg_stat_user_indexes` or equivalent regularly
+
+## Transactions
+
+- Wrap multi-step writes in a transaction — commit only after all writes
+  succeed
+- Never leave a transaction open across an HTTP request boundary
+- Keep transactions short — do not call external services inside a transaction
+- Use serialisable isolation only when genuinely required; prefer read
+  committed for OLTP workloads
+
+## Connections
+
+- Use a connection pool — never open a new connection per request
+- Inject the database session/connection as a dependency — no global DB
+  handles
+- Set explicit pool size limits appropriate to the deployment
+  (e.g. `pool_size=10`, `max_overflow=5` for a single-instance service)
+- Monitor pool exhaustion — alert when pool wait time exceeds threshold
+
+## Soft deletes
+
+- Use soft deletes (`deleted_at` timestamp) only when audit history is
+  required; otherwise use hard deletes
+- If using soft deletes, add a partial index on `deleted_at IS NULL` and
+  filter all queries by default — never return deleted rows to callers
+- Consider an append-only audit log table as an alternative to soft deletes
+
+## Testing
+[EXTEND: base-testing]
+
+- Reset state between test runs — truncate tables or wrap each test in a
+  transaction rolled back after completion
+- Do not substitute a different database engine in tests (e.g. SQLite
+  instead of PostgreSQL) — behaviour differences cause false passes
+- Never run schema migrations against a production database inside a test
+  suite
+
+<!-- templates/backend/observability.md -->
+# Backend — Observability
+[ID: backend-observability]
+
+## Logging
+
+### Log levels
+Use the correct level — do not elevate debug information to INFO:
+
+| Level | When to use | Examples |
+|-------|-------------|---------|
+| FATAL | App cannot continue — imminent shutdown | Out of memory, missing critical dependency at startup, DB schema mismatch |
+| ERROR | Operation failed — normal flow disrupted | Failed DB write, file not found, unhandled exception in request handler |
+| WARN | Unexpected but recoverable — may lead to error | Low disk space, slow response, retry attempt, deprecated endpoint accessed |
+| INFO | Normal operation — confirm correct functioning | Order accepted, service started, payment processed, scheduled job completed |
+| DEBUG | Technical detail for debugging — not for production | Query results, data mapping steps, connection established |
+| TRACE | Most verbose — step-by-step tracing, development only | Function parameters, pipeline steps, request/response payloads |
+
+- Default log level in all environments: **INFO**
+- DEBUG and TRACE MUST NOT be enabled in production by default
+- INFO MUST NOT contain debug or trace information — keep it operational
+
+### Log format
+- Use structured logging in all environments: JSON in production,
+  human-readable in development
+- Every log entry MUST include: timestamp, level, message, properties
+- Include a request ID in all log entries for a given request lifecycle
+- Minimum JSON structure:
+  ```json
+  {
+    "Timestamp": "2024-01-15T12:34:56.789Z",
+    "Level": "Information",
+    "MessageTemplate": "Order ({orderId}) accepted.",
+    "Message": "Order (ORD-78901) accepted.",
+    "Properties": { "orderId": "ORD-78901" }
+  }
+  ```
+
+### Rules
+- Log errors once — at the top of the call stack, not at every level
+- Never log sensitive data: passwords, tokens, API keys, PII
+- Client errors (4xx) — log at INFO
+- Server errors (5xx) — log at ERROR
+- All unhandled errors MUST be logged with enough context to reproduce the issue
+
+## Distributed tracing
+
+- Assign a unique **trace ID** to every inbound request at the service boundary
+- Propagate the trace ID in all outbound calls (HTTP headers, message queue
+  metadata) using the W3C `traceparent` header or OpenTelemetry context
+- Include the trace ID in every log entry for that request — use the same
+  field name across all services (`trace_id`)
+- Use OpenTelemetry as the instrumentation standard — avoid vendor-specific
+  SDKs in application code; export to the backend of choice (Jaeger, Tempo,
+  Datadog, etc.) via the OTel collector
+- Create spans for: inbound HTTP requests, outbound HTTP calls, DB queries,
+  cache operations, and background job execution
+- Span names MUST be low-cardinality — use route templates, not URLs with IDs
+  (e.g. `GET /users/{id}`, not `GET /users/42`)
+- Return the trace ID in error responses (`X-Trace-Id` header) so clients
+  can report it to support
+
+## Health check
+- Expose a health check endpoint: `/health` or `/healthz`
+- Return HTTP 200 when the service is ready to handle traffic
+- Return HTTP 503 when a critical dependency (DB, cache) is unavailable
+- Health check MUST NOT require authentication
+- Health check MUST be the first thing that passes before traffic is routed
+  to a new instance
+
+## Error visibility
+- Distinguish between client errors (4xx) and server errors (5xx) in logs
+- Include correlation/request IDs in error responses to enable log tracing
+- Never expose internal state, stack traces, or file paths in error responses
 
 <!-- templates/base/infra/cicd.md -->
 # Base — CI/CD and Delivery
@@ -2014,7 +2158,7 @@ not after deployment.
 
 <!-- templates/stack/full-nextjs.md -->
 # Stack — Next.js Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-react.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-react.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md, templates/backend/database.md, templates/backend/observability.md]
 
 Extends the React SPA stack with Next.js-specific rules. Covers the App
 Router, Server and Client Components, data fetching, API routes, metadata,

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -848,449 +848,6 @@ fixing the design fixes the testability.
 - Follow `@typescript-eslint/recommended`
 
 
-<!-- templates/frontend/ux.md -->
-# Frontend — UX Principles
-
-[ID: frontend-ux]
-
-## UX principles
-
-- Mobile-first — design for small screens first, enhance for larger ones
-- Progressive disclosure — show only what the user needs at each step
-- No dark patterns — no misleading UI, no forced actions, no hidden costs
-- Consistency — same interaction patterns throughout the product
-- Performance is UX — slow interfaces are bad user experience
-- **Least Surprise**: components and interactions should behave as users
-  expect; if a pattern looks like a button it must act like a button
-
-## Accessibility — WCAG 2.1 AA
-
-- Target standard: WCAG 2.1 AA
-- Minimum text contrast ratio: 4.5:1 (normal text), 3:1 (large text)
-- All interactive elements reachable and operable by keyboard
-- Any non-focusable element (`<th>`, `<div>`, `<span>`) with `onClick` MUST
-  contain a `<button>` — `onClick` alone does not add the element to the tab
-  order or provide keyboard activation
-- Use `:focus-visible` instead of `:focus` for focus indicators —
-  `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
-  shows them only for keyboard navigation
-- Focus indicators must be visible at all times during keyboard navigation
-- No content that relies on colour alone to convey meaning
-- Images must have descriptive `alt` text; decorative images use `alt=""`
-- Semantic HTML: correct landmark elements and heading hierarchy
-- `aria-label` on all interactive elements (buttons, icon links, social links)
-- All `<a>` elements with icon-only or ambiguous text must have a descriptive
-  `aria-label`
-- Keyboard navigation: menus must close on Escape and restore focus
-
-## Accessibility testing
-
-Meeting WCAG 2.1 AA requires both automated and manual testing — automated
-tools catch ~30–40% of issues; the rest require human judgment.
-
-### Automated (run in CI)
-
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
-- **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
-  via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
-
-### Manual (run before shipping new interactive components)
-
-- **Keyboard-only navigation** — tab through the entire feature; every
-  action reachable without a mouse; focus order is logical; no focus traps
-  except intentional modal dialogs
-- **Screen reader** — test with at least one: NVDA + Chrome (Windows),
-  VoiceOver + Safari (macOS / iOS), or TalkBack (Android); verify that
-  all content and state changes are announced correctly
-- **Zoom to 200%** — no content clipped or overlapping at double zoom;
-  horizontal scroll must not appear on a 1280px viewport
-- **High contrast mode** — verify in Windows High Contrast or forced-colors
-  CSS media query; no information lost when colours are overridden
-
-### Criteria for done
-
-A feature is not complete until:
-
-- [ ] `axe-core` reports zero violations in component tests
-- [ ] Lighthouse accessibility score ≥ 90
-- [ ] Keyboard navigation verified manually
-- [ ] Screen reader walkthrough completed for new interactive elements
-
-## Sortable tables
-
-- Boolean columns SHOULD sort descending (true first) on first click ���
-  users click a boolean column to find items that have a feature, not
-  items that lack it; ascending puts `false` first, which looks
-  identical to unsorted and appears broken
-
-## Responsive breakpoints
-
-- Tablet: max-width 1024px
-- Mobile: max-width 768px
-- Small mobile: max-width 480px
-
-## Design system
-
-- Use a design system if one exists for the project — never design ad-hoc
-  components that duplicate established patterns
-- Design tokens (colours, spacing, typography, radii) MUST come from the
-  design system — never hardcode visual values
-- Component-driven development: build UI as a hierarchy of reusable,
-  self-contained components; avoid monolithic views
-- New components SHOULD be documented with usage examples before shipping
-
-## Browser support
-
-[ID: frontend-ux-browsers]
-
-- Default target: last 2 versions of Chrome, Firefox, Safari, and Edge
-- Progressive enhancement: graceful degradation for unsupported features
-
-
-<!-- templates/frontend/quality.md -->
-# Frontend — Quality Attributes
-
-[ID: frontend-quality]
-
-## Patterns
-
-- Use error boundary, skeleton loading, optimistic update, virtual
-  scroll, debounced search, form validation, responsive switch, and
-  URL state sync patterns where appropriate
-
-## Design patterns
-
-Prefer these patterns for frontend concerns:
-
-- **Container / Presentational** — separate data-fetching and state logic
-  (container) from rendering (presentational); presentational components
-  receive only props, have no side effects, and are easy to test in isolation
-- **Custom Hook** — extract reusable stateful logic into a named hook
-  (`use[Name]`); hooks are the frontend equivalent of a service or strategy
-- **Compound Component** — expose a set of related sub-components that share
-  implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
-  prefer over deeply nested prop drilling
-- **Render Props / Slot** — pass render logic as a prop or slot to invert
-  control over what is rendered; use sparingly — prefer custom hooks where possible
-- **Observer** — subscribe to external state changes (store, event bus,
-  WebSocket) via a single subscription point; unsubscribe on component unmount
-- **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
-  behind a thin project-owned interface; never scatter SDK calls across components
-- **Optimistic Update** — apply the expected result of a mutation immediately
-  in the UI and roll back on failure; document the rollback path
-
-Avoid:
-
-- **Mediator / Event Bus** between components — use shared state or lifting
-  state up instead; an event bus between components creates invisible coupling
-
-## State management
-
-Choose the right tool for the scope of the state — do not use a global store
-for state that is local to a component or a server cache for state that is
-never fetched from a server.
-
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
-
-Rules:
-
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
-- Prefer URL state for anything the user should be able to bookmark or share
-- Keep global store slices small and focused — one slice per domain concern,
-  not one slice for everything
-
-## Linting and formatting
-
-- A linter MUST be configured for all JS/TS code
-- Linter and formatter SHOULD run on save in the IDE — never rely on CI
-  alone to catch style issues
-- No warnings or errors MUST appear in the browser console or test output
-  before a PR is merged — start every review on a clean slate
-- Lint error count SHOULD go down over time — never increase it
-
-## CSS
-
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
-- No hardcoded colour or spacing values — always use CSS custom properties
-  from `:root` or design tokens
-- Consistent naming convention (e.g. BEM-like `.component-element`)
-- Maximum line length: 80 characters (exempt: prose strings, third-party URLs)
-
-## Performance
-
-- Preload critical above-the-fold assets
-- Keep client-side JS minimal — every dependency adds to bundle size
-- Avoid unnecessary dependencies
-- Defer non-critical scripts
-- Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
-
-## SEO & analytics
-
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
-- Privacy-friendly analytics only — no consent banner required
-- No third-party tracking scripts without explicit user consent
-
-
-<!-- templates/stack/spa-react.md -->
-# Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
-
-A client-side React application with TypeScript. Covers component model,
-state management, routing, API integration, and tooling.
-
----
-
-## Stack
-[ID: react-spa-stack]
-
-- Language: TypeScript (strict mode)
-- Framework: React 18+
-- Bundler: [Vite / Create React App / Next.js]
-- Routing: [React Router v6 / TanStack Router]
-- State: [Zustand / Redux Toolkit / React Query + local state]
-- Styling: [CSS Modules / Tailwind / plain CSS]
-- HTTP client: [fetch / axios / TanStack Query]
-- Test runner: Vitest + React Testing Library
-- Package manager: [npm / pnpm / yarn]
-- Deployment: [Vercel / Netlify / GitHub Pages / Docker]
-
----
-
-## Project structure
-[ID: react-spa-structure]
-
-```
-src/
-  components/
-    [Feature]/
-      [Feature].tsx
-      [Feature].test.tsx
-      [Feature].module.css   # if using CSS Modules
-  pages/                     # or routes/ — one file per route
-  hooks/                     # custom hooks (use[Name].ts)
-  services/                  # API calls (no business logic in components)
-  store/                     # global state slices
-  types/                     # shared TypeScript types and interfaces
-  utils/                     # pure utility functions
-  App.tsx
-  main.tsx
-public/
-tsconfig.json
-vite.config.ts               # or equivalent
-package.json
-README.md
-CLAUDE.md
-```
-
----
-
-## TypeScript conventions
-[ID: react-spa-typescript]
-
-- Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
-  enforced by ESLint; do not suppress lint errors without a
-  documented reason
-- **Prettier** owns all formatting decisions — no style discussions in code
-  review; configure once and commit the config
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
-- Explicit return types on all non-trivial functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions instead
-
----
-
-## Component conventions
-[ID: react-spa-components]
-
-- One component per file — filename matches component name (PascalCase)
-- Functional components only — no class components
-- Props typed with an explicit `interface` or `type` in the same file
-- No prop drilling beyond two levels — lift state or use context/store
-- Extract reusable logic into custom hooks (`use[Name].ts` in `hooks/`)
-- Keep components small: if a component exceeds ~150 lines, split it
-
----
-
-## State management
-[ID: react-spa-state]
-
-- Local state (`useState`, `useReducer`) for component-scoped concerns
-- Shared/global state in the chosen store (Zustand slice or Redux slice)
-- Server state (fetched data) managed by React Query / TanStack Query —
-  never duplicate server state in the global store
-- No direct DOM manipulation — all state flows through React
-
----
-
-## API integration
-[ID: react-spa-api]
-
-- All API calls in `src/services/` — never inline `fetch` in components
-- Return typed response objects — no untyped `any` from API boundaries
-- Handle loading, error, and empty states explicitly in every data-dependent view
-- Never store tokens in `localStorage` — prefer `httpOnly` cookies or memory
-
----
-
-## Styling
-[ID: react-spa-styling]
-
-- No inline styles except for dynamic/computed values
-- No hardcoded colour or spacing values — use CSS custom properties or
-  design tokens from the chosen system
-- Responsive styles follow a mobile-first approach (per `templates/frontend/ux.md`)
-- Global styles in `src/index.css` only; component styles co-located
-
----
-
-## Testing
-[EXTEND: base-testing]
-
-- React Testing Library for component tests — test behaviour, not implementation
-- No `getByTestId` as a first resort — prefer accessible queries
-  (`getByRole`, `getByLabelText`, `getByText`)
-- Vitest for component tests on utils, hooks, and services
-- Mock API calls at the network boundary (`msw`) — not inside components
-- Component test naming: Given/When/Then
-  e.g. `given a logged-out user, when they submit the form, then an error is shown`
-- System tests MUST cover critical user journeys (login, checkout, key flows)
-- System tests SHOULD use Playwright or Cypress — colocated in `tests/system/`
-  at project root
-- Run before every commit: `npm test && tsc --noEmit`
-
----
-
-## Accessibility
-[EXTEND: frontend-ux]
-
-- All interactive elements must be keyboard-accessible
-- Use semantic HTML — prefer `<button>` over `<div onClick>`
-- Every form input has an associated `<label>`
-- Modals and dialogs trap focus and restore it on close
-- Test with a screen reader before shipping new interactive components
-
----
-
-## Git conventions
-[EXTEND: base-git]
-
-- Do not commit `node_modules/`, `dist/`, `.env`, `.env.local`
-- Lock file (`package-lock.json` / `pnpm-lock.yaml`) is committed — do not delete it
-- Always run `npm test && tsc --noEmit` before committing
-
----
-
-## Commands
-```
-npm run dev       # develop — hot reload
-npm run build     # production build
-npm run preview   # preview production build locally
-npm test          # run tests (watch mode)
-tsc --noEmit      # type check without emitting files
-```
-
-<!-- templates/backend/http.md -->
-# Backend — HTTP Conventions
-[ID: backend-http]
-
-## Handler design
-- Handlers are thin: decode request → call service → encode response
-- No business logic in handlers — delegate to a service layer
-- Validate all incoming request data before processing
-
-## URI design
-- Path segments MUST be lowercase with hyphens as word separators —
-  underscores and camelCase are not permitted
-- Paths MUST use nouns, not verbs: `/orders` not `/getOrders`
-- Collection resources MUST use plural nouns: `/orders`, `/products`
-- Individual resources MUST be addressed under their collection:
-  `/orders/{orderId}`
-- Sub-resources MUST be nested under their parent: `/customers/{id}/orders`
-- A URI MUST NOT end with a trailing slash
-- Paths MUST use American English spelling with no abbreviations or acronyms
-
-## Query parameters
-- Query parameter names MUST use camelCase
-- Query parameters MUST be used for filtering, sorting, and pagination —
-  not for resource identity (use path segments for that)
-- The following names are reserved for framework-level use and MUST NOT
-  be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
-
-## Request headers
-- All HTTP headers MUST follow Hyphenated-Pascal-Case casing:
-  `Api-Correlation-Id`, `Accept-Language`
-- Custom headers SHOULD NOT use the `X-` prefix — this convention was
-  deprecated by RFC 6648; use a vendor or application-specific prefix instead
-
-## HTTP methods
-| Method | Use for | Idempotent |
-|--------|---------|-----------|
-| GET | Retrieve a resource or collection — no side effects | Yes |
-| POST | Create a new resource — server assigns URI | No |
-| PUT | Replace a resource entirely | Yes |
-| PATCH | Partially update a resource | No |
-| DELETE | Remove a resource | Yes |
-
-## Resource representation
-- JSON MUST be the default serialisation format; XML MAY be used where
-  explicitly required by the consuming system
-- Field types MUST conform to the relevant ISO standard:
-  - Date and time values: ISO 8601
-  - Language codes: ISO 639
-  - Country codes: ISO 3166-1 alpha-2
-  - Currency codes: ISO 4217
-- Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
-  as a string — JavaScript cannot represent larger integers precisely
-- Responses MUST contain only the fields needed by the caller — do not pad
-  payloads with fields that are not consumed
-
-## HATEOAS
-- Embed hyperlinks in responses to enable resource discovery
-- Use a `links` array with `href`, `rel`, `type`, and `media` fields:
-  ```json
-  "links": [
-    {
-      "href": "invoices/f9c3b2a1-0d4e-4f8b-9c7a-1e2d3f4a5b6c",
-      "rel": "invoice",
-      "type": "paymentSummary",
-      "media": "application/pdf"
-    }
-  ]
-  ```
-- Support at minimum: `self`, `next`, `prev` relations on paginated collections
-
-## Error responses
-- Use consistent error response shape across all endpoints
-- Follow RFC 9457 (`application/problem+json`) for error format
-- Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
-- Set explicit `Content-Type: application/json` on all JSON responses
-
-## Authentication and authorisation
-- All API traffic MUST be served over HTTPS — plain HTTP is not acceptable
-- Access tokens MUST have a finite lifetime; use JWT or an equivalent
-  short-lived token mechanism
-- Every external API endpoint MUST enforce both authentication and
-  authorisation
-- Internal API endpoints SHOULD require authentication at minimum
-- Write endpoints MUST NOT be accessible without a valid authenticated identity
-
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1554,6 +1111,449 @@ every project regardless of language or framework.
   immediate rotation, and note that session history may be
   cached or logged
 
+
+<!-- templates/frontend/ux.md -->
+# Frontend — UX Principles
+
+[ID: frontend-ux]
+
+## UX principles
+
+- Mobile-first — design for small screens first, enhance for larger ones
+- Progressive disclosure — show only what the user needs at each step
+- No dark patterns — no misleading UI, no forced actions, no hidden costs
+- Consistency — same interaction patterns throughout the product
+- Performance is UX — slow interfaces are bad user experience
+- **Least Surprise**: components and interactions should behave as users
+  expect; if a pattern looks like a button it must act like a button
+
+## Accessibility — WCAG 2.1 AA
+
+- Target standard: WCAG 2.1 AA
+- Minimum text contrast ratio: 4.5:1 (normal text), 3:1 (large text)
+- All interactive elements reachable and operable by keyboard
+- Any non-focusable element (`<th>`, `<div>`, `<span>`) with `onClick` MUST
+  contain a `<button>` — `onClick` alone does not add the element to the tab
+  order or provide keyboard activation
+- Use `:focus-visible` instead of `:focus` for focus indicators —
+  `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
+  shows them only for keyboard navigation
+- Focus indicators must be visible at all times during keyboard navigation
+- No content that relies on colour alone to convey meaning
+- Images must have descriptive `alt` text; decorative images use `alt=""`
+- Semantic HTML: correct landmark elements and heading hierarchy
+- `aria-label` on all interactive elements (buttons, icon links, social links)
+- All `<a>` elements with icon-only or ambiguous text must have a descriptive
+  `aria-label`
+- Keyboard navigation: menus must close on Escape and restore focus
+
+## Accessibility testing
+
+Meeting WCAG 2.1 AA requires both automated and manual testing — automated
+tools catch ~30–40% of issues; the rest require human judgment.
+
+### Automated (run in CI)
+
+- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
+  `jest-axe`; zero violations allowed before merge
+- **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
+  via `lighthouse-ci`
+- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; must be configured in the linter
+
+### Manual (run before shipping new interactive components)
+
+- **Keyboard-only navigation** — tab through the entire feature; every
+  action reachable without a mouse; focus order is logical; no focus traps
+  except intentional modal dialogs
+- **Screen reader** — test with at least one: NVDA + Chrome (Windows),
+  VoiceOver + Safari (macOS / iOS), or TalkBack (Android); verify that
+  all content and state changes are announced correctly
+- **Zoom to 200%** — no content clipped or overlapping at double zoom;
+  horizontal scroll must not appear on a 1280px viewport
+- **High contrast mode** — verify in Windows High Contrast or forced-colors
+  CSS media query; no information lost when colours are overridden
+
+### Criteria for done
+
+A feature is not complete until:
+
+- [ ] `axe-core` reports zero violations in component tests
+- [ ] Lighthouse accessibility score ≥ 90
+- [ ] Keyboard navigation verified manually
+- [ ] Screen reader walkthrough completed for new interactive elements
+
+## Sortable tables
+
+- Boolean columns SHOULD sort descending (true first) on first click ���
+  users click a boolean column to find items that have a feature, not
+  items that lack it; ascending puts `false` first, which looks
+  identical to unsorted and appears broken
+
+## Responsive breakpoints
+
+- Tablet: max-width 1024px
+- Mobile: max-width 768px
+- Small mobile: max-width 480px
+
+## Design system
+
+- Use a design system if one exists for the project — never design ad-hoc
+  components that duplicate established patterns
+- Design tokens (colours, spacing, typography, radii) MUST come from the
+  design system — never hardcode visual values
+- Component-driven development: build UI as a hierarchy of reusable,
+  self-contained components; avoid monolithic views
+- New components SHOULD be documented with usage examples before shipping
+
+## Browser support
+
+[ID: frontend-ux-browsers]
+
+- Default target: last 2 versions of Chrome, Firefox, Safari, and Edge
+- Progressive enhancement: graceful degradation for unsupported features
+
+
+<!-- templates/frontend/quality.md -->
+# Frontend — Quality Attributes
+
+[ID: frontend-quality]
+
+## Patterns
+
+- Use error boundary, skeleton loading, optimistic update, virtual
+  scroll, debounced search, form validation, responsive switch, and
+  URL state sync patterns where appropriate
+
+## Design patterns
+
+Prefer these patterns for frontend concerns:
+
+- **Container / Presentational** — separate data-fetching and state logic
+  (container) from rendering (presentational); presentational components
+  receive only props, have no side effects, and are easy to test in isolation
+- **Custom Hook** — extract reusable stateful logic into a named hook
+  (`use[Name]`); hooks are the frontend equivalent of a service or strategy
+- **Compound Component** — expose a set of related sub-components that share
+  implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
+  prefer over deeply nested prop drilling
+- **Render Props / Slot** — pass render logic as a prop or slot to invert
+  control over what is rendered; use sparingly — prefer custom hooks where possible
+- **Observer** — subscribe to external state changes (store, event bus,
+  WebSocket) via a single subscription point; unsubscribe on component unmount
+- **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
+  behind a thin project-owned interface; never scatter SDK calls across components
+- **Optimistic Update** — apply the expected result of a mutation immediately
+  in the UI and roll back on failure; document the rollback path
+
+Avoid:
+
+- **Mediator / Event Bus** between components — use shared state or lifting
+  state up instead; an event bus between components creates invisible coupling
+
+## State management
+
+Choose the right tool for the scope of the state — do not use a global store
+for state that is local to a component or a server cache for state that is
+never fetched from a server.
+
+| State type          | Tool                     | When to use                                                                          |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
+| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
+| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
+| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
+| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+
+Rules:
+
+- Never duplicate server state in a global store — TanStack Query or SWR is
+  the cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state with
+  a selector or `useMemo`
+- Prefer URL state for anything the user should be able to bookmark or share
+- Keep global store slices small and focused — one slice per domain concern,
+  not one slice for everything
+
+## Linting and formatting
+
+- A linter MUST be configured for all JS/TS code
+- Linter and formatter SHOULD run on save in the IDE — never rely on CI
+  alone to catch style issues
+- No warnings or errors MUST appear in the browser console or test output
+  before a PR is merged — start every review on a clean slate
+- Lint error count SHOULD go down over time — never increase it
+
+## CSS
+
+- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No hardcoded colour or spacing values — always use CSS custom properties
+  from `:root` or design tokens
+- Consistent naming convention (e.g. BEM-like `.component-element`)
+- Maximum line length: 80 characters (exempt: prose strings, third-party URLs)
+
+## Performance
+
+- Preload critical above-the-fold assets
+- Keep client-side JS minimal — every dependency adds to bundle size
+- Avoid unnecessary dependencies
+- Defer non-critical scripts
+- Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
+
+## SEO & analytics
+
+- `robots.txt`, Open Graph, and Twitter Card meta tags required
+- Canonical URLs required
+- Privacy-friendly analytics only — no consent banner required
+- No third-party tracking scripts without explicit user consent
+
+
+<!-- templates/stack/spa-react.md -->
+# Stack — React Single-Page Application
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+
+A client-side React application with TypeScript. Covers component model,
+state management, routing, API integration, and tooling.
+
+---
+
+## Stack
+[ID: react-spa-stack]
+
+- Language: TypeScript (strict mode)
+- Framework: React 18+
+- Bundler: [Vite / Create React App / Next.js]
+- Routing: [React Router v6 / TanStack Router]
+- State: [Zustand / Redux Toolkit / React Query + local state]
+- Styling: [CSS Modules / Tailwind / plain CSS]
+- HTTP client: [fetch / axios / TanStack Query]
+- Test runner: Vitest + React Testing Library
+- Package manager: [npm / pnpm / yarn]
+- Deployment: [Vercel / Netlify / GitHub Pages / Docker]
+
+---
+
+## Project structure
+[ID: react-spa-structure]
+
+```
+src/
+  components/
+    [Feature]/
+      [Feature].tsx
+      [Feature].test.tsx
+      [Feature].module.css   # if using CSS Modules
+  pages/                     # or routes/ — one file per route
+  hooks/                     # custom hooks (use[Name].ts)
+  services/                  # API calls (no business logic in components)
+  store/                     # global state slices
+  types/                     # shared TypeScript types and interfaces
+  utils/                     # pure utility functions
+  App.tsx
+  main.tsx
+public/
+tsconfig.json
+vite.config.ts               # or equivalent
+package.json
+README.md
+CLAUDE.md
+```
+
+---
+
+## TypeScript conventions
+[ID: react-spa-typescript]
+
+- Follow the **TypeScript ESLint** recommended ruleset
+  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
+  enforced by ESLint; do not suppress lint errors without a
+  documented reason
+- **Prettier** owns all formatting decisions — no style discussions in code
+  review; configure once and commit the config
+- `strict: true` in `tsconfig.json` — no exceptions
+- No `any` — use `unknown` and narrow, or define a proper type
+- Explicit return types on all non-trivial functions
+- Use `interface` for object shapes, `type` for unions and aliases
+- Import types with `import type { ... }` to keep runtime bundle clean
+- Enums avoided — use `as const` objects or string literal unions instead
+
+---
+
+## Component conventions
+[ID: react-spa-components]
+
+- One component per file — filename matches component name (PascalCase)
+- Functional components only — no class components
+- Props typed with an explicit `interface` or `type` in the same file
+- No prop drilling beyond two levels — lift state or use context/store
+- Extract reusable logic into custom hooks (`use[Name].ts` in `hooks/`)
+- Keep components small: if a component exceeds ~150 lines, split it
+
+---
+
+## State management
+[ID: react-spa-state]
+
+- Local state (`useState`, `useReducer`) for component-scoped concerns
+- Shared/global state in the chosen store (Zustand slice or Redux slice)
+- Server state (fetched data) managed by React Query / TanStack Query —
+  never duplicate server state in the global store
+- No direct DOM manipulation — all state flows through React
+
+---
+
+## API integration
+[ID: react-spa-api]
+
+- All API calls in `src/services/` — never inline `fetch` in components
+- Return typed response objects — no untyped `any` from API boundaries
+- Handle loading, error, and empty states explicitly in every data-dependent view
+- Never store tokens in `localStorage` — prefer `httpOnly` cookies or memory
+
+---
+
+## Styling
+[ID: react-spa-styling]
+
+- No inline styles except for dynamic/computed values
+- No hardcoded colour or spacing values — use CSS custom properties or
+  design tokens from the chosen system
+- Responsive styles follow a mobile-first approach (per `templates/frontend/ux.md`)
+- Global styles in `src/index.css` only; component styles co-located
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- React Testing Library for component tests — test behaviour, not implementation
+- No `getByTestId` as a first resort — prefer accessible queries
+  (`getByRole`, `getByLabelText`, `getByText`)
+- Vitest for component tests on utils, hooks, and services
+- Mock API calls at the network boundary (`msw`) — not inside components
+- Component test naming: Given/When/Then
+  e.g. `given a logged-out user, when they submit the form, then an error is shown`
+- System tests MUST cover critical user journeys (login, checkout, key flows)
+- System tests SHOULD use Playwright or Cypress — colocated in `tests/system/`
+  at project root
+- Run before every commit: `npm test && tsc --noEmit`
+
+---
+
+## Accessibility
+[EXTEND: frontend-ux]
+
+- All interactive elements must be keyboard-accessible
+- Use semantic HTML — prefer `<button>` over `<div onClick>`
+- Every form input has an associated `<label>`
+- Modals and dialogs trap focus and restore it on close
+- Test with a screen reader before shipping new interactive components
+
+---
+
+## Git conventions
+[EXTEND: base-git]
+
+- Do not commit `node_modules/`, `dist/`, `.env`, `.env.local`
+- Lock file (`package-lock.json` / `pnpm-lock.yaml`) is committed — do not delete it
+- Always run `npm test && tsc --noEmit` before committing
+
+---
+
+## Commands
+```
+npm run dev       # develop — hot reload
+npm run build     # production build
+npm run preview   # preview production build locally
+npm test          # run tests (watch mode)
+tsc --noEmit      # type check without emitting files
+```
+
+<!-- templates/backend/http.md -->
+# Backend — HTTP Conventions
+[ID: backend-http]
+
+## Handler design
+- Handlers are thin: decode request → call service → encode response
+- No business logic in handlers — delegate to a service layer
+- Validate all incoming request data before processing
+
+## URI design
+- Path segments MUST be lowercase with hyphens as word separators —
+  underscores and camelCase are not permitted
+- Paths MUST use nouns, not verbs: `/orders` not `/getOrders`
+- Collection resources MUST use plural nouns: `/orders`, `/products`
+- Individual resources MUST be addressed under their collection:
+  `/orders/{orderId}`
+- Sub-resources MUST be nested under their parent: `/customers/{id}/orders`
+- A URI MUST NOT end with a trailing slash
+- Paths MUST use American English spelling with no abbreviations or acronyms
+
+## Query parameters
+- Query parameter names MUST use camelCase
+- Query parameters MUST be used for filtering, sorting, and pagination —
+  not for resource identity (use path segments for that)
+- The following names are reserved for framework-level use and MUST NOT
+  be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+
+## Request headers
+- All HTTP headers MUST follow Hyphenated-Pascal-Case casing:
+  `Api-Correlation-Id`, `Accept-Language`
+- Custom headers SHOULD NOT use the `X-` prefix — this convention was
+  deprecated by RFC 6648; use a vendor or application-specific prefix instead
+
+## HTTP methods
+| Method | Use for | Idempotent |
+|--------|---------|-----------|
+| GET | Retrieve a resource or collection — no side effects | Yes |
+| POST | Create a new resource — server assigns URI | No |
+| PUT | Replace a resource entirely | Yes |
+| PATCH | Partially update a resource | No |
+| DELETE | Remove a resource | Yes |
+
+## Resource representation
+- JSON MUST be the default serialisation format; XML MAY be used where
+  explicitly required by the consuming system
+- Field types MUST conform to the relevant ISO standard:
+  - Date and time values: ISO 8601
+  - Language codes: ISO 639
+  - Country codes: ISO 3166-1 alpha-2
+  - Currency codes: ISO 4217
+- Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
+  as a string — JavaScript cannot represent larger integers precisely
+- Responses MUST contain only the fields needed by the caller — do not pad
+  payloads with fields that are not consumed
+
+## HATEOAS
+- Embed hyperlinks in responses to enable resource discovery
+- Use a `links` array with `href`, `rel`, `type`, and `media` fields:
+  ```json
+  "links": [
+    {
+      "href": "invoices/f9c3b2a1-0d4e-4f8b-9c7a-1e2d3f4a5b6c",
+      "rel": "invoice",
+      "type": "paymentSummary",
+      "media": "application/pdf"
+    }
+  ]
+  ```
+- Support at minimum: `self`, `next`, `prev` relations on paginated collections
+
+## Error responses
+- Use consistent error response shape across all endpoints
+- Follow RFC 9457 (`application/problem+json`) for error format
+- Use 4xx for client errors, 5xx for server errors — never use 200 for errors
+- Never return stack traces, internal paths, or implementation details to the client
+- Set explicit `Content-Type: application/json` on all JSON responses
+
+## Authentication and authorisation
+- All API traffic MUST be served over HTTPS — plain HTTP is not acceptable
+- Access tokens MUST have a finite lifetime; use JWT or an equivalent
+  short-lived token mechanism
+- Every external API endpoint MUST enforce both authentication and
+  authorisation
+- Internal API endpoints SHOULD require authentication at minimum
+- Write endpoints MUST NOT be accessible without a valid authenticated identity
 
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -848,6 +848,270 @@ fixing the design fixes the testability.
 - Follow `@typescript-eslint/recommended`
 
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
 <!-- templates/frontend/ux.md -->
 # Frontend — UX Principles
 
@@ -1046,7 +1310,7 @@ Rules:
 
 <!-- templates/stack/spa-react.md -->
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -848,6 +848,270 @@ fixing the design fixes the testability.
 - Follow `@typescript-eslint/recommended`
 
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
 <!-- templates/frontend/ux.md -->
 # Frontend — UX Principles
 
@@ -1046,7 +1310,7 @@ Rules:
 
 <!-- templates/stack/spa-svelte.md -->
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1044,9 +1044,273 @@ Rules:
 - No third-party tracking scripts without explicit user consent
 
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
 <!-- templates/stack/spa-svelte.md -->
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.
@@ -1401,360 +1665,6 @@ DEBUG=false
 - Internal API endpoints SHOULD require authentication at minimum
 - Write endpoints MUST NOT be accessible without a valid authenticated identity
 
-<!-- templates/backend/api.md -->
-# Backend — API Design
-[ID: backend-api]
-
-## API-first
-- Software MUST be designed API-first — the public contract MUST be agreed
-  upon and documented before implementation begins
-- Any deviation from API-first design MUST be recorded in an Architecture
-  Decision Record (ADR) with a stated justification
-- Benefits: client teams (web, mobile, third-party) can work in parallel,
-  the API is testable independently of any frontend, and the contract becomes
-  a product in its own right
-
-## Protocol selection
-[ID: backend-api-protocols]
-
-| Protocol  | Use when                                                                                            |
-|-----------|-----------------------------------------------------------------------------------------------------|
-| REST      | Default. External APIs, browser/mobile clients, third-party integrations, ops/admin endpoints       |
-| gRPC      | Internal service-to-service, performance-critical paths, streaming, polyglot teams sharing a schema |
-| GraphQL   | Frontend-facing APIs where clients need flexible querying and over-fetching is a real problem       |
-| WebSocket | Real-time push, bidirectional streams where HTTP polling is not viable                              |
-| Messaging | Async, fire-and-forget, event-driven                                                                        |
-
-- Start with REST — only deviate with a stated reason in an ADR
-- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot paths
-- Never use gRPC as the primary interface for browser clients
-- GraphQL and REST in the same service require strong justification — dual surfaces double the maintenance burden
-- SOAP and other legacy protocols require a per-case ADR
-
-## OpenAPI specification
-- Every API MUST have an OpenAPI specification
-- The spec MUST be kept up to date — a stale spec is worse than no spec
-- Include: all resources, methods, parameters, response schemas, error responses,
-  and authentication requirements
-- Provide a changelog documenting API changes across versions
-
-## Versioning
-- APIs in a given version MUST maintain backward compatibility
-- Version the API in the URI path prefix: `/v1/`, `/v2/`
-- Start versioning from `v1`; introduce `v2` only when breaking changes are
-  unavoidable
-- Alternatively, use a custom request header: `Api-Version: 2`
-- MUST NOT use media type to control API versions
-
-## Backward compatibility
-A new major version is required whenever a breaking change is introduced.
-
-**Breaking changes** — any of the following constitutes a break:
-- Removing or renaming a response field or object
-- Changing the type of an existing field
-- Switching the authentication scheme
-- Modifying an existing HTTP verb or URI path
-- Changing the wire protocol or Content-Type
-- Altering business logic in a way that changes observable results
-
-**Non-breaking changes** — these MUST NOT require a version bump:
-- Adding a new optional field or object to a response
-- Adding a new endpoint or HTTP verb
-- Adding new optional query parameters
-
-## Deprecation strategy
-When a breaking change is introduced:
-
-1. Deploy the new version alongside the old one
-2. Add the `Deprecation` header to all responses from the old version with
-   the Unix timestamp of when deprecation started:
-   `Deprecation: @<unix-timestamp>`
-3. Optionally add the `Sunset` header with the planned removal date:
-   `Sunset: <HTTP-date>`
-4. Notify all consumers and agree on a migration timeline
-5. Remove the old version only after the sunset date has passed
-
-```
-Deprecation: @<unix-timestamp>
-Sunset: <HTTP-date>
-```
-
-## Statelessness
-- APIs MUST be stateless — no client context stored on the server between requests
-- All information needed to process a request MUST be in the request itself
-- Session state belongs in the client or a dedicated session store, not in the
-  API service
-
-## Pagination
-- Collection endpoints MUST be paginated — never return unbounded lists
-- Use `limit` and `offset` (or cursor-based) pagination
-- Include navigation links (`next`, `prev`) in the response per HATEOAS
-
-
-<!-- templates/base/security/security.md -->
-# Base — Application Security
-
-[ID: base-security]
-
-Cross-cutting security rules for application code. Applies to
-every project regardless of language or framework.
-
-
----
-
-## Input validation
-
-[ID: security-input]
-
-- Validate all external input at the system boundary — the first
-  point where untrusted data enters the application
-- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
-  — never hand-write validation for complex inputs
-- Allowlist, not blocklist — define what is valid, reject everything
-  else
-- Reject invalid input with a clear error — do not silently coerce
-  or strip fields
-- Internal code trusts validated data — do not re-validate in
-  service or repository layers
-
----
-
-## Output encoding
-
-[ID: security-output]
-
-- Encode dynamic data for its rendering context at the point of
-  output — HTML, URL, JavaScript, SQL, shell
-- Encode on output, not on input — store the raw value, encode
-  when rendering
-- Use framework-provided encoding: React JSX, Jinja2 autoescape,
-  Go `html/template`, Astro `{expression}`
-- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
-  or `| safe` with user-supplied data
-- Context matters — HTML encoding does not prevent URL injection
-
----
-
-## Injection prevention
-
-[ID: security-injection]
-
-- Use parameterized queries for all database access — never
-  concatenate user input into SQL strings
-- Use prepared statements or ORM query builders — raw SQL with
-  string interpolation is a SQL injection vulnerability
-- Escape shell arguments when invoking external commands — or
-  use API alternatives that do not invoke a shell
-- Never pass user input to `eval()`, `exec()`, `Function()`,
-  or equivalent dynamic code execution
-
----
-
-## Authentication
-
-[ID: security-authn]
-
-- Hash passwords with a modern algorithm: bcrypt, scrypt, or
-  Argon2 — never MD5, SHA-1, or plain SHA-256
-- Enforce minimum password complexity at the boundary
-- Use constant-time comparison for secrets and tokens — timing
-  attacks leak information through response time
-- Support multi-factor authentication for privileged operations
-- Lock accounts or throttle after repeated failed attempts
-
----
-
-## Session management
-
-[ID: security-sessions]
-
-- Generate session IDs with a cryptographic random generator
-- Regenerate the session ID after login — prevents session fixation
-- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
-  `Strict` for sensitive applications)
-- Expire sessions after a reasonable idle period — 30 minutes
-  for sensitive applications, configurable otherwise
-- Invalidate sessions on logout — do not rely on cookie expiry
-  alone
-
----
-
-## Secrets in code
-
-[ID: security-secrets]
-
-- Never hardcode secrets, API keys, tokens, or credentials in
-  source files
-- Never commit secrets to version control — even in test files
-  or example configurations
-- Use `.env` files for local development — add to `.gitignore`
-- Provide `.env.example` with placeholder values — never real
-  secrets
-- If a secret is accidentally committed, rotate it immediately —
-  removing from git history is not sufficient; the secret is
-  compromised
-
----
-
-## Transport security
-
-[ID: security-transport]
-
-- HTTPS everywhere — no exceptions for production traffic
-- HSTS MUST be enabled on all production sites with
-  `includeSubDomains` and a minimum `max-age` of one year
-- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
-- Use strong cipher suites — disable known-weak ciphers
-- Internal service-to-service traffic SHOULD use mTLS via a
-  service mesh or explicit certificate configuration
-
----
-
-## Security headers
-
-[ID: security-headers]
-
-- Set security headers on every HTTP response at the reverse proxy
-  or middleware level — not per route
-- Required headers:
-  - `Content-Security-Policy` — start strict, relax only as needed
-  - `X-Content-Type-Options: nosniff`
-  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
-  - `Strict-Transport-Security` (see Transport security)
-  - `Referrer-Policy: strict-origin-when-cross-origin`
-  - `Permissions-Policy` — disable unused browser APIs
-- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
-  written justification
-- Do not expose server version or technology stack in headers —
-  remove `X-Powered-By`, `Server` version strings
-
----
-
-## Error handling
-
-[ID: security-errors]
-
-- Never expose stack traces, internal paths, or database errors
-  to end users — return generic error messages externally
-- Log full error details server-side for debugging
-- Use consistent error response formats — do not leak internal
-  structure through varying error shapes
-- Return appropriate HTTP status codes — do not use 200 for errors
-- Do not reveal whether a resource exists via error messages —
-  login errors should say "invalid credentials", not "user not
-  found" vs "wrong password"
-
----
-
-## Logging
-
-[ID: security-logging]
-
-- Never log secrets, tokens, passwords, or personally identifiable
-  information (PII)
-- Sanitize log output — user-supplied data in logs can enable
-  log injection attacks
-- Log security-relevant events: authentication attempts, access
-  denials, privilege changes, configuration changes
-- Include enough context for investigation: timestamp, user ID,
-  IP, action, result
-- Retain security logs for a defined period — compliance may
-  require 90 days to 7 years
-
----
-
-## CORS
-
-[ID: security-cors]
-
-- Restrict `Access-Control-Allow-Origin` to specific known
-  origins — never use `*` for authenticated endpoints
-- Do not reflect the `Origin` header back as
-  `Access-Control-Allow-Origin` without validation
-- Restrict allowed methods and headers to what the API actually
-  needs
-- Set `Access-Control-Max-Age` to cache preflight responses —
-  reduces latency and server load
-
----
-
-## Deserialization and data integrity
-
-[ID: security-integrity]
-
-- Never deserialize untrusted data with native serialization
-  formats (Python `pickle`, Java `ObjectInputStream`, PHP
-  `unserialize`) — use safe formats (JSON, Protocol Buffers)
-- Validate the structure and types of deserialized data before
-  use — treat it as untrusted input
-- Verify integrity of downloaded artifacts, updates, and
-  dependencies — use checksums or digital signatures
-- Pin dependency versions and verify checksums in lockfiles —
-  do not trust upstream registries blindly
-- CI/CD pipelines MUST use pinned, verified actions and images —
-  never pull `latest` tags in production pipelines
-
----
-
-## Server-Side Request Forgery (SSRF)
-
-[ID: security-ssrf]
-
-- Never pass user-supplied URLs directly to server-side HTTP
-  clients — validate and sanitize first
-- Allowlist permitted destination hosts and schemes — reject
-  anything not on the list
-- Block requests to internal networks (`127.0.0.0/8`,
-  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
-  `::1`, `fc00::/7`) — even after DNS resolution
-- Resolve the hostname and validate the IP before making the
-  request — prevents DNS rebinding attacks
-- Disable HTTP redirects in server-side HTTP clients, or
-  re-validate the destination after each redirect
-- Limit response size and timeout for outbound requests to
-  prevent resource exhaustion
-
----
-
-## File uploads
-
-[ID: security-uploads]
-
-- Validate file type by content (magic bytes), not by extension
-  or MIME type — both are trivially spoofed
-- Enforce maximum file size at the boundary
-- Store uploads outside the web root — never serve user uploads
-  from the same domain without sanitization
-- Generate random filenames — do not use the original filename
-  (path traversal risk)
-- Scan uploaded files for malware if the application serves them
-  to other users
-
----
-
-## Agent secrets handling
-
-[ID: security-agent-secrets]
-
-- MUST NOT read, print, or cat files that may contain secrets:
-  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
-  `serviceaccount.json`, `secrets.yaml`
-- MUST NOT echo, log, or display environment variable values —
-  use `printenv | grep -c KEY` to check presence without
-  revealing the value
-- MUST NOT include secret values in commit messages, PR
-  descriptions, or conversation output
-- MUST warn the user before committing files that commonly
-  contain secrets (`.env`, `credentials.json`, private keys)
-- Use targeted commands to verify secret presence without
-  exposure: `grep -c PATTERN file` (count matches),
-  `test -f .env && echo exists` (check file existence)
-- If secrets are accidentally exposed in a session, immediately
-  flag to the user: name the exposed secret, recommend
-  immediate rotation, and note that session history may be
-  cached or logged
-
-
 <!-- templates/backend/auth.md -->
 # Backend — Authentication and Authorization
 [ID: backend-auth]
@@ -2007,7 +1917,7 @@ not after deployment.
 
 <!-- templates/stack/full-sveltekit.md -->
 # Stack — SvelteKit Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-svelte.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-svelte.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/auth.md]
 
 Extends the Svelte stack with SvelteKit-specific rules. Covers file-based
 routing, server-side rendering, API routes, form actions, and deployment

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -809,7 +809,7 @@ fixing the design fixes the testability.
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site
 [ID: frontend-static-site]
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 Abstract rules for any static site generated at build time and served as
 plain HTML, CSS, and minimal JavaScript. Never used directly — always

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -848,6 +848,270 @@ fixing the design fixes the testability.
 - Follow `@typescript-eslint/recommended`
 
 
+<!-- templates/base/security/security.md -->
+# Base — Application Security
+
+[ID: base-security]
+
+Cross-cutting security rules for application code. Applies to
+every project regardless of language or framework.
+
+
+---
+
+## Input validation
+
+[ID: security-input]
+
+- Validate all external input at the system boundary — the first
+  point where untrusted data enters the application
+- Use schema validation libraries (Zod, Joi, Pydantic, JSON Schema)
+  — never hand-write validation for complex inputs
+- Allowlist, not blocklist — define what is valid, reject everything
+  else
+- Reject invalid input with a clear error — do not silently coerce
+  or strip fields
+- Internal code trusts validated data — do not re-validate in
+  service or repository layers
+
+---
+
+## Output encoding
+
+[ID: security-output]
+
+- Encode dynamic data for its rendering context at the point of
+  output — HTML, URL, JavaScript, SQL, shell
+- Encode on output, not on input — store the raw value, encode
+  when rendering
+- Use framework-provided encoding: React JSX, Jinja2 autoescape,
+  Go `html/template`, Astro `{expression}`
+- Never use `innerHTML`, `set:html`, `dangerouslySetInnerHTML`,
+  or `| safe` with user-supplied data
+- Context matters — HTML encoding does not prevent URL injection
+
+---
+
+## Injection prevention
+
+[ID: security-injection]
+
+- Use parameterized queries for all database access — never
+  concatenate user input into SQL strings
+- Use prepared statements or ORM query builders — raw SQL with
+  string interpolation is a SQL injection vulnerability
+- Escape shell arguments when invoking external commands — or
+  use API alternatives that do not invoke a shell
+- Never pass user input to `eval()`, `exec()`, `Function()`,
+  or equivalent dynamic code execution
+
+---
+
+## Authentication
+
+[ID: security-authn]
+
+- Hash passwords with a modern algorithm: bcrypt, scrypt, or
+  Argon2 — never MD5, SHA-1, or plain SHA-256
+- Enforce minimum password complexity at the boundary
+- Use constant-time comparison for secrets and tokens — timing
+  attacks leak information through response time
+- Support multi-factor authentication for privileged operations
+- Lock accounts or throttle after repeated failed attempts
+
+---
+
+## Session management
+
+[ID: security-sessions]
+
+- Generate session IDs with a cryptographic random generator
+- Regenerate the session ID after login — prevents session fixation
+- Set cookie flags: `HttpOnly`, `Secure`, `SameSite=Lax` (or
+  `Strict` for sensitive applications)
+- Expire sessions after a reasonable idle period — 30 minutes
+  for sensitive applications, configurable otherwise
+- Invalidate sessions on logout — do not rely on cookie expiry
+  alone
+
+---
+
+## Secrets in code
+
+[ID: security-secrets]
+
+- Never hardcode secrets, API keys, tokens, or credentials in
+  source files
+- Never commit secrets to version control — even in test files
+  or example configurations
+- Use `.env` files for local development — add to `.gitignore`
+- Provide `.env.example` with placeholder values — never real
+  secrets
+- If a secret is accidentally committed, rotate it immediately —
+  removing from git history is not sufficient; the secret is
+  compromised
+
+---
+
+## Transport security
+
+[ID: security-transport]
+
+- HTTPS everywhere — no exceptions for production traffic
+- HSTS MUST be enabled on all production sites with
+  `includeSubDomains` and a minimum `max-age` of one year
+- TLS 1.2 is the minimum version — disable TLS 1.0 and 1.1
+- Use strong cipher suites — disable known-weak ciphers
+- Internal service-to-service traffic SHOULD use mTLS via a
+  service mesh or explicit certificate configuration
+
+---
+
+## Security headers
+
+[ID: security-headers]
+
+- Set security headers on every HTTP response at the reverse proxy
+  or middleware level — not per route
+- Required headers:
+  - `Content-Security-Policy` — start strict, relax only as needed
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY` (or CSP `frame-ancestors`)
+  - `Strict-Transport-Security` (see Transport security)
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` — disable unused browser APIs
+- Never use `unsafe-inline` or `unsafe-eval` in CSP without a
+  written justification
+- Do not expose server version or technology stack in headers —
+  remove `X-Powered-By`, `Server` version strings
+
+---
+
+## Error handling
+
+[ID: security-errors]
+
+- Never expose stack traces, internal paths, or database errors
+  to end users — return generic error messages externally
+- Log full error details server-side for debugging
+- Use consistent error response formats — do not leak internal
+  structure through varying error shapes
+- Return appropriate HTTP status codes — do not use 200 for errors
+- Do not reveal whether a resource exists via error messages —
+  login errors should say "invalid credentials", not "user not
+  found" vs "wrong password"
+
+---
+
+## Logging
+
+[ID: security-logging]
+
+- Never log secrets, tokens, passwords, or personally identifiable
+  information (PII)
+- Sanitize log output — user-supplied data in logs can enable
+  log injection attacks
+- Log security-relevant events: authentication attempts, access
+  denials, privilege changes, configuration changes
+- Include enough context for investigation: timestamp, user ID,
+  IP, action, result
+- Retain security logs for a defined period — compliance may
+  require 90 days to 7 years
+
+---
+
+## CORS
+
+[ID: security-cors]
+
+- Restrict `Access-Control-Allow-Origin` to specific known
+  origins — never use `*` for authenticated endpoints
+- Do not reflect the `Origin` header back as
+  `Access-Control-Allow-Origin` without validation
+- Restrict allowed methods and headers to what the API actually
+  needs
+- Set `Access-Control-Max-Age` to cache preflight responses —
+  reduces latency and server load
+
+---
+
+## Deserialization and data integrity
+
+[ID: security-integrity]
+
+- Never deserialize untrusted data with native serialization
+  formats (Python `pickle`, Java `ObjectInputStream`, PHP
+  `unserialize`) — use safe formats (JSON, Protocol Buffers)
+- Validate the structure and types of deserialized data before
+  use — treat it as untrusted input
+- Verify integrity of downloaded artifacts, updates, and
+  dependencies — use checksums or digital signatures
+- Pin dependency versions and verify checksums in lockfiles —
+  do not trust upstream registries blindly
+- CI/CD pipelines MUST use pinned, verified actions and images —
+  never pull `latest` tags in production pipelines
+
+---
+
+## Server-Side Request Forgery (SSRF)
+
+[ID: security-ssrf]
+
+- Never pass user-supplied URLs directly to server-side HTTP
+  clients — validate and sanitize first
+- Allowlist permitted destination hosts and schemes — reject
+  anything not on the list
+- Block requests to internal networks (`127.0.0.0/8`,
+  `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`,
+  `::1`, `fc00::/7`) — even after DNS resolution
+- Resolve the hostname and validate the IP before making the
+  request — prevents DNS rebinding attacks
+- Disable HTTP redirects in server-side HTTP clients, or
+  re-validate the destination after each redirect
+- Limit response size and timeout for outbound requests to
+  prevent resource exhaustion
+
+---
+
+## File uploads
+
+[ID: security-uploads]
+
+- Validate file type by content (magic bytes), not by extension
+  or MIME type — both are trivially spoofed
+- Enforce maximum file size at the boundary
+- Store uploads outside the web root — never serve user uploads
+  from the same domain without sanitization
+- Generate random filenames — do not use the original filename
+  (path traversal risk)
+- Scan uploaded files for malware if the application serves them
+  to other users
+
+---
+
+## Agent secrets handling
+
+[ID: security-agent-secrets]
+
+- MUST NOT read, print, or cat files that may contain secrets:
+  `.env`, `credentials.json`, `*-key*`, `*.pem`, `*.key`,
+  `serviceaccount.json`, `secrets.yaml`
+- MUST NOT echo, log, or display environment variable values —
+  use `printenv | grep -c KEY` to check presence without
+  revealing the value
+- MUST NOT include secret values in commit messages, PR
+  descriptions, or conversation output
+- MUST warn the user before committing files that commonly
+  contain secrets (`.env`, `credentials.json`, private keys)
+- Use targeted commands to verify secret presence without
+  exposure: `grep -c PATTERN file` (count matches),
+  `test -f .env && echo exists` (check file existence)
+- If secrets are accidentally exposed in a session, immediately
+  flag to the user: name the exposed secret, recommend
+  immediate rotation, and note that session history may be
+  cached or logged
+
+
 <!-- templates/frontend/ux.md -->
 # Frontend — UX Principles
 
@@ -1046,7 +1310,7 @@ Rules:
 
 <!-- templates/stack/spa-vue.md -->
 # Stack — Vue Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Vue application with TypeScript. Covers the Composition API,
 component model, state management with Pinia, routing, API integration,

--- a/templates/frontend/static-site.md
+++ b/templates/frontend/static-site.md
@@ -1,6 +1,6 @@
 # Frontend — Static Site
 [ID: frontend-static-site]
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 Abstract rules for any static site generated at build time and served as
 plain HTML, CSS, and minimal JavaScript. Never used directly — always

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -111,7 +111,7 @@ frontend:
     file: templates/frontend/static-site.md
     description: Abstract SSG rules — content, assets, SEO
     depends_on:
-      [base-git, base-docs, base-quality, frontend-ux, frontend-quality]
+      [base-git, base-docs, base-quality, base-security, frontend-ux, frontend-quality]
 
 backend:
   - id: base-config
@@ -180,6 +180,10 @@ stacks:
     layer: hypermedia
     description: HTMX 2.x, Alpine.js, SSE, OOB swaps, partial responses
     depends_on:
+      - base-git
+      - base-docs
+      - base-quality
+      - base-config
       - backend-templating
 
   - id: stack-astro
@@ -211,6 +215,7 @@ stacks:
       - base-docs
       - base-quality
       - base-typescript
+      - base-security
       - frontend-ux
       - frontend-quality
 
@@ -231,6 +236,8 @@ stacks:
       - backend-http
       - backend-api
       - backend-auth
+      - backend-database
+      - backend-observability
       - base-cicd
       - base-devsecops
 
@@ -300,6 +307,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-testing
 
   - id: stack-go-service
     file: templates/stack/go-service.md
@@ -337,6 +345,7 @@ stacks:
       - base-docs
       - base-quality
       - base-typescript
+      - base-security
       - frontend-ux
       - frontend-quality
 
@@ -350,6 +359,7 @@ stacks:
       - base-docs
       - base-quality
       - base-typescript
+      - base-security
       - frontend-ux
       - frontend-quality
 
@@ -368,7 +378,6 @@ stacks:
       - stack-svelte
       - base-config
       - backend-http
-      - backend-api
       - backend-auth
       - base-cicd
       - base-devsecops
@@ -458,7 +467,6 @@ stacks:
       - base-config
       - backend-jobs
       - backend-observability
-      - backend-messaging
       - backend-quality
       - base-cicd
       - base-devsecops
@@ -471,7 +479,7 @@ stacks:
     description: gRPC service, bufconn, errgroup
     depends_on:
       - stack-go-lib
-      - stack-go-service
+      - base-config
       - backend-grpc
       - backend-concurrency
       - base-cicd
@@ -502,6 +510,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-testing
       - base-config
       - backend-grpc
       - backend-concurrency

--- a/templates/stack/full-nextjs.md
+++ b/templates/stack/full-nextjs.md
@@ -1,5 +1,5 @@
 # Stack — Next.js Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-react.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-react.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md, templates/backend/database.md, templates/backend/observability.md]
 
 Extends the React SPA stack with Next.js-specific rules. Covers the App
 Router, Server and Client Components, data fetching, API routes, metadata,

--- a/templates/stack/full-sveltekit.md
+++ b/templates/stack/full-sveltekit.md
@@ -1,5 +1,5 @@
 # Stack — SvelteKit Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-svelte.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/api.md, templates/backend/auth.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md, templates/stack/spa-svelte.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/auth.md]
 
 Extends the Svelte stack with SvelteKit-specific rules. Covers file-based
 routing, server-side rendering, API routes, form actions, and deployment

--- a/templates/stack/go-grpc.md
+++ b/templates/stack/go-grpc.md
@@ -1,7 +1,7 @@
 # Stack — gRPC Service (Go)
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md, templates/stack/go-service.md]
+[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
 
-Extends the Go service stack and the gRPC backend layer with Go-specific
+Extends the Go library stack and the gRPC backend layer with Go-specific
 conventions for implementing gRPC servers and clients.
 
 ---
@@ -20,7 +20,7 @@ conventions for implementing gRPC servers and clients.
 ---
 
 ## Project structure
-[OVERRIDE: go-service-structure]
+[ID: grpc-go-structure]
 
 ```
 cmd/

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -1,5 +1,5 @@
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by `templates/stack/go-service.md`.

--- a/templates/stack/htmx.md
+++ b/templates/stack/htmx.md
@@ -1,5 +1,5 @@
 # Stack — HTMX
-[DEPENDS ON: templates/backend/templating.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/templating.md]
 
 Extends server-side templating with HTMX hypermedia conventions. Covers swap
 strategies, triggers, out-of-band updates, server-sent events, Alpine.js

--- a/templates/stack/java-grpc.md
+++ b/templates/stack/java-grpc.md
@@ -1,5 +1,5 @@
 # Stack — gRPC Service (Java / Kotlin)
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/core/config.md, templates/backend/grpc.md, templates/backend/concurrency.md]
 
 Extends the gRPC backend layer with Java/Kotlin-specific conventions for
 implementing gRPC servers and clients using grpc-java.

--- a/templates/stack/python-celery-worker.md
+++ b/templates/stack/python-celery-worker.md
@@ -1,5 +1,5 @@
 # Stack — Celery Worker
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/jobs.md, templates/backend/observability.md, templates/backend/messaging.md, templates/backend/quality.md, templates/stack/python-lib.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/jobs.md, templates/backend/observability.md, templates/backend/quality.md, templates/stack/python-lib.md]
 
 A standalone Celery worker process. No HTTP layer — purely a background task
 processor. Covers task design, retry/backoff, scheduling, observability,

--- a/templates/stack/spa-react.md
+++ b/templates/stack/spa-react.md
@@ -1,5 +1,5 @@
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.

--- a/templates/stack/spa-svelte.md
+++ b/templates/stack/spa-svelte.md
@@ -1,5 +1,5 @@
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.

--- a/templates/stack/spa-vue.md
+++ b/templates/stack/spa-vue.md
@@ -1,5 +1,5 @@
 # Stack — Vue Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Vue application with TypeScript. Covers the Composition API,
 component model, state management with Pinia, routing, API integration,


### PR DESCRIPTION
## Summary

- **#274** — Fix wrong dependency chains:
  - `go-grpc`: remove `go-service` (pulls REST/DB/messaging for a pure gRPC service), depend on `go-lib` directly
  - `celery-worker`: remove `backend-messaging` (Celery is a job queue, not a message broker)
  - `sveltekit`: remove `backend-api` (BFF routes don't need OpenAPI/versioning)
- **#271** — Fix missing dependencies:
  - `htmx`: add `base-git`, `base-docs`, `base-quality`, `base-config`
  - React/Vue/Svelte SPAs + `frontend-static-site`: add `base-security`
  - `nextjs`: add `backend-database`, `backend-observability`
  - `go-lib`, `java-grpc`: add `base-testing` (both use `[EXTEND: base-testing]`)

## Test plan

- [x] `py tools/sync.py` — generated files regenerated
- [x] `py tests/run_smoke.py` — all 11 checks pass

Closes #271
Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)