### PR TITLE
feat: add TPL-06 smoke check for chain reachability (#283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,7 @@ Priority order (highest first):
 Run `py tests/run_smoke.py` before every PR. It checks:
 - All `[DEPENDS ON: ...]` reference existing files
 - All `[EXTEND: ...]` and `[OVERRIDE: ...]` reference valid IDs
+- All EXTEND/OVERRIDE targets are reachable in the resolved chain
 - All manifest entries point to existing files
 - All template files have a manifest entry
 - No duplicate IDs across layers

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1612,6 +1612,150 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1872,6 +1872,150 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1872,6 +1872,150 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1872,6 +1872,150 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -722,119 +722,6 @@ fixing the design fixes the testability.
   not hand-written mocks
 
 
-<!-- templates/stack/go-lib.md -->
-# Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
-
-Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
-Can be used directly for pure Go libraries or standalone CLI tools with
-no HTTP layer.
-
----
-
-## Stack
-[ID: go-lib-stack]
-
-- Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for command packages
-- Test runner: go test (stdlib)
-- Distribution: [binary / GitHub Releases / Go module proxy]
-
----
-
-## Package and interface design
-[ID: go-lib-packages]
-
-- Small, focused packages — one domain concern per package
-- Define interfaces where the caller, not the implementer, owns them
-- Keep interfaces small: prefer 1–3 methods
-- Accept interfaces, return concrete types (in most cases)
-- Avoid package-level `init()` — use explicit initialisation in `main`
-- No `utils/` or `helpers/` packages — name packages by domain
-
----
-
-## Error handling
-[ID: go-lib-errors]
-
-- Always handle errors — never `_` discard an error return
-- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
-- Use `errors.Is()` and `errors.As()` for inspection — never string matching
-- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
-  that owns the concept
-- Log errors once — at the top of the call stack, not at every level
-
----
-
-## Code quality
-[ID: go-lib-quality]
-[EXTEND: base-quality]
-
-- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
-  design decisions — the canonical Go style reference
-- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
-  for common pitfalls and reviewer expectations
-- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
-- Run `go vet ./...` — fix all warnings before committing
-- Run `staticcheck ./...` for additional static analysis
-- No unused imports or variables — the compiler rejects these
-- Exported symbols must have a doc comment
-
----
-
-## Testing
-[ID: go-lib-testing]
-[EXTEND: base-testing]
-
-- Use stdlib `testing` package — no third-party assertion libraries
-- Table-driven tests with `t.Run()` for parameterised cases
-- Test the public API of each package — not unexported functions
-- Use interfaces to inject dependencies in tests — no monkey-patching
-- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
-  e.g. `TestParseConfig_MissingField_ReturnsError`
-- Run before every commit: `go test ./... && go vet ./...`
-
----
-
-## Git conventions
-[ID: go-lib-git]
-[EXTEND: base-git]
-
-- Do not commit compiled binaries or `*.test` files
-- Do not commit `vendor/` unless vendoring is an explicit project decision —
-  document it in README if so
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
-
----
-
-## Commands
-```
-go build ./...        # compile all packages
-go test ./...         # run all tests
-go vet ./...          # static analysis
-goimports -w .        # format imports
-staticcheck ./...     # additional static analysis
-```
----
-
-## Quality gates
-[EXTEND: base-quality-gates]
-
-| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
-|----------|-----------------|---------------------|-------------|--------|
-| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
-| Format | gofmt | gofmt | gofmt -l | built-in |
-| Type check | built-in | built-in | go vet | — |
-| Security | — | — | govulncheck + platform SAST | — |
-| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
-| Tests | — | — | go test ./... | — |
-| Coverage | — | — | go test -cover ≥ 80% | — |
-
-- Hook framework: `pre-commit` or Makefile
-
-
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]
@@ -950,6 +837,263 @@ SECRET_KEY=change-me
 LOG_LEVEL=info
 DEBUG=false
 ```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
+<!-- templates/stack/go-lib.md -->
+# Stack — Go Library / CLI
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+
+Base Go conventions for any Go module — library, CLI tool, or service.
+Never used directly for services — always extended by `templates/stack/go-service.md`.
+Can be used directly for pure Go libraries or standalone CLI tools with
+no HTTP layer.
+
+---
+
+## Stack
+[ID: go-lib-stack]
+
+- Language: Go 1.22+
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
+- Test runner: go test (stdlib)
+- Distribution: [binary / GitHub Releases / Go module proxy]
+
+---
+
+## Package and interface design
+[ID: go-lib-packages]
+
+- Small, focused packages — one domain concern per package
+- Define interfaces where the caller, not the implementer, owns them
+- Keep interfaces small: prefer 1–3 methods
+- Accept interfaces, return concrete types (in most cases)
+- Avoid package-level `init()` — use explicit initialisation in `main`
+- No `utils/` or `helpers/` packages — name packages by domain
+
+---
+
+## Error handling
+[ID: go-lib-errors]
+
+- Always handle errors — never `_` discard an error return
+- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
+- Use `errors.Is()` and `errors.As()` for inspection — never string matching
+- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
+  that owns the concept
+- Log errors once — at the top of the call stack, not at every level
+
+---
+
+## Code quality
+[ID: go-lib-quality]
+[EXTEND: base-quality]
+
+- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
+  design decisions — the canonical Go style reference
+- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
+  for common pitfalls and reviewer expectations
+- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
+- Run `go vet ./...` — fix all warnings before committing
+- Run `staticcheck ./...` for additional static analysis
+- No unused imports or variables — the compiler rejects these
+- Exported symbols must have a doc comment
+
+---
+
+## Testing
+[ID: go-lib-testing]
+[EXTEND: base-testing]
+
+- Use stdlib `testing` package — no third-party assertion libraries
+- Table-driven tests with `t.Run()` for parameterised cases
+- Test the public API of each package — not unexported functions
+- Use interfaces to inject dependencies in tests — no monkey-patching
+- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
+  e.g. `TestParseConfig_MissingField_ReturnsError`
+- Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Git conventions
+[ID: go-lib-git]
+[EXTEND: base-git]
+
+- Do not commit compiled binaries or `*.test` files
+- Do not commit `vendor/` unless vendoring is an explicit project decision —
+  document it in README if so
+- `go.sum` is committed — do not delete or regenerate without cause
+- Tag releases with `vX.Y.Z` — Go module proxy uses these
+
+---
+
+## Commands
+```
+go build ./...        # compile all packages
+go test ./...         # run all tests
+go vet ./...          # static analysis
+goimports -w .        # format imports
+staticcheck ./...     # additional static analysis
+```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
+| Format | gofmt | gofmt | gofmt -l | built-in |
+| Type check | built-in | built-in | go vet | — |
+| Security | — | — | govulncheck + platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
+| Tests | — | — | go test ./... | — |
+| Coverage | — | — | go test -cover ≥ 80% | — |
+
+- Hook framework: `pre-commit` or Makefile
 
 
 <!-- templates/backend/http.md -->

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -722,6 +722,267 @@ fixing the design fixes the testability.
   not hand-written mocks
 
 
+<!-- templates/base/core/config.md -->
+# Base — Configuration
+[ID: base-config]
+
+Follows the [12-factor app](https://12factor.net/config) principle:
+store config in the environment, not in code.
+
+## Rules
+
+- All configuration from environment variables — no hardcoded values
+  in source
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in
+  `.gitignore`
+- Separate configuration per environment (development, testing,
+  production)
+- Pass config explicitly to components — no global config objects
+  accessed from arbitrary locations
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+
+## Naming conventions
+
+- Use `SCREAMING_SNAKE_CASE` for all environment variables
+- Prefix with the app or service name to avoid collisions
+  (e.g. `MYAPP_DATABASE_URL`, not `DATABASE_URL`)
+- Group related variables with a common prefix
+  (e.g. `MYAPP_DB_HOST`, `MYAPP_DB_PORT`, `MYAPP_DB_NAME`)
+- Boolean variables use `ENABLE_` or `DISABLE_` prefix
+  (e.g. `MYAPP_ENABLE_CACHE`)
+
+## Config precedence
+
+Sources override in this order (highest wins):
+
+1. **Hardcoded defaults** — in code, lowest priority
+2. **Config file** — `config.yaml`, `appsettings.json`, etc.
+3. **Environment variables** — override file values
+4. **CLI flags / arguments** — override everything
+
+- Document the precedence model for the project
+- Never let a lower-priority source silently override a
+  higher-priority one
+
+## Build-time vs runtime config
+
+- **Build-time** — values baked into the artifact at build (API base
+  URLs, feature flags, public keys). Changing them requires a rebuild.
+- **Runtime** — values read when the process starts or on each
+  request (secrets, database URLs, log levels). Changing them
+  requires a restart or hot-reload.
+- Never put secrets in build-time config — they end up in the
+  artifact and are visible to anyone who inspects it
+- Document which variables are build-time and which are runtime
+
+## Validation
+
+- Validate types, ranges, and formats at load time — not at first use
+- Use a typed config object or schema — never scatter raw environment
+  variable reads across the codebase
+- Provide sensible defaults only for optional, non-sensitive settings
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys
+
+## Secrets management
+
+- In production, source secrets from a dedicated secrets manager or
+  CI/CD secret store — not from flat `.env` files
+- Design secret loading to support rotation without a full
+  redeployment
+- Never log config values — redact or omit secrets from logs and
+  diagnostic output
+- Reference secrets by name or path, not by embedding them in config
+  files
+
+## Environment separation
+
+| Environment | Purpose           | Secrets source       |
+|-------------|-------------------|----------------------|
+| development | local work        | `.env` file          |
+| testing     | automated tests   | hardcoded stubs      |
+| staging     | pre-production    | secrets manager / CI |
+| production  | live              | secrets manager      |
+
+## Dependencies
+
+- Declare all dependencies explicitly in a manifest (`package.json`,
+  `pyproject.toml`, `go.mod`, `Cargo.toml`, `requirements.txt`)
+- Commit the lockfile (`package-lock.json`, `poetry.lock`, `go.sum`,
+  `Cargo.lock`) — it pins exact versions for reproducible builds
+- Never rely on system-wide packages — the app MUST run with only
+  its declared dependencies installed
+- Separate production dependencies from dev/test dependencies
+
+## Port binding
+
+- The application exposes its service by binding to a port — it does
+  not depend on an external web server injecting itself at runtime
+- The port MUST be configurable via environment variable
+  (e.g. `PORT=8080`)
+- Do not hardcode port numbers in source code
+- In development, use a well-known default; in production, the
+  platform assigns the port
+
+## `.env.example` structure
+
+```
+# Required
+API_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me
+
+# Optional — defaults shown
+LOG_LEVEL=info
+DEBUG=false
+```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -722,119 +722,6 @@ fixing the design fixes the testability.
   not hand-written mocks
 
 
-<!-- templates/stack/go-lib.md -->
-# Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
-
-Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
-Can be used directly for pure Go libraries or standalone CLI tools with
-no HTTP layer.
-
----
-
-## Stack
-[ID: go-lib-stack]
-
-- Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for command packages
-- Test runner: go test (stdlib)
-- Distribution: [binary / GitHub Releases / Go module proxy]
-
----
-
-## Package and interface design
-[ID: go-lib-packages]
-
-- Small, focused packages — one domain concern per package
-- Define interfaces where the caller, not the implementer, owns them
-- Keep interfaces small: prefer 1–3 methods
-- Accept interfaces, return concrete types (in most cases)
-- Avoid package-level `init()` — use explicit initialisation in `main`
-- No `utils/` or `helpers/` packages — name packages by domain
-
----
-
-## Error handling
-[ID: go-lib-errors]
-
-- Always handle errors — never `_` discard an error return
-- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
-- Use `errors.Is()` and `errors.As()` for inspection — never string matching
-- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
-  that owns the concept
-- Log errors once — at the top of the call stack, not at every level
-
----
-
-## Code quality
-[ID: go-lib-quality]
-[EXTEND: base-quality]
-
-- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
-  design decisions — the canonical Go style reference
-- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
-  for common pitfalls and reviewer expectations
-- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
-- Run `go vet ./...` — fix all warnings before committing
-- Run `staticcheck ./...` for additional static analysis
-- No unused imports or variables — the compiler rejects these
-- Exported symbols must have a doc comment
-
----
-
-## Testing
-[ID: go-lib-testing]
-[EXTEND: base-testing]
-
-- Use stdlib `testing` package — no third-party assertion libraries
-- Table-driven tests with `t.Run()` for parameterised cases
-- Test the public API of each package — not unexported functions
-- Use interfaces to inject dependencies in tests — no monkey-patching
-- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
-  e.g. `TestParseConfig_MissingField_ReturnsError`
-- Run before every commit: `go test ./... && go vet ./...`
-
----
-
-## Git conventions
-[ID: go-lib-git]
-[EXTEND: base-git]
-
-- Do not commit compiled binaries or `*.test` files
-- Do not commit `vendor/` unless vendoring is an explicit project decision —
-  document it in README if so
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
-
----
-
-## Commands
-```
-go build ./...        # compile all packages
-go test ./...         # run all tests
-go vet ./...          # static analysis
-goimports -w .        # format imports
-staticcheck ./...     # additional static analysis
-```
----
-
-## Quality gates
-[EXTEND: base-quality-gates]
-
-| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
-|----------|-----------------|---------------------|-------------|--------|
-| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
-| Format | gofmt | gofmt | gofmt -l | built-in |
-| Type check | built-in | built-in | go vet | — |
-| Security | — | — | govulncheck + platform SAST | — |
-| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
-| Tests | — | — | go test ./... | — |
-| Coverage | — | — | go test -cover ≥ 80% | — |
-
-- Hook framework: `pre-commit` or Makefile
-
-
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]
@@ -950,6 +837,263 @@ SECRET_KEY=change-me
 LOG_LEVEL=info
 DEBUG=false
 ```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
