### PR TITLE
fix: clean framework-specific content from shared templates (#265, #266, #267, #273)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -56,7 +56,8 @@ base/
 │   ├── review.md       # Peer review priority, MUST/SHOULD checklists, deviation rules
 │   ├── testing.md      # Test pyramid, coverage thresholds, naming conventions
 │   ├── agents.md       # Output structure, models (inline/reference/hybrid), formatting rules
-│   └── readme.md       # README structure, badges, quick start, contribution guide
+│   ├── readme.md       # README structure, badges, quick start, contribution guide
+│   └── oop.md          # SOLID, OOP, GoF design patterns, AOP guidance
 ├── security/
 │   ├── devsecops.md    # SAST, SCA, SBOM, secret detection, license compliance
 │   └── security.md     # Application security rules — input, output, injection, auth, sessions, TLS, headers

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/frontend/static-site.md -->
@@ -995,6 +910,16 @@ to change.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/static-site-astro.md -->

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/c-embedded.md -->

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1081,6 +996,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Distinguish between client errors (4xx) and server errors (5xx) in logs
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
 
 <!-- templates/base/security/security.md -->
 # Base — Application Security
@@ -1399,7 +1378,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1429,6 +1408,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1153,6 +1068,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1470,7 +1449,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1500,6 +1479,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1639,6 +1564,70 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/infra/containers.md -->
 # Base — Containers
 [ID: base-containers]
@@ -1692,7 +1681,7 @@ security template with backend-specific depth.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1722,6 +1711,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1153,6 +1068,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1470,7 +1449,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1500,6 +1479,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1153,6 +1068,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1470,7 +1449,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1500,6 +1479,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/backend/http.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/go-lib.md -->
@@ -1266,6 +1181,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1583,7 +1562,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1613,6 +1592,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/go-lib.md -->

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/go-lib.md -->
@@ -1266,6 +1181,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1583,7 +1562,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1613,6 +1592,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/go-lib.md -->

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/frontend/static-site.md -->

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1639,6 +1564,70 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/infra/containers.md -->
 # Base — Containers
 [ID: base-containers]
@@ -1692,7 +1681,7 @@ security template with backend-specific depth.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1722,6 +1711,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/frontend/ux.md -->
@@ -890,12 +815,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -993,20 +921,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1022,7 +949,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1036,12 +963,77 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/security/security.md -->
@@ -1310,7 +1302,7 @@ every project regardless of language or framework.
 
 <!-- templates/stack/spa-react.md -->
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.
@@ -1363,19 +1355,11 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: react-spa-typescript]
+[EXTEND: base-typescript]
 
-- Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
-  enforced by ESLint; do not suppress lint errors without a
-  documented reason
+- `eslint-plugin-sonarjs` MUST be included in the ESLint config
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
-- Explicit return types on all non-trivial functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions instead
 
 ---
 
@@ -1394,10 +1378,16 @@ CLAUDE.md
 ## State management
 [ID: react-spa-state]
 
-- Local state (`useState`, `useReducer`) for component-scoped concerns
-- Shared/global state in the chosen store (Zustand slice or Redux slice)
-- Server state (fetched data) managed by React Query / TanStack Query —
-  never duplicate server state in the global store
+| State type          | Tool                     | When to use                            |
+| ------------------- | ------------------------ | -------------------------------------- |
+| **Local UI state**  | `useState`, `useReducer` | Form inputs, toggles, counters         |
+| **Shared UI state** | Zustand / Redux Toolkit  | Auth session, sidebar, active filters  |
+| **Server state**    | TanStack Query / SWR     | Lists, detail views, paginated results |
+| **Form state**      | React Hook Form / Formik | Validation, field arrays, multi-step   |
+| **URL state**       | Router search params     | Bookmarkable filters, pagination, tabs |
+
+- Never duplicate server state in the global store — TanStack Query or SWR
+  is the cache; the store holds only client-owned state
 - No direct DOM manipulation — all state flows through React
 
 ---

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/nodejs-lib.md -->

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1153,6 +1068,70 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 
@@ -1470,7 +1449,7 @@ every project regardless of language or framework.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1500,6 +1479,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,80 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/security/security.md -->
@@ -1154,12 +1143,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -1257,20 +1249,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1286,7 +1277,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1300,17 +1291,18 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
 
 
 <!-- templates/stack/spa-react.md -->
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.
@@ -1363,19 +1355,11 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: react-spa-typescript]
+[EXTEND: base-typescript]
 
-- Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
-  enforced by ESLint; do not suppress lint errors without a
-  documented reason
+- `eslint-plugin-sonarjs` MUST be included in the ESLint config
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
-- Explicit return types on all non-trivial functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions instead
 
 ---
 
@@ -1394,10 +1378,16 @@ CLAUDE.md
 ## State management
 [ID: react-spa-state]
 
-- Local state (`useState`, `useReducer`) for component-scoped concerns
-- Shared/global state in the chosen store (Zustand slice or Redux slice)
-- Server state (fetched data) managed by React Query / TanStack Query —
-  never duplicate server state in the global store
+| State type          | Tool                     | When to use                            |
+| ------------------- | ------------------------ | -------------------------------------- |
+| **Local UI state**  | `useState`, `useReducer` | Form inputs, toggles, counters         |
+| **Shared UI state** | Zustand / Redux Toolkit  | Auth session, sidebar, active filters  |
+| **Server state**    | TanStack Query / SWR     | Lists, detail views, paginated results |
+| **Form state**      | React Hook Form / Formik | Validation, field arrays, multi-step   |
+| **URL state**       | Router search params     | Bookmarkable filters, pagination, tabs |
+
+- Never duplicate server state in the global store — TanStack Query or SWR
+  is the cache; the store holds only client-owned state
 - No direct DOM manipulation — all state flows through React
 
 ---

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,70 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +825,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/security/security.md -->
@@ -1154,12 +1143,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -1257,20 +1249,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1286,7 +1277,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1300,17 +1291,18 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
 
 
 <!-- templates/stack/spa-react.md -->
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.
@@ -1363,19 +1355,11 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: react-spa-typescript]
+[EXTEND: base-typescript]
 
-- Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
-  enforced by ESLint; do not suppress lint errors without a
-  documented reason
+- `eslint-plugin-sonarjs` MUST be included in the ESLint config
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
-- Explicit return types on all non-trivial functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions instead
 
 ---
 
@@ -1394,10 +1378,16 @@ CLAUDE.md
 ## State management
 [ID: react-spa-state]
 
-- Local state (`useState`, `useReducer`) for component-scoped concerns
-- Shared/global state in the chosen store (Zustand slice or Redux slice)
-- Server state (fetched data) managed by React Query / TanStack Query —
-  never duplicate server state in the global store
+| State type          | Tool                     | When to use                            |
+| ------------------- | ------------------------ | -------------------------------------- |
+| **Local UI state**  | `useState`, `useReducer` | Form inputs, toggles, counters         |
+| **Shared UI state** | Zustand / Redux Toolkit  | Auth session, sidebar, active filters  |
+| **Server state**    | TanStack Query / SWR     | Lists, detail views, paginated results |
+| **Form state**      | React Hook Form / Formik | Validation, field arrays, multi-step   |
+| **URL state**       | Router search params     | Bookmarkable filters, pagination, tabs |
+
+- Never duplicate server state in the global store — TanStack Query or SWR
+  is the cache; the store holds only client-owned state
 - No direct DOM manipulation — all state flows through React
 
 ---

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/rust-lib.md -->

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/core/config.md -->
@@ -1597,6 +1512,70 @@ security template with backend-specific depth.
 - Test token revocation: assert that a revoked refresh token cannot obtain
   a new access token
 
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
+
+
 <!-- templates/base/infra/containers.md -->
 # Base — Containers
 [ID: base-containers]
