### PR TITLE
fix: add missing override declarations for stack contradictions (#277)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -830,8 +831,11 @@ CLAUDE.md
 ## Testing
 [ID: c-embedded-testing]
 [EXTEND: base-testing]
+[OVERRIDE: base-testing-general]
 
-- Unit tests run on the host (PC), not on the target hardware
+- All tests run on the host (PC), not on the target hardware — real
+  hardware dependencies are replaced with HAL mocks or hardware-in-the-loop
+  simulators
 - Mock the HAL layer to isolate modules under test
 - One test file per module: `tests/test_[module].c`
 - Use Unity macros: `TEST_ASSERT_EQUAL`, `TEST_ASSERT_NULL`, etc.

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1047,6 +1048,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1118,6 +1119,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,
@@ -2204,6 +2206,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
@@ -2421,9 +2424,14 @@ CLAUDE.md
 
 ## Authentication
 [EXTEND: backend-auth]
+[OVERRIDE: backend-api-statelessness]
 
+- REST API endpoints (DRF/Ninja) MUST be stateless — use JWT or
+  token-based auth; no server-side sessions for API consumers
+- Server-rendered views MAY use `django.contrib.auth` session auth —
+  this is the standard Django pattern for browser-based admin and
+  HTML views; the statelessness rule applies to API endpoints only
 - Use `djangorestframework-simplejwt` for JWT-based APIs
-- Use `django.contrib.auth` sessions for server-rendered views
 - Permission classes on every ViewSet — never rely on `IsAuthenticated` alone
   for sensitive operations; use object-level permissions where needed
 - Custom user model from project start — `AUTH_USER_MODEL` must be set before

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1055,6 +1056,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
@@ -1614,6 +1616,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1118,6 +1119,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1118,6 +1119,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1231,6 +1232,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1231,6 +1232,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1055,6 +1056,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
@@ -1614,6 +1616,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,
@@ -2217,6 +2220,20 @@ CLAUDE.md
 - Never pass raw `req.body` to a service — always go through a validated DTO
 
 ---
+
+## Cross-cutting concerns
+[OVERRIDE: base-oop-aop]
+
+NestJS uses framework-managed interceptors, guards, pipes, and filters as
+its standard cross-cutting model. These are explicit, typed, and visible in
+the module wiring — not hidden AOP proxies.
+
+- Use guards for auth, interceptors for logging/transform, pipes for
+  validation, and exception filters for error handling
+- Register cross-cutting providers at the module or global level — never
+  via hidden runtime proxies or bytecode weaving
+- Each provider has a single responsibility — do not combine auth and
+  logging in one interceptor
 
 ## Guards and interceptors
 [ID: nestjs-guards]

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1022,6 +1023,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,
@@ -1741,6 +1743,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
@@ -2158,6 +2161,7 @@ and deployment.
 
 ## Stack
 [ID: nextjs-stack]
+[OVERRIDE: react-spa-stack]
 
 - Language: TypeScript (strict mode)
 - Framework: Next.js 14+ (App Router)

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1118,6 +1119,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -823,6 +824,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -771,6 +772,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1003,6 +1004,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
@@ -1562,6 +1564,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -771,6 +772,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -1022,6 +1023,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -705,6 +705,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later
@@ -771,6 +772,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/templates/backend/api.md
+++ b/templates/backend/api.md
@@ -76,6 +76,7 @@ Sunset: <HTTP-date>
 ```
 
 ## Statelessness
+[ID: backend-api-statelessness]
 - APIs MUST be stateless — no client context stored on the server between requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the

--- a/templates/base/core/oop.md
+++ b/templates/base/core/oop.md
@@ -47,6 +47,7 @@ Apply SOLID at the class, module, and service level:
   does not
 
 ## Aspect-Oriented Programming (AOP)
+[ID: base-oop-aop]
 
 - **Do not use AOP frameworks** — hidden cross-cutting behaviour (method
   interception, bytecode weaving, runtime proxies) makes code hard to read,

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -184,6 +184,7 @@ fixing the design fixes the testability.
 ---
 
 ## General rules
+[ID: base-testing-general]
 
 - Design for testability from the start — do not write code first and
   struggle to test later

--- a/templates/stack/c-embedded.md
+++ b/templates/stack/c-embedded.md
@@ -106,8 +106,11 @@ CLAUDE.md
 ## Testing
 [ID: c-embedded-testing]
 [EXTEND: base-testing]
+[OVERRIDE: base-testing-general]
 
-- Unit tests run on the host (PC), not on the target hardware
+- All tests run on the host (PC), not on the target hardware — real
+  hardware dependencies are replaced with HAL mocks or hardware-in-the-loop
+  simulators
 - Mock the HAL layer to isolate modules under test
 - One test file per module: `tests/test_[module].c`
 - Use Unity macros: `TEST_ASSERT_EQUAL`, `TEST_ASSERT_NULL`, etc.

--- a/templates/stack/full-nextjs.md
+++ b/templates/stack/full-nextjs.md
@@ -9,6 +9,7 @@ and deployment.
 
 ## Stack
 [ID: nextjs-stack]
+[OVERRIDE: react-spa-stack]
 
 - Language: TypeScript (strict mode)
 - Framework: Next.js 14+ (App Router)

--- a/templates/stack/node-nestjs.md
+++ b/templates/stack/node-nestjs.md
@@ -113,6 +113,20 @@ CLAUDE.md
 
 ---
 
+## Cross-cutting concerns
+[OVERRIDE: base-oop-aop]
+
+NestJS uses framework-managed interceptors, guards, pipes, and filters as
+its standard cross-cutting model. These are explicit, typed, and visible in
+the module wiring — not hidden AOP proxies.
+
+- Use guards for auth, interceptors for logging/transform, pipes for
+  validation, and exception filters for error handling
+- Register cross-cutting providers at the module or global level — never
+  via hidden runtime proxies or bytecode weaving
+- Each provider has a single responsibility — do not combine auth and
+  logging in one interceptor
+
 ## Guards and interceptors
 [ID: nestjs-guards]
 

--- a/templates/stack/python-django.md
+++ b/templates/stack/python-django.md
@@ -113,9 +113,14 @@ CLAUDE.md
 
 ## Authentication
 [EXTEND: backend-auth]
+[OVERRIDE: backend-api-statelessness]
 
+- REST API endpoints (DRF/Ninja) MUST be stateless — use JWT or
+  token-based auth; no server-side sessions for API consumers
+- Server-rendered views MAY use `django.contrib.auth` session auth —
+  this is the standard Django pattern for browser-based admin and
+  HTML views; the statelessness rule applies to API endpoints only
 - Use `djangorestframework-simplejwt` for JWT-based APIs
-- Use `django.contrib.auth` sessions for server-rendered views
 - Permission classes on every ViewSet — never rely on `IsAuthenticated` alone
   for sensitive operations; use object-level permissions where needed
 - Custom user model from project start — `AUTH_USER_MODEL` must be set before


### PR DESCRIPTION
## Summary

Adds explicit `[OVERRIDE]` declarations where stack rules contradict inherited base rules, so agents receive clear precedence instead of conflicting guidance.

| Stack | Contradiction | Fix |
|-------|-------------|-----|
| nestjs | base-oop AOP: "no interceptors" | `[OVERRIDE: base-oop-aop]` — NestJS interceptors/guards/pipes are framework-managed |
| c-embedded | base-testing: "use real dependencies" | `[OVERRIDE: base-testing-general]` — all tests run on host with HAL mocks |
| django | backend-api: "APIs MUST be stateless" | `[OVERRIDE: backend-api-statelessness]` — session auth for views, JWT for APIs |
| nextjs | Inherits react-spa-stack (Vite/CRA) | `[OVERRIDE: react-spa-stack]` — Next.js is its own bundler |

3 of 7 original contradictions were already resolved by prior PRs:
- c-embedded Disposability/Admin — moved to backend/quality.md (#279)
- sveltekit TanStack Query — table now framework-agnostic (#279)
- sveltekit backend-api — removed from chain (#278)

## Test plan

- [x] `py tools/sync.py` — 30 generated files regenerated
- [x] `py tests/run_smoke.py` — all 11 checks pass

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)