+<!-- templates/stack/go-lib.md -->
+# Stack — Go Library / CLI
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+
+Base Go conventions for any Go module — library, CLI tool, or service.
+Never used directly for services — always extended by `templates/stack/go-service.md`.
+Can be used directly for pure Go libraries or standalone CLI tools with
+no HTTP layer.
+
+---
+
+## Stack
+[ID: go-lib-stack]
+
+- Language: Go 1.22+
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
+- Test runner: go test (stdlib)
+- Distribution: [binary / GitHub Releases / Go module proxy]
+
+---
+
+## Package and interface design
+[ID: go-lib-packages]
+
+- Small, focused packages — one domain concern per package
+- Define interfaces where the caller, not the implementer, owns them
+- Keep interfaces small: prefer 1–3 methods
+- Accept interfaces, return concrete types (in most cases)
+- Avoid package-level `init()` — use explicit initialisation in `main`
+- No `utils/` or `helpers/` packages — name packages by domain
+
+---
+
+## Error handling
+[ID: go-lib-errors]
+
+- Always handle errors — never `_` discard an error return
+- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
+- Use `errors.Is()` and `errors.As()` for inspection — never string matching
+- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
+  that owns the concept
+- Log errors once — at the top of the call stack, not at every level
+
+---
+
+## Code quality
+[ID: go-lib-quality]
+[EXTEND: base-quality]
+
+- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
+  design decisions — the canonical Go style reference
+- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
+  for common pitfalls and reviewer expectations
+- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
+- Run `go vet ./...` — fix all warnings before committing
+- Run `staticcheck ./...` for additional static analysis
+- No unused imports or variables — the compiler rejects these
+- Exported symbols must have a doc comment
+
+---
+
+## Testing
+[ID: go-lib-testing]
+[EXTEND: base-testing]
+
+- Use stdlib `testing` package — no third-party assertion libraries
+- Table-driven tests with `t.Run()` for parameterised cases
+- Test the public API of each package — not unexported functions
+- Use interfaces to inject dependencies in tests — no monkey-patching
+- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
+  e.g. `TestParseConfig_MissingField_ReturnsError`
+- Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Git conventions
+[ID: go-lib-git]
+[EXTEND: base-git]
+
+- Do not commit compiled binaries or `*.test` files
+- Do not commit `vendor/` unless vendoring is an explicit project decision —
+  document it in README if so
+- `go.sum` is committed — do not delete or regenerate without cause
+- Tag releases with `vX.Y.Z` — Go module proxy uses these
+
+---
+
+## Commands
+```
+go build ./...        # compile all packages
+go test ./...         # run all tests
+go vet ./...          # static analysis
+goimports -w .        # format imports
+staticcheck ./...     # additional static analysis
+```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
+| Format | gofmt | gofmt | gofmt -l | built-in |
+| Type check | built-in | built-in | go vet | — |
+| Security | — | — | govulncheck + platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
+| Tests | — | — | go test ./... | — |
+| Coverage | — | — | go test -cover ≥ 80% | — |
+
+- Hook framework: `pre-commit` or Makefile
 
 
 <!-- templates/backend/http.md -->

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -722,119 +722,6 @@ fixing the design fixes the testability.
   not hand-written mocks
 
 