@@ -1650,7 +1629,7 @@ security template with backend-specific depth.
 <!-- templates/backend/quality.md -->
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -1680,6 +1659,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,70 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +825,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/security/security.md -->
@@ -1154,12 +1143,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -1257,20 +1249,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1286,7 +1277,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1300,17 +1291,18 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
 
 
 <!-- templates/stack/spa-svelte.md -->
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +761,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/frontend/ux.md -->
@@ -890,12 +815,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -993,20 +921,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1022,7 +949,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1036,12 +963,77 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/security/security.md -->
@@ -1310,7 +1302,7 @@ every project regardless of language or framework.
 
 <!-- templates/stack/spa-svelte.md -->
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/infra/cicd.md -->

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,6 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/frontend/static-site.md -->
@@ -995,6 +910,16 @@ to change.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/stack/static-site-astro.md -->

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -5,36 +5,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -45,61 +22,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 
@@ -650,19 +572,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -798,12 +719,70 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic
+
+
+<!-- templates/base/core/oop.md -->
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not
 
 
 <!-- templates/base/language/typescript.md -->
@@ -846,6 +825,16 @@ fixing the design fixes the testability.
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic
 
 
 <!-- templates/base/security/security.md -->
@@ -1154,12 +1143,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 
@@ -1257,20 +1249,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -1286,7 +1277,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -1300,17 +1291,18 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
 
 
 <!-- templates/stack/spa-vue.md -->
 # Stack — Vue Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Vue application with TypeScript. Covers the Composition API,
 component model, state management with Pinia, routing, API integration,

--- a/templates/backend/quality.md
+++ b/templates/backend/quality.md
@@ -1,6 +1,6 @@
 # Backend — Quality Attributes
 [ID: backend-quality]
-[DEPENDS ON: templates/base/core/quality.md, templates/base/security/security.md, templates/base/infra/containers.md]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/oop.md, templates/base/security/security.md, templates/base/infra/containers.md]
 
 ## Layered architecture
 - Enforce a strict handler → service → repository separation
@@ -30,6 +30,29 @@ Prefer these patterns for backend concerns:
   write to an outbox table in the same transaction and relay asynchronously
 - **CQRS** — separate read models from write models when query and command
   requirements diverge significantly; do not apply by default
+
+## Disposability
+
+- Processes MUST start fast — minimize initialization time
+- Processes MUST shut down gracefully on `SIGTERM` — finish
+  in-flight work, release resources, then exit
+- Set a shutdown timeout — if graceful shutdown exceeds the
+  deadline, force-exit
+- Design for crash safety — the system MUST recover cleanly if
+  a process is killed without warning (`SIGKILL`, power loss)
+- Do not store state in-process — use external stores (database,
+  cache, queue) so processes are disposable and replaceable
+
+## Admin processes
+
+- One-off tasks (migrations, data fixes, REPL sessions) MUST run
+  in the same environment as the application — same code, same
+  config, same dependencies
+- Admin scripts MUST be committed to the repository — not run
+  from ad-hoc shell commands
+- Prefer idempotent scripts — safe to re-run without side effects
+- Never run admin tasks directly against production without a
+  tested rollback plan
 
 ## Security
 [EXTEND: security-input]

--- a/templates/base/core/oop.md
+++ b/templates/base/core/oop.md
@@ -1,0 +1,61 @@
+# Base — Object-Oriented Design
+
+[ID: base-oop]
+
+## SOLID principles
+
+Apply SOLID at the class, module, and service level:
+
+- **S — Single Responsibility**: every class or module has exactly one reason
+  to change; split anything that serves more than one concern
+- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
+  existing code; use interfaces, abstract base classes, or composition
+- **L — Liskov Substitution**: subtypes must be fully substitutable for their
+  base type without altering correctness; never override a method in a way
+  that weakens its contract
+- **I — Interface Segregation**: prefer many small, focused interfaces over
+  one large general-purpose one; callers should not depend on methods they
+  do not use
+- **D — Dependency Inversion**: depend on abstractions, not concretions;
+  inject dependencies rather than instantiating them inside a class
+
+## OOP
+
+- Prefer **composition over inheritance** — inherit only to model a true
+  is-a relationship; compose for code reuse
+- **Encapsulate** implementation details — expose behaviour through a public
+  interface, hide state and implementation
+- Design to interfaces (or protocols / abstract base classes), not concrete
+  types
+- Keep class hierarchies shallow — more than two levels of inheritance is a
+  signal to refactor towards composition
+
+## Design patterns
+
+- Apply established **GoF design patterns** where they fit the problem —
+  do not invent ad-hoc solutions for problems that have named solutions
+- Favour **behavioural patterns** for algorithm variation:
+  Strategy, Command, Observer, Template Method
+- Favour **structural patterns** for object composition:
+  Adapter, Decorator, Facade, Proxy
+- Use **creational patterns** to decouple object creation:
+  Factory Method, Abstract Factory, Builder
+- Use **Singleton** only for stateless services or infrastructure objects
+  (logger, config) — never for mutable shared state
+- Name the pattern in code when you use one: a class named
+  `OrderExportStrategy` communicates intent; a class named `OrderHelper`
+  does not
+
+## Aspect-Oriented Programming (AOP)
+
+- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
+  interception, bytecode weaving, runtime proxies) makes code hard to read,
+  debug, and test
+- Implement cross-cutting concerns explicitly:
+  - Logging: call the logger directly in the function
+  - Auth: explicit middleware or guard in the call chain
+  - Transactions: explicit context manager or decorator with visible
+    call site
+  - Validation: explicit call at the boundary
+- Transparent decorators (a decorator that wraps and clearly delegates) are
+  acceptable; opaque interceptors that inject hidden behaviour are not

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -4,36 +4,13 @@
 
 ## Architecture
 
