### PR TITLE
fix: remove rule duplications and fix dangling references (#275, #276)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -923,9 +923,270 @@ to change.
   smell that can silently break sorting, filtering, and UI logic
 
 
+<!-- templates/base/core/config.md -->
+# Base — Configuration
+[ID: base-config]
+
+Follows the [12-factor app](https://12factor.net/config) principle:
+store config in the environment, not in code.
+
+## Rules
+
+- All configuration from environment variables — no hardcoded values
+  in source
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in
+  `.gitignore`
+- Separate configuration per environment (development, testing,
+  production)
+- Pass config explicitly to components — no global config objects
+  accessed from arbitrary locations
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+
+## Naming conventions
+
+- Use `SCREAMING_SNAKE_CASE` for all environment variables
+- Prefix with the app or service name to avoid collisions
+  (e.g. `MYAPP_DATABASE_URL`, not `DATABASE_URL`)
+- Group related variables with a common prefix
+  (e.g. `MYAPP_DB_HOST`, `MYAPP_DB_PORT`, `MYAPP_DB_NAME`)
+- Boolean variables use `ENABLE_` or `DISABLE_` prefix
+  (e.g. `MYAPP_ENABLE_CACHE`)
+
+## Config precedence
+
+Sources override in this order (highest wins):
+
+1. **Hardcoded defaults** — in code, lowest priority
+2. **Config file** — `config.yaml`, `appsettings.json`, etc.
+3. **Environment variables** — override file values
+4. **CLI flags / arguments** — override everything
+
+- Document the precedence model for the project
+- Never let a lower-priority source silently override a
+  higher-priority one
+
+## Build-time vs runtime config
+
+- **Build-time** — values baked into the artifact at build (API base
+  URLs, feature flags, public keys). Changing them requires a rebuild.
+- **Runtime** — values read when the process starts or on each
+  request (secrets, database URLs, log levels). Changing them
+  requires a restart or hot-reload.
+- Never put secrets in build-time config — they end up in the
+  artifact and are visible to anyone who inspects it
+- Document which variables are build-time and which are runtime
+
+## Validation
+
+- Validate types, ranges, and formats at load time — not at first use
+- Use a typed config object or schema — never scatter raw environment
+  variable reads across the codebase
+- Provide sensible defaults only for optional, non-sensitive settings
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys
+
+## Secrets management
+
+- In production, source secrets from a dedicated secrets manager or
+  CI/CD secret store — not from flat `.env` files
+- Design secret loading to support rotation without a full
+  redeployment
+- Never log config values — redact or omit secrets from logs and
+  diagnostic output
+- Reference secrets by name or path, not by embedding them in config
+  files
+
+## Environment separation
+
+| Environment | Purpose           | Secrets source       |
+|-------------|-------------------|----------------------|
+| development | local work        | `.env` file          |
+| testing     | automated tests   | hardcoded stubs      |
+| staging     | pre-production    | secrets manager / CI |
+| production  | live              | secrets manager      |
+
+## Dependencies
+
+- Declare all dependencies explicitly in a manifest (`package.json`,
+  `pyproject.toml`, `go.mod`, `Cargo.toml`, `requirements.txt`)
+- Commit the lockfile (`package-lock.json`, `poetry.lock`, `go.sum`,
+  `Cargo.lock`) — it pins exact versions for reproducible builds
+- Never rely on system-wide packages — the app MUST run with only
+  its declared dependencies installed
+- Separate production dependencies from dev/test dependencies
+
+## Port binding
+
+- The application exposes its service by binding to a port — it does
+  not depend on an external web server injecting itself at runtime
+- The port MUST be configurable via environment variable
+  (e.g. `PORT=8080`)
+- Do not hardcode port numbers in source code
+- In development, use a well-known default; in production, the
+  platform assigns the port
+
+## `.env.example` structure
+
+```
+# Required
+API_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me
+
+# Optional — defaults shown
+LOG_LEVEL=info
+DEBUG=false
+```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/static-site-astro.md -->
 # Stack — Astro (Static Site)
-[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md]
+[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md, templates/base/workflow/quality-gates.md]
 
 Extends the static site stack with Astro-specific rules.
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1817,9 +1817,6 @@ CLAUDE.md
 ## Task design
 [EXTEND: backend-jobs]
 
-- Keep task functions thin — delegate all logic to a service function;
-  the task is the entry point, not the implementation
-- Every task MUST be idempotent — assume it will execute more than once
 - Bind tasks with `@app.task(bind=True)` only when the task needs access
   to `self` (e.g. for retry logic) — avoid `bind=True` by default
 - Never pass ORM model instances as task arguments — pass primitive IDs

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2036,8 +2036,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Layered architecture
 [ID: python-service-layers]
-
-All Python web services follow a three-layer model regardless of framework:
+[EXTEND: backend-quality]
 
 ```
 HTTP handler / view / route
@@ -2047,12 +2046,8 @@ HTTP handler / view / route
     Repository / ORM query    ← data access lives here
 ```
 
-- **Handler layer**: decode request, validate input, call service, return response.
-  No business logic. No database calls.
-- **Service layer**: pure functions or classes containing all business logic.
-  No HTTP concerns (`request`, `response`, status codes). Independently testable.
-- **Repository layer**: all database interaction. No business logic. Returns
-  domain objects, not ORM model instances passed to the caller.
+- Repository layer returns domain objects, not ORM model instances
+  passed to the caller
 
 ---
 
@@ -2087,10 +2082,7 @@ Overridden by each framework stack. The common principle:
 
 - SQLAlchemy 2.x for Flask and FastAPI — use `select()` style queries,
   no legacy `Query` API
-- Migrations managed by Alembic — one migration per logical schema change,
-  committed to source control
-- Never edit a migration already applied in any environment
-- No raw SQL strings — parameterised queries via the ORM only
+- Migrations managed by Alembic
 
 ---
 
@@ -2113,8 +2105,6 @@ Overridden by each framework stack. The common principle:
 ## Observability
 [EXTEND: backend-observability]
 
-- Structured JSON logs — inject a request ID per request
-- Never log passwords, tokens, or PII
 - `/health` — liveness check
 - `/ready` — readiness check (verifies DB and any required external dependencies)
 
@@ -2451,7 +2441,7 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `pytest-django` for all tests — no `unittest.TestCase` unless there is a
   specific reason
@@ -2459,14 +2449,6 @@ CLAUDE.md
   keeps the test suite fast
 - One `settings` fixture using `testing.py` — never use production settings
   in tests
-- No mocking of the database in integration tests — use the test database
-- Test each view/viewset for: success (2xx), validation error (400/422),
-  auth error (401/403), not found (404)
-- Component test naming: `test_<view_or_function>_<state>_<expected>`
-  e.g. `test_create_order_missing_quantity_returns_400`
-- Component tests in `tests/component/`, integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2036,8 +2036,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Layered architecture
 [ID: python-service-layers]
-
-All Python web services follow a three-layer model regardless of framework:
+[EXTEND: backend-quality]
 
 ```
 HTTP handler / view / route
@@ -2047,12 +2046,8 @@ HTTP handler / view / route
     Repository / ORM query    ← data access lives here
 ```
 
-- **Handler layer**: decode request, validate input, call service, return response.
-  No business logic. No database calls.
-- **Service layer**: pure functions or classes containing all business logic.
-  No HTTP concerns (`request`, `response`, status codes). Independently testable.
-- **Repository layer**: all database interaction. No business logic. Returns
-  domain objects, not ORM model instances passed to the caller.
+- Repository layer returns domain objects, not ORM model instances
+  passed to the caller
 
 ---
 
@@ -2087,10 +2082,7 @@ Overridden by each framework stack. The common principle:
 
 - SQLAlchemy 2.x for Flask and FastAPI — use `select()` style queries,
   no legacy `Query` API
-- Migrations managed by Alembic — one migration per logical schema change,
-  committed to source control
-- Never edit a migration already applied in any environment
-- No raw SQL strings — parameterised queries via the ORM only
+- Migrations managed by Alembic
 
 ---
 
@@ -2113,8 +2105,6 @@ Overridden by each framework stack. The common principle:
 ## Observability
 [EXTEND: backend-observability]
 
-- Structured JSON logs — inject a request ID per request
-- Never log passwords, tokens, or PII
 - `/health` — liveness check
 - `/ready` — readiness check (verifies DB and any required external dependencies)
 
@@ -2278,10 +2268,7 @@ CLAUDE.md
 ---
 
 ## Configuration
-[EXTEND: base-config]
-
-- Use `pydantic-settings` (`BaseSettings`) for all configuration
-- `Settings` instantiated once and injected as a dependency — never imported globally
+[EXTEND: python-service-config]
 
 ---
 
@@ -2336,18 +2323,11 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient` (sync)
 - One async `client` fixture in `conftest.py`
-- Test each route for: success (2xx), validation error (422), auth error (401/403)
-- No mocking of the database in component integration tests — use a test database
 - Override dependencies with `app.dependency_overrides` in tests
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
-  e.g. `test_create_item_invalid_payload_returns_422`
-- Component tests in `tests/component/`, component integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2036,8 +2036,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Layered architecture
 [ID: python-service-layers]
-
-All Python web services follow a three-layer model regardless of framework:
+[EXTEND: backend-quality]
 
 ```
 HTTP handler / view / route
@@ -2047,12 +2046,8 @@ HTTP handler / view / route
     Repository / ORM query    ← data access lives here
 ```
 
-- **Handler layer**: decode request, validate input, call service, return response.
-  No business logic. No database calls.
-- **Service layer**: pure functions or classes containing all business logic.
-  No HTTP concerns (`request`, `response`, status codes). Independently testable.
-- **Repository layer**: all database interaction. No business logic. Returns
-  domain objects, not ORM model instances passed to the caller.
+- Repository layer returns domain objects, not ORM model instances
+  passed to the caller
 
 ---
 
@@ -2087,10 +2082,7 @@ Overridden by each framework stack. The common principle:
 
 - SQLAlchemy 2.x for Flask and FastAPI — use `select()` style queries,
   no legacy `Query` API
-- Migrations managed by Alembic — one migration per logical schema change,
-  committed to source control
-- Never edit a migration already applied in any environment
-- No raw SQL strings — parameterised queries via the ORM only
+- Migrations managed by Alembic
 
 ---
 
@@ -2113,8 +2105,6 @@ Overridden by each framework stack. The common principle:
 ## Observability
 [EXTEND: backend-observability]
 
-- Structured JSON logs — inject a request ID per request
-- Never log passwords, tokens, or PII
 - `/health` — liveness check
 - `/ready` — readiness check (verifies DB and any required external dependencies)
 
@@ -2192,7 +2182,7 @@ CLAUDE.md
 ---
 
 ## Configuration
-[EXTEND: base-config]
+[EXTEND: python-service-config]
 
 - Three config classes: `DevelopmentConfig`, `TestingConfig`, `ProductionConfig`
 - `FLASK_ENV` / `FLASK_DEBUG` must be `False` in production
@@ -2225,17 +2215,10 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `pytest-flask` for the test client and app fixture
 - One `app` fixture in `conftest.py` — uses `TestingConfig`
-- Test each route for: success, validation error, auth error (if applicable)
-- No mocking of the database in component integration tests — use a test database
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
-  e.g. `test_create_user_duplicate_email_returns_409`
-- Component tests in `tests/component/`, component integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -737,7 +737,7 @@ no HTTP layer.
 [ID: go-lib-stack]
 
 - Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for binary crates
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
 - Test runner: go test (stdlib)
 - Distribution: [binary / GitHub Releases / Go module proxy]
 
@@ -1181,6 +1181,92 @@ Use the correct level — do not elevate debug information to INFO:
 - Distinguish between client errors (4xx) and server errors (5xx) in logs
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
+
+<!-- templates/backend/errors.md -->
+# Backend — Error Handling
+[ID: backend-errors]
+[DEPENDS ON: templates/backend/http.md, templates/backend/observability.md]
+
+Error response format and logging rules are defined in `templates/backend/http.md` and
+`templates/backend/observability.md`. This template covers classification, propagation,
+and recovery.
+
+---
+
+## Error classification
+
+Classify every error before handling it — the class determines the response,
+the log level, and the recovery strategy:
+
+| Class | Cause | HTTP range | Log level |
+|-------|-------|------------|-----------|
+| **Validation** | Invalid input from the caller | 400, 422 | INFO |
+| **Authentication** | Missing or invalid credentials | 401 | INFO |
+| **Authorization** | Valid credentials, insufficient permission | 403 | INFO |
+| **Not found** | Resource does not exist | 404 | INFO |
+| **Conflict** | State violation (duplicate, stale write) | 409 | INFO |
+| **Infrastructure** | DB, cache, or queue unavailable | 503 | ERROR |
+| **External** | Third-party API or service failure | 502, 504 | ERROR |
+| **Unexpected** | Unhandled exception, programming error | 500 | ERROR |
+
+- Never map an infrastructure or unexpected error to a 4xx — that misleads
+  the caller about who is responsible
+- Never map a validation error to a 5xx — the caller must know the request
+  was rejected, not that the server failed
+
+---
+
+## Propagation through layers
+
+- **Repository layer**: raise typed, domain-agnostic errors
+  (e.g. `RecordNotFound`, `ConnectionError`) — never expose ORM or driver
+  exceptions to the layers above
+- **Service layer**: catch repository errors and re-raise as domain errors
+  (e.g. `OrderNotFound`, `PaymentServiceUnavailable`); add business context
+  before re-raising
+- **Handler layer**: catch domain errors, map them to HTTP responses using a
+  central error mapper — no ad-hoc `try/except` per route
+- Log once, at the handler or middleware boundary — never log the same error
+  at multiple layers
+
+---
+
+## Recovery and graceful degradation
+
+- Wrap all outbound calls (HTTP, DB, cache, queue) in a timeout — never wait
+  indefinitely for an external response
+- Use the **Circuit Breaker** pattern for repeated calls to external services
+  — fail fast after a threshold of failures; recover automatically after a
+  cool-down period
+- Degrade gracefully when a non-critical dependency is unavailable — serve
+  a reduced response rather than failing the entire request
+  (e.g. return cached data if the live source is down)
+- Non-idempotent operations that fail mid-way MUST leave the system in a
+  consistent state — use transactions or compensating actions; never leave
+  partial writes uncommitted
+
+---
+
+## External service failures
+
+- Never surface a third-party error message directly to the caller — translate
+  it into a domain error with a message you control
+- Distinguish between a timeout (client waited too long) and a rejection
+  (external service actively refused) — use 504 for timeout, 502 for rejection
+- Log the full external error response at ERROR level for diagnosis; return
+  only a safe, generic message to the caller
+- Implement retry with exponential backoff and jitter for transient external
+  failures — do not retry on 4xx responses from the external service
+
+---
+
+## Unexpected errors
+
+- All unhandled exceptions MUST be caught at the outermost middleware boundary
+  — no exception should escape to the framework's default handler
+- Return a generic 500 response with a trace ID — never return a stack trace,
+  internal path, or error message that reveals implementation details
+- Treat every unexpected error as a bug — create a ticket, do not suppress
 
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
@@ -2070,7 +2156,7 @@ not after deployment.
 
 <!-- templates/stack/go-service.md -->
 # Stack — Go Service
-[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
+[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/errors.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
 
 Extends the Go library stack with service-specific rules. Covers project
 structure, HTTP handlers, configuration, concurrency, graceful shutdown,
@@ -2165,7 +2251,6 @@ CLAUDE.md
 - Integration tests in `internal/[feature]/*_integration_test.go`
   behind a build tag: `//go:build integration`
 - Performance tests with k6 — colocated in `tests/performance/`
-- Run before every commit: `go test ./... && go vet ./...`
 
 ---
 
@@ -2191,14 +2276,6 @@ CLAUDE.md
   never pass raw `[]byte` to business logic
 
 ---
-
-## Git conventions
-[EXTEND: go-lib-git]
-
-- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless
-  vendoring intentionally)
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -737,7 +737,7 @@ no HTTP layer.
 [ID: go-lib-stack]
 
 - Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for binary crates
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
 - Test runner: go test (stdlib)
 - Distribution: [binary / GitHub Releases / Go module proxy]
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -737,7 +737,7 @@ no HTTP layer.
 [ID: go-lib-stack]
 
 - Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for binary crates
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
 - Test runner: go test (stdlib)
 - Distribution: [binary / GitHub Releases / Go module proxy]
 
@@ -1181,6 +1181,92 @@ Use the correct level — do not elevate debug information to INFO:
 - Distinguish between client errors (4xx) and server errors (5xx) in logs
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
+
+<!-- templates/backend/errors.md -->
+# Backend — Error Handling
+[ID: backend-errors]
+[DEPENDS ON: templates/backend/http.md, templates/backend/observability.md]
+
+Error response format and logging rules are defined in `templates/backend/http.md` and
+`templates/backend/observability.md`. This template covers classification, propagation,
+and recovery.
+
+---
+
+## Error classification
+
+Classify every error before handling it — the class determines the response,
+the log level, and the recovery strategy:
+
+| Class | Cause | HTTP range | Log level |
+|-------|-------|------------|-----------|
+| **Validation** | Invalid input from the caller | 400, 422 | INFO |
+| **Authentication** | Missing or invalid credentials | 401 | INFO |
+| **Authorization** | Valid credentials, insufficient permission | 403 | INFO |
+| **Not found** | Resource does not exist | 404 | INFO |
+| **Conflict** | State violation (duplicate, stale write) | 409 | INFO |
+| **Infrastructure** | DB, cache, or queue unavailable | 503 | ERROR |
+| **External** | Third-party API or service failure | 502, 504 | ERROR |
+| **Unexpected** | Unhandled exception, programming error | 500 | ERROR |
+
+- Never map an infrastructure or unexpected error to a 4xx — that misleads
+  the caller about who is responsible
+- Never map a validation error to a 5xx — the caller must know the request
+  was rejected, not that the server failed
+
+---
+
+## Propagation through layers
+
+- **Repository layer**: raise typed, domain-agnostic errors
+  (e.g. `RecordNotFound`, `ConnectionError`) — never expose ORM or driver
+  exceptions to the layers above
+- **Service layer**: catch repository errors and re-raise as domain errors
+  (e.g. `OrderNotFound`, `PaymentServiceUnavailable`); add business context
+  before re-raising
+- **Handler layer**: catch domain errors, map them to HTTP responses using a
+  central error mapper — no ad-hoc `try/except` per route
+- Log once, at the handler or middleware boundary — never log the same error
+  at multiple layers
+
+---
+
+## Recovery and graceful degradation
+
+- Wrap all outbound calls (HTTP, DB, cache, queue) in a timeout — never wait
+  indefinitely for an external response
+- Use the **Circuit Breaker** pattern for repeated calls to external services
+  — fail fast after a threshold of failures; recover automatically after a
+  cool-down period
+- Degrade gracefully when a non-critical dependency is unavailable — serve
+  a reduced response rather than failing the entire request
+  (e.g. return cached data if the live source is down)
+- Non-idempotent operations that fail mid-way MUST leave the system in a
+  consistent state — use transactions or compensating actions; never leave
+  partial writes uncommitted
+
+---
+
+## External service failures
+
+- Never surface a third-party error message directly to the caller — translate
+  it into a domain error with a message you control
+- Distinguish between a timeout (client waited too long) and a rejection
+  (external service actively refused) — use 504 for timeout, 502 for rejection
+- Log the full external error response at ERROR level for diagnosis; return
+  only a safe, generic message to the caller
+- Implement retry with exponential backoff and jitter for transient external
+  failures — do not retry on 4xx responses from the external service
+
+---
+
+## Unexpected errors
+
+- All unhandled exceptions MUST be caught at the outermost middleware boundary
+  — no exception should escape to the framework's default handler
+- Return a generic 500 response with a trace ID — never return a stack trace,
+  internal path, or error message that reveals implementation details
+- Treat every unexpected error as a bug — create a ticket, do not suppress
 
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
@@ -2070,7 +2156,7 @@ not after deployment.
 
 <!-- templates/stack/go-service.md -->
 # Stack — Go Service
-[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
+[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/errors.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
 
 Extends the Go library stack with service-specific rules. Covers project
 structure, HTTP handlers, configuration, concurrency, graceful shutdown,
@@ -2165,7 +2251,6 @@ CLAUDE.md
 - Integration tests in `internal/[feature]/*_integration_test.go`
   behind a build tag: `//go:build integration`
 - Performance tests with k6 — colocated in `tests/performance/`
-- Run before every commit: `go test ./... && go vet ./...`
 
 ---
 
@@ -2191,14 +2276,6 @@ CLAUDE.md
   never pass raw `[]byte` to business logic
 
 ---
-
-## Git conventions
-[EXTEND: go-lib-git]
-
-- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless
-  vendoring intentionally)
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -737,7 +737,7 @@ no HTTP layer.
 [ID: go-lib-stack]
 
 - Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for binary crates
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
 - Test runner: go test (stdlib)
 - Distribution: [binary / GitHub Releases / Go module proxy]
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -985,7 +985,7 @@ CLAUDE.md
 ---
 
 ## SEO
-[EXTEND: frontend-quality]
+[EXTEND: static-site-seo]
 
 - `robots.txt` generated from `layouts/robots.txt` template
 - Open Graph and Twitter Card meta tags in `layouts/partials/head.html`

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2128,7 +2128,7 @@ and testing.
 - Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Jest + Supertest
-- ASGI server (production): Node.js process managed by PM2 or Docker
+- Process manager (production): PM2 or Docker
 - Distribution: Docker image / [platform]
 
 ---

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -824,12 +824,8 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: nodejs-lib-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` in public API — use specific types, generics, or `unknown`
-- Explicit return types on all exported functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` — keeps the runtime bundle clean
 - `tsconfig.build.json` excludes `tests/` — type-check tests separately
 
 ---

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2036,8 +2036,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Layered architecture
 [ID: python-service-layers]
-
-All Python web services follow a three-layer model regardless of framework:
+[EXTEND: backend-quality]
 
 ```
 HTTP handler / view / route
@@ -2047,12 +2046,8 @@ HTTP handler / view / route
     Repository / ORM query    ← data access lives here
 ```
 
-- **Handler layer**: decode request, validate input, call service, return response.
-  No business logic. No database calls.
-- **Service layer**: pure functions or classes containing all business logic.
-  No HTTP concerns (`request`, `response`, status codes). Independently testable.
-- **Repository layer**: all database interaction. No business logic. Returns
-  domain objects, not ORM model instances passed to the caller.
+- Repository layer returns domain objects, not ORM model instances
+  passed to the caller
 
 ---
 
@@ -2087,10 +2082,7 @@ Overridden by each framework stack. The common principle:
 
 - SQLAlchemy 2.x for Flask and FastAPI — use `select()` style queries,
   no legacy `Query` API
-- Migrations managed by Alembic — one migration per logical schema change,
-  committed to source control
-- Never edit a migration already applied in any environment
-- No raw SQL strings — parameterised queries via the ORM only
+- Migrations managed by Alembic
 
 ---
 
@@ -2113,8 +2105,6 @@ Overridden by each framework stack. The common principle:
 ## Observability
 [EXTEND: backend-observability]
 
-- Structured JSON logs — inject a request ID per request
-- Never log passwords, tokens, or PII
 - `/health` — liveness check
 - `/ready` — readiness check (verifies DB and any required external dependencies)
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1358,11 +1358,9 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: svelte-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
 - Type component props explicitly: `let { label, onClick }: { label: string; onClick: () => void } = $props()`
-- Import types with `import type { ... }` to keep the runtime bundle clean
 
 ---
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1358,11 +1358,9 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: svelte-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
 - Type component props explicitly: `let { label, onClick }: { label: string; onClick: () => void } = $props()`
-- Import types with `import type { ... }` to keep the runtime bundle clean
 
 ---
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -923,9 +923,270 @@ to change.
   smell that can silently break sorting, filtering, and UI logic
 
 
+<!-- templates/base/core/config.md -->
+# Base — Configuration
+[ID: base-config]
+
+Follows the [12-factor app](https://12factor.net/config) principle:
+store config in the environment, not in code.
+
+## Rules
+
+- All configuration from environment variables — no hardcoded values
+  in source
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in
+  `.gitignore`
+- Separate configuration per environment (development, testing,
+  production)
+- Pass config explicitly to components — no global config objects
+  accessed from arbitrary locations
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+
+## Naming conventions
+
+- Use `SCREAMING_SNAKE_CASE` for all environment variables
+- Prefix with the app or service name to avoid collisions
+  (e.g. `MYAPP_DATABASE_URL`, not `DATABASE_URL`)
+- Group related variables with a common prefix
+  (e.g. `MYAPP_DB_HOST`, `MYAPP_DB_PORT`, `MYAPP_DB_NAME`)
+- Boolean variables use `ENABLE_` or `DISABLE_` prefix
+  (e.g. `MYAPP_ENABLE_CACHE`)
+
+## Config precedence
+
+Sources override in this order (highest wins):
+
+1. **Hardcoded defaults** — in code, lowest priority
+2. **Config file** — `config.yaml`, `appsettings.json`, etc.
+3. **Environment variables** — override file values
+4. **CLI flags / arguments** — override everything
+
+- Document the precedence model for the project
+- Never let a lower-priority source silently override a
+  higher-priority one
+
+## Build-time vs runtime config
+
+- **Build-time** — values baked into the artifact at build (API base
+  URLs, feature flags, public keys). Changing them requires a rebuild.
+- **Runtime** — values read when the process starts or on each
+  request (secrets, database URLs, log levels). Changing them
+  requires a restart or hot-reload.
+- Never put secrets in build-time config — they end up in the
+  artifact and are visible to anyone who inspects it
+- Document which variables are build-time and which are runtime
+
+## Validation
+
+- Validate types, ranges, and formats at load time — not at first use
+- Use a typed config object or schema — never scatter raw environment
+  variable reads across the codebase
+- Provide sensible defaults only for optional, non-sensitive settings
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys
+
+## Secrets management
+
+- In production, source secrets from a dedicated secrets manager or
+  CI/CD secret store — not from flat `.env` files
+- Design secret loading to support rotation without a full
+  redeployment
+- Never log config values — redact or omit secrets from logs and
+  diagnostic output
+- Reference secrets by name or path, not by embedding them in config
+  files
+
+## Environment separation
+
+| Environment | Purpose           | Secrets source       |
+|-------------|-------------------|----------------------|
+| development | local work        | `.env` file          |
+| testing     | automated tests   | hardcoded stubs      |
+| staging     | pre-production    | secrets manager / CI |
+| production  | live              | secrets manager      |
+
+## Dependencies
+
+- Declare all dependencies explicitly in a manifest (`package.json`,
+  `pyproject.toml`, `go.mod`, `Cargo.toml`, `requirements.txt`)
+- Commit the lockfile (`package-lock.json`, `poetry.lock`, `go.sum`,
+  `Cargo.lock`) — it pins exact versions for reproducible builds
+- Never rely on system-wide packages — the app MUST run with only
+  its declared dependencies installed
+- Separate production dependencies from dev/test dependencies
+
+## Port binding
+
+- The application exposes its service by binding to a port — it does
+  not depend on an external web server injecting itself at runtime
+- The port MUST be configurable via environment variable
+  (e.g. `PORT=8080`)
+- Do not hardcode port numbers in source code
+- In development, use a well-known default; in production, the
+  platform assigns the port
+
+## `.env.example` structure
+
+```
+# Required
+API_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me
+
+# Optional — defaults shown
+LOG_LEVEL=info
+DEBUG=false
+```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/static-site-astro.md -->
 # Stack — Astro (Static Site)
-[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md]
+[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md, templates/base/workflow/quality-gates.md]
 
 Extends the static site stack with Astro-specific rules.
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1359,13 +1359,10 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: vue-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
 - Use `defineProps<T>()` and `defineEmits<T>()` for typed component APIs —
   never the options-style `props: {}` object
-- Import types with `import type { ... }` to keep the runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions
 
 ---
 

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -197,6 +197,7 @@ stacks:
     depends_on:
       - frontend-static-site
       - base-typescript
+      - base-quality-gates
 
   - id: stack-tutorial
     file: templates/stack/static-site-tutorial.md
@@ -324,6 +325,7 @@ stacks:
       - backend-http
       - backend-database
       - backend-observability
+      - backend-errors
       - backend-quality
       - backend-concurrency
       - backend-features

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -12,7 +12,7 @@ no HTTP layer.
 [ID: go-lib-stack]
 
 - Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for binary crates
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
 - Test runner: go test (stdlib)
 - Distribution: [binary / GitHub Releases / Go module proxy]
 

--- a/templates/stack/go-service.md
+++ b/templates/stack/go-service.md
@@ -1,5 +1,5 @@
 # Stack — Go Service
-[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
+[DEPENDS ON: templates/stack/go-lib.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/errors.md, templates/backend/quality.md, templates/backend/concurrency.md, templates/backend/features.md, templates/backend/messaging.md]
 
 Extends the Go library stack with service-specific rules. Covers project
 structure, HTTP handlers, configuration, concurrency, graceful shutdown,
@@ -94,7 +94,6 @@ CLAUDE.md
 - Integration tests in `internal/[feature]/*_integration_test.go`
   behind a build tag: `//go:build integration`
 - Performance tests with k6 — colocated in `tests/performance/`
-- Run before every commit: `go test ./... && go vet ./...`
 
 ---
 
@@ -120,14 +119,6 @@ CLAUDE.md
   never pass raw `[]byte` to business logic
 
 ---
-
-## Git conventions
-[EXTEND: go-lib-git]
-
-- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless
-  vendoring intentionally)
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
 
 ---
 

--- a/templates/stack/node-nestjs.md
+++ b/templates/stack/node-nestjs.md
@@ -20,7 +20,7 @@ and testing.
 - Linter: ESLint (`@typescript-eslint/recommended`, `eslint-plugin-sonarjs`)
 - Formatter: Prettier
 - Test runner: Jest + Supertest
-- ASGI server (production): Node.js process managed by PM2 or Docker
+- Process manager (production): PM2 or Docker
 - Distribution: Docker image / [platform]
 
 ---

--- a/templates/stack/nodejs-lib.md
+++ b/templates/stack/nodejs-lib.md
@@ -47,12 +47,8 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: nodejs-lib-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` in public API — use specific types, generics, or `unknown`
-- Explicit return types on all exported functions
-- Use `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` — keeps the runtime bundle clean
 - `tsconfig.build.json` excludes `tests/` — type-check tests separately
 
 ---

--- a/templates/stack/python-celery-worker.md
+++ b/templates/stack/python-celery-worker.md
@@ -67,9 +67,6 @@ CLAUDE.md
 ## Task design
 [EXTEND: backend-jobs]
 
-- Keep task functions thin — delegate all logic to a service function;
-  the task is the entry point, not the implementation
-- Every task MUST be idempotent — assume it will execute more than once
 - Bind tasks with `@app.task(bind=True)` only when the task needs access
   to `self` (e.g. for retry logic) — avoid `bind=True` by default
 - Never pass ORM model instances as task arguments — pass primitive IDs

--- a/templates/stack/python-django.md
+++ b/templates/stack/python-django.md
@@ -140,7 +140,7 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `pytest-django` for all tests — no `unittest.TestCase` unless there is a
   specific reason
@@ -148,14 +148,6 @@ CLAUDE.md
   keeps the test suite fast
 - One `settings` fixture using `testing.py` — never use production settings
   in tests
-- No mocking of the database in integration tests — use the test database
-- Test each view/viewset for: success (2xx), validation error (400/422),
-  auth error (401/403), not found (404)
-- Component test naming: `test_<view_or_function>_<state>_<expected>`
-  e.g. `test_create_order_missing_quantity_returns_400`
-- Component tests in `tests/component/`, integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/templates/stack/python-fastapi.md
+++ b/templates/stack/python-fastapi.md
@@ -65,10 +65,7 @@ CLAUDE.md
 ---
 
 ## Configuration
-[EXTEND: base-config]
-
-- Use `pydantic-settings` (`BaseSettings`) for all configuration
-- `Settings` instantiated once and injected as a dependency — never imported globally
+[EXTEND: python-service-config]
 
 ---
 
@@ -123,18 +120,11 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient` (sync)
 - One async `client` fixture in `conftest.py`
-- Test each route for: success (2xx), validation error (422), auth error (401/403)
-- No mocking of the database in component integration tests — use a test database
 - Override dependencies with `app.dependency_overrides` in tests
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
-  e.g. `test_create_item_invalid_payload_returns_422`
-- Component tests in `tests/component/`, component integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/templates/stack/python-flask.md
+++ b/templates/stack/python-flask.md
@@ -62,7 +62,7 @@ CLAUDE.md
 ---
 
 ## Configuration
-[EXTEND: base-config]
+[EXTEND: python-service-config]
 
 - Three config classes: `DevelopmentConfig`, `TestingConfig`, `ProductionConfig`
 - `FLASK_ENV` / `FLASK_DEBUG` must be `False` in production
@@ -95,17 +95,10 @@ CLAUDE.md
 ---
 
 ## Testing
-[EXTEND: base-testing]
+[EXTEND: python-service-testing]
 
 - `pytest-flask` for the test client and app fixture
 - One `app` fixture in `conftest.py` — uses `TestingConfig`
-- Test each route for: success, validation error, auth error (if applicable)
-- No mocking of the database in component integration tests — use a test database
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
-  e.g. `test_create_user_duplicate_email_returns_409`
-- Component tests in `tests/component/`, component integration tests in
-  `tests/integration/`
-- Run before every commit: `pytest && mypy src/ --strict`
 
 ---
 

--- a/templates/stack/python-service.md
+++ b/templates/stack/python-service.md
@@ -26,8 +26,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Layered architecture
 [ID: python-service-layers]
-
-All Python web services follow a three-layer model regardless of framework:
+[EXTEND: backend-quality]
 
 ```
 HTTP handler / view / route
@@ -37,12 +36,8 @@ HTTP handler / view / route
     Repository / ORM query    ← data access lives here
 ```
 
-- **Handler layer**: decode request, validate input, call service, return response.
-  No business logic. No database calls.
-- **Service layer**: pure functions or classes containing all business logic.
-  No HTTP concerns (`request`, `response`, status codes). Independently testable.
-- **Repository layer**: all database interaction. No business logic. Returns
-  domain objects, not ORM model instances passed to the caller.
+- Repository layer returns domain objects, not ORM model instances
+  passed to the caller
 
 ---
 
@@ -77,10 +72,7 @@ Overridden by each framework stack. The common principle:
 
 - SQLAlchemy 2.x for Flask and FastAPI — use `select()` style queries,
   no legacy `Query` API
-- Migrations managed by Alembic — one migration per logical schema change,
-  committed to source control
-- Never edit a migration already applied in any environment
-- No raw SQL strings — parameterised queries via the ORM only
+- Migrations managed by Alembic
 
 ---
 
@@ -103,8 +95,6 @@ Overridden by each framework stack. The common principle:
 ## Observability
 [EXTEND: backend-observability]
 
-- Structured JSON logs — inject a request ID per request
-- Never log passwords, tokens, or PII
 - `/health` — liveness check
 - `/ready` — readiness check (verifies DB and any required external dependencies)
 

--- a/templates/stack/spa-svelte.md
+++ b/templates/stack/spa-svelte.md
@@ -53,11 +53,9 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: svelte-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
 - Type component props explicitly: `let { label, onClick }: { label: string; onClick: () => void } = $props()`
-- Import types with `import type { ... }` to keep the runtime bundle clean
 
 ---
 

--- a/templates/stack/spa-vue.md
+++ b/templates/stack/spa-vue.md
@@ -54,13 +54,10 @@ CLAUDE.md
 
 ## TypeScript conventions
 [ID: vue-typescript]
+[EXTEND: base-typescript]
 
-- `strict: true` in `tsconfig.json` — no exceptions
-- No `any` — use `unknown` and narrow, or define a proper type
 - Use `defineProps<T>()` and `defineEmits<T>()` for typed component APIs —
   never the options-style `props: {}` object
-- Import types with `import type { ... }` to keep the runtime bundle clean
-- Enums avoided — use `as const` objects or string literal unions
 
 ---
 

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -1,5 +1,5 @@
 # Stack — Astro (Static Site)
-[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md]
+[DEPENDS ON: templates/frontend/static-site.md, templates/base/language/typescript.md, templates/base/workflow/quality-gates.md]
 
 Extends the static site stack with Astro-specific rules.
 

--- a/templates/stack/static-site-hugo.md
+++ b/templates/stack/static-site-hugo.md
@@ -111,7 +111,7 @@ CLAUDE.md
 ---
 
 ## SEO
-[EXTEND: frontend-quality]
+[EXTEND: static-site-seo]
 
 - `robots.txt` generated from `layouts/robots.txt` template
 - Open Graph and Twitter Card meta tags in `layouts/partials/head.html`

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -313,11 +313,11 @@ def check_tpl_02():
         failures.append("  base/core/testing.md [ID: base-testing] section is empty")
 
     flask_content = _extract_section(
-        os.path.join(ROOT, "templates", "stack", "python-flask.md"), "base-testing"
+        os.path.join(ROOT, "templates", "stack", "python-flask.md"), "python-service-testing"
     )
     if not flask_content:
         failures.append(
-            "  stack/python-flask.md [EXTEND: base-testing] section is empty "
+            "  stack/python-flask.md [EXTEND: python-service-testing] section is empty "
             "— base rules may have been lost"
         )
 


### PR DESCRIPTION
## Summary

Closes #275 and #276 (sub-issues of #264).

**#276 — Dangling references and terminology (5 fixes):**
- `go-echo.md` `[EXTEND: backend-errors]` — added `backend/errors.md` to go-service dependency chain
- `astro.md` `[EXTEND: base-quality-gates]` — added `quality-gates.md` to astro dependency chain
- `nestjs.md` — "ASGI server (production)" → "Process manager (production)" (ASGI is a Python interface)
- `go-lib.md` — "binary crates" → "command packages" (Rust → Go terminology)
- `hugo.md` — SEO section `[EXTEND: frontend-quality]` → `[EXTEND: static-site-seo]` (was skipping intermediate layer)

**#275 — Rule duplications across stack families:**
- **Python testing**: flask/fastapi/django now extend `python-service-testing` instead of `base-testing`; removed 5-8 duplicated rules per file
- **Python config**: flask/fastapi now extend `python-service-config` instead of `base-config`; removed duplicated pydantic-settings rules from fastapi
- **python-service**: deduplicated layered architecture (vs backend-quality), ORM (vs backend-database), observability (vs backend-observability)
- **celery-worker**: removed idempotency and thin-handler rules duplicated from backend-jobs
- **go-service**: removed entire git section (all rules verbatim from go-lib-git); removed duplicated "run before commit" from testing
- **nodejs-lib/vue/svelte**: TypeScript sections now `[EXTEND: base-typescript]`; removed 3-5 duplicated rules per file

Also updated smoke test TPL-02 to match the new flask testing EXTEND target.

## Test plan
- [x] `py tests/run_smoke.py` — 11/11 pass
- [x] `py tools/sync.py --check` — all files in sync
- [x] `py tools/resolve.py --generate` — all 30 stacks regenerated
- [x] Verified `backend/errors.md` appears in go-echo chain
- [x] Verified `quality-gates.md` appears in astro chain

Closes #275
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)