-<!-- templates/stack/go-lib.md -->
-# Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
-
-Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
-Can be used directly for pure Go libraries or standalone CLI tools with
-no HTTP layer.
-
----
-
-## Stack
-[ID: go-lib-stack]
-
-- Language: Go 1.22+
-- CLI framework: [cobra / flag (stdlib)] — only for command packages
-- Test runner: go test (stdlib)
-- Distribution: [binary / GitHub Releases / Go module proxy]
-
----
-
-## Package and interface design
-[ID: go-lib-packages]
-
-- Small, focused packages — one domain concern per package
-- Define interfaces where the caller, not the implementer, owns them
-- Keep interfaces small: prefer 1–3 methods
-- Accept interfaces, return concrete types (in most cases)
-- Avoid package-level `init()` — use explicit initialisation in `main`
-- No `utils/` or `helpers/` packages — name packages by domain
-
----
-
-## Error handling
-[ID: go-lib-errors]
-
-- Always handle errors — never `_` discard an error return
-- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
-- Use `errors.Is()` and `errors.As()` for inspection — never string matching
-- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
-  that owns the concept
-- Log errors once — at the top of the call stack, not at every level
-
----
-
-## Code quality
-[ID: go-lib-quality]
-[EXTEND: base-quality]
-
-- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
-  design decisions — the canonical Go style reference
-- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
-  for common pitfalls and reviewer expectations
-- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
-- Run `go vet ./...` — fix all warnings before committing
-- Run `staticcheck ./...` for additional static analysis
-- No unused imports or variables — the compiler rejects these
-- Exported symbols must have a doc comment
-
----
-
-## Testing
-[ID: go-lib-testing]
-[EXTEND: base-testing]
-
-- Use stdlib `testing` package — no third-party assertion libraries
-- Table-driven tests with `t.Run()` for parameterised cases
-- Test the public API of each package — not unexported functions
-- Use interfaces to inject dependencies in tests — no monkey-patching
-- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
-  e.g. `TestParseConfig_MissingField_ReturnsError`
-- Run before every commit: `go test ./... && go vet ./...`
-
----
-
-## Git conventions
-[ID: go-lib-git]
-[EXTEND: base-git]
-
-- Do not commit compiled binaries or `*.test` files
-- Do not commit `vendor/` unless vendoring is an explicit project decision —
-  document it in README if so
-- `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
-
----
-
-## Commands
-```
-go build ./...        # compile all packages
-go test ./...         # run all tests
-go vet ./...          # static analysis
-goimports -w .        # format imports
-staticcheck ./...     # additional static analysis
-```
----
-
-## Quality gates
-[EXTEND: base-quality-gates]
-
-| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
-|----------|-----------------|---------------------|-------------|--------|
-| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
-| Format | gofmt | gofmt | gofmt -l | built-in |
-| Type check | built-in | built-in | go vet | — |
-| Security | — | — | govulncheck + platform SAST | — |
-| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
-| Tests | — | — | go test ./... | — |
-| Coverage | — | — | go test -cover ≥ 80% | — |
-
-- Hook framework: `pre-commit` or Makefile
-
-
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]
@@ -950,6 +837,263 @@ SECRET_KEY=change-me
 LOG_LEVEL=info
 DEBUG=false
 ```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