-- All editable content in a data directory — never hardcoded in components
+- All editable content in a data directory — never hardcoded in source modules
 - Never hardcode derived counts or statistics — compute them from the data
   source; a hardcoded number is a stale number
-- Default to the simplest component type; only reach for heavier abstractions
+- Default to the simplest abstraction; only reach for heavier patterns
   when genuinely needed
-- No dead code — remove unused components, styles, and data files promptly
+- No dead code — remove unused modules, assets, and data files promptly
 - No over-engineering — build the minimum needed for the current requirement
-
-## Disposability
-
-- Processes MUST start fast — minimize initialization time
-- Processes MUST shut down gracefully on `SIGTERM` — finish
-  in-flight work, release resources, then exit
-- Set a shutdown timeout — if graceful shutdown exceeds the
-  deadline, force-exit
-- Design for crash safety — the system MUST recover cleanly if
-  a process is killed without warning (`SIGKILL`, power loss)
-- Do not store state in-process — use external stores (database,
-  cache, queue) so processes are disposable and replaceable
-
-## Admin processes
-
-- One-off tasks (migrations, data fixes, REPL sessions) MUST run
-  in the same environment as the application — same code, same
-  config, same dependencies
-- Admin scripts MUST be committed to the repository — not run
-  from ad-hoc shell commands
-- Prefer idempotent scripts — safe to re-run without side effects
-- Never run admin tasks directly against production without a
-  tested rollback plan
 
 ## Core principles
 
@@ -44,61 +21,6 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
-
-## SOLID principles
-
-Apply SOLID at the class, module, and service level:
-
-- **S — Single Responsibility**: every class or module has exactly one reason
-  to change; split anything that serves more than one concern
-- **O — Open/Closed**: extend behaviour by adding new code, not by modifying
-  existing code; use interfaces, abstract base classes, or composition
-- **L — Liskov Substitution**: subtypes must be fully substitutable for their
-  base type without altering correctness; never override a method in a way
-  that weakens its contract
-- **I — Interface Segregation**: prefer many small, focused interfaces over
-  one large general-purpose one; callers should not depend on methods they
-  do not use
-- **D — Dependency Inversion**: depend on abstractions, not concretions;
-  inject dependencies rather than instantiating them inside a class
-
-## OOP
-
-- Prefer **composition over inheritance** — inherit only to model a true
-  is-a relationship; compose for code reuse
-- **Encapsulate** implementation details — expose behaviour through a public
-  interface, hide state and implementation
-- Design to interfaces (or protocols / abstract base classes), not concrete types
-- Keep class hierarchies shallow — more than two levels of inheritance is a
-  signal to refactor towards composition
-
-## Design patterns
-
-- Apply established **GoF design patterns** where they fit the problem —
-  do not invent ad-hoc solutions for problems that have named solutions
-- Favour **behavioural patterns** for algorithm variation:
-  Strategy, Command, Observer, Template Method
-- Favour **structural patterns** for object composition:
-  Adapter, Decorator, Facade, Proxy
-- Use **creational patterns** to decouple object creation:
-  Factory Method, Abstract Factory, Builder
-- Use **Singleton** only for stateless services or infrastructure objects
-  (logger, config) — never for mutable shared state
-- Name the pattern in code when you use one: a class named `OrderExportStrategy`
-  communicates intent; a class named `OrderHelper` does not
-
-## Aspect-Oriented Programming (AOP)
-
-- **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
-  interception, bytecode weaving, runtime proxies) makes code hard to read,
-  debug, and test
-- Implement cross-cutting concerns explicitly:
-  - Logging → call the logger directly in the function
-  - Auth → explicit middleware or guard in the call chain
-  - Transactions → explicit context manager or decorator with visible call site
-  - Validation → explicit call at the boundary
-- Transparent decorators (a decorator that wraps and clearly delegates) are
-  acceptable; opaque interceptors that inject hidden behaviour are not
 
 ## Readability
 

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -51,19 +51,18 @@ communication partner). Mocks MUST NOT substitute the dependency being
 integrated — they MAY be used for unrelated dependencies outside the scope
 of the test.
 
