### PR TITLE
fix: restructure quality.md and add .editorconfig rule (#224, #255)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -3,16 +3,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -22,6 +12,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -98,10 +98,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -110,6 +106,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -122,6 +121,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -2,16 +2,6 @@
 
 [ID: base-quality]
 
-## Architecture
-
-- All editable content in a data directory — never hardcoded in source modules
-- Never hardcode derived counts or statistics — compute them from the data
-  source; a hardcoded number is a stale number
-- Default to the simplest abstraction; only reach for heavier patterns
-  when genuinely needed
-- No dead code — remove unused modules, assets, and data files promptly
-- No over-engineering — build the minimum needed for the current requirement
-
 ## Core principles
 
 - **DRY — Don't Repeat Yourself**: every piece of knowledge must have
@@ -21,6 +11,16 @@
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
   need is real
+
+## Architecture
+
+- All editable content in a data directory — never hardcoded in source modules
+- Never hardcode derived counts or statistics — compute them from the data
+  source; a hardcoded number is a stale number
+- Default to the simplest abstraction; only reach for heavier patterns
+  when genuinely needed
+- No dead code — remove unused modules, assets, and data files promptly
+- No over-engineering — build the minimum needed for the current requirement
 
 ## Readability
 
@@ -97,10 +97,6 @@
   code first and struggle to test later
 - If code is hard to test, treat it as a design problem, not a
   testing problem
-## Automated enforcement
-
-- Quality conventions in this document are enforced automatically via
-  quality gates (editor → pre-commit → CI)
 
 ## Code style
 
@@ -109,6 +105,9 @@
 - Line endings MUST be LF — CRLF is not acceptable in any committed file
 - A linter SHOULD enforce formatting automatically on save; keep manual style
   rules to a minimum
+- Commit an `.editorconfig` file at the project root — enforces indent
+  style, indent size, line endings, charset, and trailing whitespace
+  across all editors without tool-specific config
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
@@ -121,6 +120,11 @@
 - No commented-out code blocks — delete dead code; version control is the history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
+
+## Automated enforcement
+
+- Quality conventions in this document are enforced automatically via
+  quality gates (editor → pre-commit → CI)
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Closes #224 and #255.

**#224** — quality.md was restructured for logical flow (many sections were already extracted in earlier sessions, so only reordering remained):
- Core principles moved before Architecture (foundation first)
- Automated enforcement moved after Debug code (group all enforcement together)
- Flow: principles → structure → quality → enforcement → testing

**#255** — Added `.editorconfig` recommendation to the Code style section.

## Test plan
- [x] `py tests/run_smoke.py` — 12/12 pass
- [x] All 30 generated stacks regenerated

Closes #224
Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)