+<!-- templates/stack/go-lib.md -->
+# Stack — Go Library / CLI
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+
+Base Go conventions for any Go module — library, CLI tool, or service.
+Never used directly for services — always extended by `templates/stack/go-service.md`.
+Can be used directly for pure Go libraries or standalone CLI tools with
+no HTTP layer.
+
+---
+
+## Stack
+[ID: go-lib-stack]
+
+- Language: Go 1.22+
+- CLI framework: [cobra / flag (stdlib)] — only for command packages
+- Test runner: go test (stdlib)
+- Distribution: [binary / GitHub Releases / Go module proxy]
+
+---
+
+## Package and interface design
+[ID: go-lib-packages]
+
+- Small, focused packages — one domain concern per package
+- Define interfaces where the caller, not the implementer, owns them
+- Keep interfaces small: prefer 1–3 methods
+- Accept interfaces, return concrete types (in most cases)
+- Avoid package-level `init()` — use explicit initialisation in `main`
+- No `utils/` or `helpers/` packages — name packages by domain
+
+---
+
+## Error handling
+[ID: go-lib-errors]
+
+- Always handle errors — never `_` discard an error return
+- Wrap errors with context: `fmt.Errorf("creating user: %w", err)`
+- Use `errors.Is()` and `errors.As()` for inspection — never string matching
+- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
+  that owns the concept
+- Log errors once — at the top of the call stack, not at every level
+
+---
+
+## Code quality
+[ID: go-lib-quality]
+[EXTEND: base-quality]
+
+- Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and
+  design decisions — the canonical Go style reference
+- Follow **Go Code Review Comments** (https://go.dev/wiki/CodeReviewComments)
+  for common pitfalls and reviewer expectations
+- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted code
+- Run `go vet ./...` — fix all warnings before committing
+- Run `staticcheck ./...` for additional static analysis
+- No unused imports or variables — the compiler rejects these
+- Exported symbols must have a doc comment
+
+---
+
+## Testing
+[ID: go-lib-testing]
+[EXTEND: base-testing]
+
+- Use stdlib `testing` package — no third-party assertion libraries
+- Table-driven tests with `t.Run()` for parameterised cases
+- Test the public API of each package — not unexported functions
+- Use interfaces to inject dependencies in tests — no monkey-patching
+- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
+  e.g. `TestParseConfig_MissingField_ReturnsError`
+- Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Git conventions
+[ID: go-lib-git]
+[EXTEND: base-git]
+
+- Do not commit compiled binaries or `*.test` files
+- Do not commit `vendor/` unless vendoring is an explicit project decision —
+  document it in README if so
+- `go.sum` is committed — do not delete or regenerate without cause
+- Tag releases with `vX.Y.Z` — Go module proxy uses these
+
+---
+
+## Commands
+```
+go build ./...        # compile all packages
+go test ./...         # run all tests
+go vet ./...          # static analysis
+goimports -w .        # format imports
+staticcheck ./...     # additional static analysis
+```
+---
+
+## Quality gates
+[EXTEND: base-quality-gates]
+
+| Category | Layer 1 (editor) | Layer 2 (pre-commit) | Layer 3 (CI) | Config |
+|----------|-----------------|---------------------|-------------|--------|
+| Lint | golangci-lint | golangci-lint | golangci-lint | `.golangci.yml` |
+| Format | gofmt | gofmt | gofmt -l | built-in |
+| Type check | built-in | built-in | go vet | — |
+| Security | — | — | govulncheck + platform SAST | — |
+| Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
+| Tests | — | — | go test ./... | — |
+| Coverage | — | — | go test -cover ≥ 80% | — |
+
+- Hook framework: `pre-commit` or Makefile
 
 
 <!-- templates/backend/http.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1558,6 +1558,150 @@ CPU-bound work cannot be offloaded to a background job or worker process.
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -722,6 +722,267 @@ fixing the design fixes the testability.
   not hand-written mocks
 
 
+<!-- templates/base/core/config.md -->
+# Base — Configuration
+[ID: base-config]
+
+Follows the [12-factor app](https://12factor.net/config) principle:
+store config in the environment, not in code.
+
+## Rules
+
+- All configuration from environment variables — no hardcoded values
+  in source
+- Never hardcode secrets, API keys, or credentials — environment only
+- `.env.example` committed with placeholder values; `.env` in
+  `.gitignore`
+- Separate configuration per environment (development, testing,
+  production)
+- Pass config explicitly to components — no global config objects
+  accessed from arbitrary locations
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+
+## Naming conventions
+
+- Use `SCREAMING_SNAKE_CASE` for all environment variables
+- Prefix with the app or service name to avoid collisions
+  (e.g. `MYAPP_DATABASE_URL`, not `DATABASE_URL`)
+- Group related variables with a common prefix
+  (e.g. `MYAPP_DB_HOST`, `MYAPP_DB_PORT`, `MYAPP_DB_NAME`)
+- Boolean variables use `ENABLE_` or `DISABLE_` prefix
+  (e.g. `MYAPP_ENABLE_CACHE`)
+
+## Config precedence
+
+Sources override in this order (highest wins):
+
+1. **Hardcoded defaults** — in code, lowest priority
+2. **Config file** — `config.yaml`, `appsettings.json`, etc.
+3. **Environment variables** — override file values
+4. **CLI flags / arguments** — override everything
+
+- Document the precedence model for the project
+- Never let a lower-priority source silently override a
+  higher-priority one
+
+## Build-time vs runtime config
+
+- **Build-time** — values baked into the artifact at build (API base
+  URLs, feature flags, public keys). Changing them requires a rebuild.
+- **Runtime** — values read when the process starts or on each
+  request (secrets, database URLs, log levels). Changing them
+  requires a restart or hot-reload.
+- Never put secrets in build-time config — they end up in the
+  artifact and are visible to anyone who inspects it
+- Document which variables are build-time and which are runtime
+
+## Validation
+
+- Validate types, ranges, and formats at load time — not at first use
+- Use a typed config object or schema — never scatter raw environment
+  variable reads across the codebase
+- Provide sensible defaults only for optional, non-sensitive settings
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys
+
+## Secrets management
+
+- In production, source secrets from a dedicated secrets manager or
+  CI/CD secret store — not from flat `.env` files
+- Design secret loading to support rotation without a full
+  redeployment
+- Never log config values — redact or omit secrets from logs and
+  diagnostic output
+- Reference secrets by name or path, not by embedding them in config
+  files
+
+## Environment separation
+
+| Environment | Purpose           | Secrets source       |
+|-------------|-------------------|----------------------|
+| development | local work        | `.env` file          |
+| testing     | automated tests   | hardcoded stubs      |
+| staging     | pre-production    | secrets manager / CI |
+| production  | live              | secrets manager      |
+
+## Dependencies
+
+- Declare all dependencies explicitly in a manifest (`package.json`,
+  `pyproject.toml`, `go.mod`, `Cargo.toml`, `requirements.txt`)
+- Commit the lockfile (`package-lock.json`, `poetry.lock`, `go.sum`,
+  `Cargo.lock`) — it pins exact versions for reproducible builds
+- Never rely on system-wide packages — the app MUST run with only
+  its declared dependencies installed
+- Separate production dependencies from dev/test dependencies
+
+## Port binding
+
+- The application exposes its service by binding to a port — it does
+  not depend on an external web server injecting itself at runtime
+- The port MUST be configurable via environment variable
+  (e.g. `PORT=8080`)
+- Do not hardcode port numbers in source code
+- In development, use a well-known default; in production, the
+  platform assigns the port
+
+## `.env.example` structure
+
+```
+# Required
+API_BASE_URL=http://localhost:8000
+SECRET_KEY=change-me
+
+# Optional — defaults shown
+LOG_LEVEL=info
+DEBUG=false
+```
+
+
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1872,6 +1872,150 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/workflow/quality-gates.md -->
+# Base — Quality Gates
+
+[ID: base-quality-gates]
+[DEPENDS ON: templates/base/core/quality.md, templates/base/core/git.md, templates/base/core/testing.md]
+
+Stack-agnostic quality gate model. Defines the layers, categories,
+thresholds, and constraints. Stack templates extend with concrete tools.
+Platform templates extend with CI-specific integration.
+
+---
+
+## Shift-left principle
+
+[ID: quality-gates-principle]
+
+The earlier a defect is caught, the cheaper it is to fix. Every check
+that can run locally MUST run locally. CI is the backstop, not the first
+line of defense.
+
+```
+Editor (0s) → Pre-commit (1-5s) → CI (1-5min) → Code review (hours)
+```
+
+---
+
+## Three-layer gate model
+
+[ID: quality-gates-layers]
+
+### Layer 1 — Editor (instant feedback)
+
+Runs in the developer's IDE as they type. Zero friction.
+
+- Every project MUST provide config files that enable checks automatically
+  when the project is opened in a supported editor
+- Checks: lint, format, type check
+
+### Layer 2 — Pre-commit hooks (1–5 seconds)
+
+Runs automatically before every commit. Blocks bad commits locally.
+
+- Every project MUST have pre-commit hooks
+- The hook framework is stack-specific (see stack template)
+- Checks: lint, format, type check, secret detection, file hygiene
+  (trailing whitespace, merge conflict markers, large files)
+
+### Layer 3 — CI (1–5 minutes)
+
+Runs on every PR. The final gate before merge.
+
+- Every project MUST have a CI workflow that runs on PRs
+- CI checks MUST be configured as required status checks in branch
+  protection — a passing CI run that does not block merge is
+  informational, not a gate
+- CI MUST duplicate Layer 2 checks — pre-commit hooks can be bypassed
+  with `--no-verify`
+- CI adds checks that cannot run locally: deep security analysis (SAST),
+  test suite, coverage measurement, build verification
+- The CI platform is project-specific (see platform template)
+
+---
+
+## Gate categories
+
+[ID: quality-gates-categories]
+
+Every project MUST enforce checks in the following categories. Stack
+templates map each category to a concrete tool.
+
+| Category         | Layer 1 | Layer 2 | Layer 3 | Description                                          |
+| ---------------- | ------- | ------- | ------- | ---------------------------------------------------- |
+| Lint             | MUST    | MUST    | MUST    | Code smells, unused variables, complexity            |
+| Format           | MUST    | MUST    | MUST    | Consistent style (indentation, spacing, line length) |
+| Type check       | SHOULD  | SHOULD  | MUST    | Type errors before runtime                           |
+| Secret detection | —       | MUST    | MUST    | API keys, tokens, passwords                          |
+| File hygiene     | —       | MUST    | —       | Trailing whitespace, merge conflicts, large files    |
+| Security (SAST)  | —       | —       | MUST    | Static analysis for vulnerabilities                  |
+| Tests            | —       | —       | MUST    | Unit and integration tests                           |
+| Coverage         | —       | —       | MUST    | Percentage of code exercised by tests                |
+| Build            | —       | —       | MUST    | Does it compile / build successfully                 |
+
+Stack templates MAY add additional categories (e.g. link checking, site
+quality scoring for web projects, docstring enforcement for Python).
+
+### Recommended lint plugins
+
+- **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
+  branches, identical expressions, and other code smells that standard
+  ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+---
+
+## Thresholds
+
+[ID: quality-gates-thresholds]
+
+| Metric                   | Threshold | Enforcement                  |
+| ------------------------ | --------- | ---------------------------- |
+| Lint errors              | 0         | CI fails                     |
+| Format compliance        | 100%      | CI fails                     |
+| Type errors              | 0         | CI fails                     |
+| Security (high/critical) | 0         | CI fails                     |
+| Secrets detected         | 0         | Pre-commit blocks + CI fails |
+| Build                    | Success   | CI fails                     |
+
+### Coverage policy
+
+- **New projects** — 80% from day one; CI fails below threshold
+- **Legacy projects** — coverage reported as warning only; CI shows the
+  number but never blocks; flip to error when the team has the mandate
+  to invest in testing
+
+Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
+
+---
+
+## What NOT to gate
+
+[ID: quality-gates-exclusions]
+
+- **Docstring coverage for non-public functions** — enforcing docs on
+  internal helpers creates busywork
+- **Cyclomatic complexity thresholds** — too many false positives on
+  legitimate complex logic; rely on lint warnings instead
+- **100% test coverage** — incentivizes meaningless tests; 80% is the
+  practical sweet spot
+- **Commit message format** — enforce in PR title via repository settings,
+  not per-commit hooks; allow messy WIP commits on feature branches
+
+---
+
+## Tool constraints
+
+[ID: quality-gates-constraints]
+
+- All tools MUST be free for private repositories
+- Prefer open-source tools over SaaS — no vendor lock-in
+- Prefer tools with CI integration for the project's platform
+- Prefer one tool per category — no redundant linters
+- Stack templates define the specific tool per category
+- Platform templates define the CI integration and SAST tool
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -255,6 +255,7 @@ stacks:
       - base-git
       - base-docs
       - base-quality
+      - base-quality-gates
 
   - id: stack-python-service
     file: templates/stack/python-service.md
@@ -313,6 +314,7 @@ stacks:
       - base-docs
       - base-quality
       - base-testing
+      - base-quality-gates
 
   - id: stack-go-service
     file: templates/stack/go-service.md

--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -76,6 +76,7 @@ reused for a different component within the same area.
 | `03` | OVERRIDE — replacement directive behaviour |
 | `04` | Reference resolution — EXTEND/OVERRIDE refs point to existing IDs |
 | `05` | Conflict resolution — two templates OVERRIDE the same section ID |
+| `06` | Chain reachability — EXTEND/OVERRIDE targets in resolved chain |
 
 ### MNF - Manifest
 
@@ -162,6 +163,7 @@ corrected prerequisites where test intent is unchanged.
 | `SAIT-INT-TPL-02-001A` | Integration — composition — EXTEND directive — spec 1, version A |
 | `SAIT-INT-TPL-03-001A` | Integration — composition — OVERRIDE directive — spec 1, version A |
 | `SAIT-INT-TPL-05-001A` | Integration — composition — conflict resolution — spec 1, version A |
+| `SAIT-INT-TPL-06-001A` | Integration — composition — chain reachability — spec 1, version A |
 | `SAIT-INT-MNF-01-001A` | Integration — manifest — manifest entries — spec 1, version A |
 | `SAIT-INT-MNF-02-001A` | Integration — manifest — resolution — spec 1, version A |
 | `SAIT-INT-MNF-03-001A` | Integration — manifest — core tier — spec 1, version A |

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -16,6 +16,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-INT-TPL-02-001A` | INT | P1 | EXTEND adds rules without removing base rules |
 | `SAIT-INT-TPL-03-001A` | INT | P1 | OVERRIDE replaces parent section entirely |
 | `SAIT-INT-TPL-05-001A` | INT | P1 | Conflicting OVERRIDEs on the same ID are flagged or resolved |
+| `SAIT-INT-TPL-06-001A` | INT | P1 | EXTEND/OVERRIDE targets are reachable in the resolved chain |
 | `SAIT-INT-MNF-01-001A` | INT | P0 | All manifest entries reference valid paths and IDs |
 | `SAIT-INT-MNF-02-001A` | INT | P0 | All stacks resolve to valid, non-empty file lists |
 | `SAIT-INT-MNF-03-001A` | INT | P0 | All resolved chains include core tier files |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -6,6 +6,7 @@ Implements:
   SAIT-SMK-SYS-01-001A  — all DEPENDS ON paths resolve to existing files
   SAIT-SMK-SYS-02-001A  — all section IDs are unique across all templates
   SAIT-SMK-TPL-04-001A  — all EXTEND/OVERRIDE directives reference existing IDs
+  SAIT-INT-TPL-06-001A  — EXTEND/OVERRIDE targets reachable in resolved chain
   SAIT-INT-MNF-01-001A  — all manifest entries reference valid paths and IDs
 
 Usage:
@@ -457,6 +458,49 @@ def check_mnf_04():
 
 
 # ---------------------------------------------------------------------------
+# TPL-06 — EXTEND/OVERRIDE targets reachable in resolved chain
+# ---------------------------------------------------------------------------
+
+def check_tpl_06():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    core_ids, entries, _ = _load_manifest()
+    id_pattern = re.compile(r'\[ID:\s*([^\]]+)\]')
+    ref_pattern = re.compile(r'\[(EXTEND|OVERRIDE):\s*([^\]]+)\]')
+    failures = []
+
+    stacks = [e for e in entries.values()
+              if e["file"].startswith("templates/stack/")]
+
+    for stack in stacks:
+        sid = stack["id"]
+        chain_files, _ = _resolve_stack(sid, core_ids, entries)
+
+        # Collect all IDs declared in chain files
+        chain_ids = set()
+        for f in chain_files:
+            content = read(os.path.join(ROOT, f))
+            for match in id_pattern.finditer(content):
+                chain_ids.add(match.group(1).strip())
+
+        # Check EXTEND/OVERRIDE targets in chain files
+        for f in chain_files:
+            content = read(os.path.join(ROOT, f))
+            rel = f.replace("\\", "/")
+            for match in ref_pattern.finditer(content):
+                directive = match.group(1)
+                ref_id = match.group(2).strip()
+                if ref_id not in chain_ids:
+                    failures.append(
+                        f"  {sid}: {rel} [{directive}: {ref_id}]"
+                        f" — target not in resolved chain"
+                    )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # E2E-01 — all cases.py paths resolve to existing files
 # ---------------------------------------------------------------------------
 
@@ -529,6 +573,8 @@ CHECKS = [
      "title": "EXTEND adds rules without removing base rules", "fn": check_tpl_02},
     {"id": "TPL-03", "spec": "SAIT-INT-TPL-03-001A",
      "title": "OVERRIDE replaces parent section with different content", "fn": check_tpl_03},
+    {"id": "TPL-06", "spec": "SAIT-INT-TPL-06-001A",
+     "title": "EXTEND/OVERRIDE targets reachable in resolved chain", "fn": check_tpl_06},
     {"id": "E2E-01", "spec": "SAIT-SMK-E2E-01-001A",
      "title": "All cases.py paths resolve to existing files", "fn": check_e2e_01},
 ]

--- a/tests/specs/SAIT-INT-TPL-06-001A.md
+++ b/tests/specs/SAIT-INT-TPL-06-001A.md
@@ -1,0 +1,68 @@
+---
+id: SAIT-INT-TPL-06-001A
+title: EXTEND and OVERRIDE targets are reachable in the resolved chain
+product: sait
+type: integration
+area: TPL
+priority: p1
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-05-06
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [chain, extend, override, reachability]
+---
+
+## Short description
+
+> **Given** the manifest is loaded and all stacks are resolved
+> **When** every `[EXTEND: <id>]` and `[OVERRIDE: <id>]` directive in every
+> file of a stack's resolved chain is collected
+> **Then** each referenced ID matches an `[ID: <id>]` tag declared in a file
+> that is also part of that same resolved chain
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every EXTEND/OVERRIDE target in every chain file is declared by another file in the same chain |
+| FAILED | One or more targets reference an ID declared in a file outside the resolved chain |
+| SKIPPED | PyYAML not installed |
+| BLOCKED | `SAIT-INT-MNF-02-001A` is failing |
+| ERROR | File system or manifest is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- `pyyaml` installed (`pip install pyyaml`)
+
+### Setup
+
+1. Load `templates/manifest.yaml`
+2. Resolve the dependency chain for every stack entry
+
+### Execution
+
+1. For each stack, collect all `[ID: X]` declarations from every
+   file in its resolved chain into a set `chain_ids`
+2. For each file in the chain, collect all `[EXTEND: X]` and
+   `[OVERRIDE: X]` references
+3. For each reference, check that the target ID is in `chain_ids`
+
+### Assertions
+
+1. Assert every EXTEND/OVERRIDE target is present in the chain's
+   collected IDs
+
+### Teardown
+
+None.
+
+## Related
+
+- Supersedes gap in: `SAIT-SMK-TPL-04-001A` (checks global existence only)
+- Depends on: `SAIT-INT-MNF-02-001A` (chains must resolve first)
+- Context: issue #283, discovered via #276


### PR DESCRIPTION
## Summary

Closes #283.

Adds a new smoke check (TPL-06) that verifies every `[EXTEND: X]` and `[OVERRIDE: X]` target in a stack's resolved chain references an ID declared in a file that is also part of that chain. This closes the gap where TPL-04 only checked global existence.

**Bonus:** The new check immediately caught two more dangling references:
- `python-lib` had `[EXTEND: base-quality-gates]` but `base-quality-gates` was missing from its manifest `depends_on`
- `go-lib` had the same issue

Both fixed by adding `base-quality-gates` to their manifest entries.

## Changes

- `tests/run_smoke.py` — new `check_tpl_06()` function + registry entry
- `tests/specs/SAIT-INT-TPL-06-001A.md` — spec file
- `tests/INDEX.md` — added new spec row
- `tests/CODIFICATION.md` — added TPL-06 component group + full ID example
- `CLAUDE.md` — added check to §5.2 structure audit list
- `templates/manifest.yaml` — added `base-quality-gates` to python-lib and go-lib
- Regenerated affected stacks (python-lib 6→8 files, go-lib 6→8 files, plus downstream)

## Test plan

- [x] `py tests/run_smoke.py` — 12/12 pass (was 11 before)
- [x] `py tools/sync.py --check` — all in sync
- [x] New check catches known-bad state (verified by running against pre-fix manifest)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)