-Configuration MAY be sourced from the product manual when the integration
-requires a formally defined input (e.g. a communication configuration packet).
-This does not change the classification — the boundary crossed determines the
-type, not the asset used.
+Configuration MAY be sourced from the product specification when the
+integration requires a formally defined input. This does not change the
+classification — the boundary crossed determines the type, not the asset
+used.
 
 - MUST verify the primary interaction path between the integrated components
 - SHOULD cover fault scenarios — dependency unavailable, malformed response,
   timeout, boundary violations
 - SHOULD cover cases where a behaviour is only valid under specific conditions
 - MUST NOT rely on shared mutable state between test runs
-- Names MUST follow the codification scheme defined in the Imbra knowledge
-  repository under `standards/` — the scheme provides a structured format
-  that enables filtering, traceability, and maintenance across projects
+- Names SHOULD follow a structured codification scheme that enables
+  filtering, traceability, and maintenance across projects
 
 ---
 
@@ -199,9 +198,3 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
-- Test factory defaults for optional fields MUST be `undefined` (omitted),
-  not convenient values like `false` or `0` — explicit defaults mask bugs
-  that only appear with real data shapes
-- Data validation tests SHOULD flag boolean fields where one branch (`true`
-  or `false`) has zero occurrences across the dataset — this is a data
-  smell that can silently break sorting, filtering, and UI logic

--- a/templates/base/language/typescript.md
+++ b/templates/base/language/typescript.md
@@ -37,3 +37,13 @@
 
 - `strict: true` — no exceptions
 - Follow `@typescript-eslint/recommended`
+
+## Testing
+[ID: base-typescript-testing]
+
+- Test factory defaults for optional fields MUST be `undefined` (omitted),
+  not convenient values like `false` or `0` — explicit defaults mask bugs
+  that only appear with real data shapes
+- Data validation tests SHOULD flag boolean fields where one branch (`true`
+  or `false`) has zero occurrences across the dataset — this is a data
+  smell that can silently break sorting, filtering, and UI logic

--- a/templates/frontend/quality.md
+++ b/templates/frontend/quality.md
@@ -40,20 +40,19 @@ Choose the right tool for the scope of the state — do not use a global store
 for state that is local to a component or a server cache for state that is
 never fetched from a server.
 
-| State type          | Tool                     | When to use                                                                          |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
-| **Local UI state**  | `useState`, `useReducer` | Scoped to one component — form inputs, toggles, counters                             |
-| **Shared UI state** | Zustand / Redux Toolkit  | Needed by multiple unrelated components — auth session, sidebar open, active filters |
-| **Server state**    | TanStack Query / SWR     | Data fetched from an API — lists, detail views, paginated results                    |
-| **Form state**      | React Hook Form / Formik | Complex forms with validation, field arrays, multi-step flows                        |
-| **URL state**       | Router search params     | Shareable or bookmarkable UI state — filters, pagination, selected tab               |
+| State type          | Scope                | When to use                                       |
+| ------------------- | -------------------- | ------------------------------------------------- |
+| **Local UI state**  | Single component     | Form inputs, toggles, counters                    |
+| **Shared UI state** | Multiple components  | Auth session, sidebar state, active filters       |
+| **Server state**    | Cached from API      | Lists, detail views, paginated results            |
+| **Form state**      | Form lifecycle       | Validation, field arrays, multi-step flows        |
+| **URL state**       | URL search params    | Bookmarkable filters, pagination, selected tab    |
 
 Rules:
 
-- Never duplicate server state in a global store — TanStack Query or SWR is
-  the cache; the store holds only client-owned state
-- Never put derived state in the store — compute it from existing state with
-  a selector or `useMemo`
+- Never duplicate server state in a global store — use a dedicated server
+  cache; the store holds only client-owned state
+- Never put derived state in the store — compute it from existing state
 - Prefer URL state for anything the user should be able to bookmark or share
 - Keep global store slices small and focused — one slice per domain concern,
   not one slice for everything
@@ -69,7 +68,7 @@ Rules:
 
 ## CSS
 
-- All CSS in a single stylesheet — no inline styles except dynamic/computed values
+- No inline styles except for dynamic/computed values
 - No hardcoded colour or spacing values — always use CSS custom properties
   from `:root` or design tokens
 - Consistent naming convention (e.g. BEM-like `.component-element`)
@@ -83,9 +82,10 @@ Rules:
 - Defer non-critical scripts
 - Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
 
-## SEO & analytics
+## SEO & analytics (if applicable)
 
-- `robots.txt`, Open Graph, and Twitter Card meta tags required
-- Canonical URLs required
+- `robots.txt`, Open Graph, and Twitter Card meta tags required for
+  server-rendered and static pages
+- Canonical URLs required for publicly indexed pages
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent

--- a/templates/frontend/ux.md
+++ b/templates/frontend/ux.md
@@ -39,12 +39,15 @@ tools catch ~30–40% of issues; the rest require human judgment.
 
 ### Automated (run in CI)
 
-- **axe-core** — integrate via `@axe-core/react`, `axe-playwright`, or
-  `jest-axe`; zero violations allowed before merge
+- **axe-core** — integrate via the framework adapter (`@axe-core/react`,
+  `@axe-core/vue`, `axe-playwright`, or `jest-axe`); zero violations
+  allowed before merge
 - **Lighthouse** — accessibility score ≥ 90 on all key pages; run in CI
   via `lighthouse-ci`
-- **ESLint `jsx-a11y`** — catches missing `alt`, incorrect ARIA roles, and
-  missing form labels at write time; must be configured in the linter
+- **Linter a11y plugin** — catches missing `alt`, incorrect ARIA roles, and
+  missing form labels at write time; use the plugin for your framework
+  (`eslint-plugin-jsx-a11y` for React, `eslint-plugin-vuejs-accessibility`
+  for Vue; Svelte has built-in a11y warnings)
 
 ### Manual (run before shipping new interactive components)
 

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -77,6 +77,9 @@ base:
   - id: base-scope
     file: templates/base/workflow/scope.md
     description: Scope guard, session protocol, drift prevention
+  - id: base-oop
+    file: templates/base/core/oop.md
+    description: SOLID, OOP, GoF design patterns, AOP guidance
   - id: base-quality-gates
     file: templates/base/workflow/quality-gates.md
     description: Three-layer gate model (editor, pre-commit, CI), thresholds
@@ -168,7 +171,7 @@ backend:
   - id: backend-quality
     file: templates/backend/quality.md
     description: Layered architecture, security, performance, API stability
-    depends_on: [base-quality, base-security, base-containers]
+    depends_on: [base-quality, base-oop, base-security, base-containers]
   - id: backend-templating
     file: templates/backend/templating.md
     description: Server-side rendering, partials, escaping, caching, forms, testing
@@ -214,6 +217,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-oop
       - base-typescript
       - base-security
       - frontend-ux
@@ -344,6 +348,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-oop
       - base-typescript
       - base-security
       - frontend-ux
@@ -358,6 +363,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-oop
       - base-typescript
       - base-security
       - frontend-ux

--- a/templates/stack/spa-react.md
+++ b/templates/stack/spa-react.md
@@ -1,5 +1,5 @@
 # Stack — React Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side React application with TypeScript. Covers component model,
 state management, routing, API integration, and tooling.
@@ -52,19 +52,11 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: react-spa-typescript]
+[EXTEND: base-typescript]
 
-- Follow the **TypeScript ESLint** recommended ruleset
-  (`@typescript-eslint/recommended`) and `eslint-plugin-sonarjs` —
-  enforced by ESLint; do not suppress lint errors without a
-  documented reason
+- `eslint-plugin-sonarjs` MUST be included in the ESLint config
 - **Prettier** owns all formatting decisions — no style discussions in code
   review; configure once and commit the config
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
-- Explicit return types on all non-trivial functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions instead
 
 ---
 
@@ -83,10 +75,16 @@ CLAUDE.md
 ## State management
 [ID: react-spa-state]
 
-- Local state (`useState`, `useReducer`) for component-scoped concerns
-- Shared/global state in the chosen store (Zustand slice or Redux slice)
-- Server state (fetched data) managed by React Query / TanStack Query —
-  never duplicate server state in the global store
+| State type          | Tool                     | When to use                            |
+| ------------------- | ------------------------ | -------------------------------------- |
+| **Local UI state**  | `useState`, `useReducer` | Form inputs, toggles, counters         |
+| **Shared UI state** | Zustand / Redux Toolkit  | Auth session, sidebar, active filters  |
+| **Server state**    | TanStack Query / SWR     | Lists, detail views, paginated results |
+| **Form state**      | React Hook Form / Formik | Validation, field arrays, multi-step   |
+| **URL state**       | Router search params     | Bookmarkable filters, pagination, tabs |
+
+- Never duplicate server state in the global store — TanStack Query or SWR
+  is the cache; the store holds only client-owned state
 - No direct DOM manipulation — all state flows through React
 
 ---

--- a/templates/stack/spa-svelte.md
+++ b/templates/stack/spa-svelte.md
@@ -1,5 +1,5 @@
 # Stack — Svelte Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Svelte application with TypeScript. Svelte compiles components
 to vanilla JS at build time — no virtual DOM, minimal runtime overhead.

--- a/templates/stack/spa-vue.md
+++ b/templates/stack/spa-vue.md
@@ -1,5 +1,5 @@
 # Stack — Vue Single-Page Application
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/oop.md, templates/base/language/typescript.md, templates/base/security/security.md, templates/frontend/ux.md, templates/frontend/quality.md]
 
 A client-side Vue application with TypeScript. Covers the Composition API,
 component model, state management with Pinia, routing, API integration,


### PR DESCRIPTION
## Summary

Removes framework-specific content from shared templates so non-matching stacks don't inherit irrelevant rules.

- **#265** — Extract OOP sections (SOLID, GoF patterns, AOP) from `base/core/quality.md` into new `base/core/oop.md`; move 12-factor sections (Disposability, Admin processes) to `backend/quality.md`; reword architecture bullets to stack-neutral language
- **#266** — Remove Imbra org reference from `base/core/testing.md`; move JS-specific test rules (`undefined` defaults, boolean fields) to `base/language/typescript.md`
- **#267** — Replace React-specific state table in `frontend/quality.md` with framework-agnostic version; move React tooling table to `spa-react.md`; remove "single stylesheet" mandate; qualify SEO as `(if applicable)`; deduplicate TypeScript rules via `[EXTEND]`
- **#273** — Make `frontend/ux.md` accessibility tooling references framework-agnostic (list adapters per framework)

**Net effect:** non-OOP stacks (Go lib, Rust, C, Terraform, static sites) lose ~80 lines of irrelevant OOP/12-factor content. Non-React frontend stacks no longer receive React-specific state and tooling advice.

## Test plan

- [x] `py tools/sync.py` — SPEC.md synced, 30 generated files regenerated
- [x] `py tests/run_smoke.py` — all 11 checks pass

Closes #265
Closes #266
Closes #267
Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)