### PR TITLE
docs: replace stale hardcoded values in docs (#203)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -129,7 +129,7 @@ If the agent cannot run scripts, use the pre-resolved files in
 ## Run the test suite
 
 ```bash
-py tests/run_smoke.py              # 12 structural checks — seconds
+py tests/run_smoke.py              # structural checks — seconds
 py tests/run_e2e.py                # canary test (python-lib)
 py tests/run_e2e.py --all          # all agent tests
 py tests/run_e2e.py STK-01 FMT-01  # specific tests only
@@ -148,7 +148,7 @@ After editing any template or `manifest.yaml`, regenerate the cached
 files in `generated/`:
 
 ```bash
-py tools/resolve.py --generate     # regenerate all 30 files
+py tools/resolve.py --generate     # regenerate all cached files
 py tools/resolve.py --check        # verify they are up to date
 py tools/sync.py                   # also regenerates via --check
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -428,72 +428,54 @@ Ordering: base → backend/frontend → stack (topological sort of
 the dependency graph). Within the same depth level, order follows
 the `depends_on` list declaration order.
 
-### Example: static-site-astro (Resolution: full)
+### Example: static-site-astro
 
-```
-Declaration:
-  Stack: stack-astro
-  Extras: data-quality, 360, issues, scope
-  Platform: github
-  Resolution: full
-
-Resolved (17 files):
-  templates/base/core/git.md
-  templates/base/core/docs.md
-  templates/base/core/quality.md
-  templates/base/workflow/quality-gates.md
-  templates/base/core/testing.md
-  docs/patterns/testing.md            ← full resolution
-  templates/base/language/typescript.md
-  templates/frontend/ux.md
-  templates/frontend/quality.md
-  docs/patterns/frontend.md           ← full resolution
-  templates/frontend/static-site.md
-  templates/stack/static-site-astro.md
-  templates/base/language/data-quality.md  ← extra
-  templates/base/workflow/360.md           ← extra
-  templates/base/workflow/issues.md        ← extra
-  templates/base/workflow/scope.md         ← extra
-  templates/platform/github.md             ← platform
+```bash
+py tools/resolve.py stack-astro
 ```
 
-### Example: python-flask (Resolution: rules)
-
 ```
-Declaration:
-  Stack: stack-flask
-  Extras: scope, issues
-  Platform: github
-  Resolution: rules
-
-Resolved (17 files):
-  templates/base/core/git.md
-  templates/base/core/docs.md
-  templates/base/core/quality.md
-  templates/stack/python-lib.md
-  templates/backend/config.md
-  templates/backend/http.md
-  templates/backend/database.md
-  templates/backend/observability.md
-  templates/backend/quality.md
-  templates/backend/features.md
-  templates/backend/messaging.md
-  templates/stack/python-service.md
-  templates/stack/python-flask.md
-  templates/base/workflow/scope.md       ← extra
-  templates/base/workflow/issues.md      ← extra
-  templates/platform/github.md           ← platform
-  templates/base/core/agents.md          ← output format
+templates/base/core/quality.md
+templates/base/core/git.md
+templates/base/core/docs.md
+templates/base/core/readme.md
+templates/base/core/testing.md
+templates/frontend/static-site.md
+templates/base/language/typescript.md
+templates/base/core/config.md
+templates/base/workflow/quality-gates.md
+templates/stack/static-site-astro.md
 ```
 
-### Current vs target
+### Example: python-flask
 
-| Step | Current | Target |
-|------|---------|--------|
-| Declaration | Hand-curated file list | `Stack: <id>` + extras |
-| Resolution | None — flat list is the resolution | Agent resolves from manifest.yaml |
-| Pattern inclusion | Manual — must list each file | Automatic via `Resolution: full` |
-| Upstream changes | Must edit startup block manually | Submodule bump is sufficient |
+```bash
+py tools/resolve.py stack-flask
+```
+
+```
+templates/base/core/quality.md
+templates/base/core/git.md
+templates/base/core/docs.md
+templates/base/core/readme.md
+templates/base/core/testing.md
+templates/base/core/config.md
+templates/backend/http.md
+templates/backend/database.md
+templates/backend/observability.md
+templates/base/core/oop.md
+templates/base/security/security.md
+templates/base/infra/containers.md
+templates/backend/quality.md
+templates/backend/features.md
+templates/backend/messaging.md
+templates/base/infra/cicd.md
+templates/base/security/devsecops.md
+templates/base/workflow/quality-gates.md
+templates/stack/python-lib.md
+templates/stack/python-service.md
+templates/stack/python-flask.md
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #203.

- **SPEC.md** — replaced resolution examples that referenced non-existent files (`docs/patterns/testing.md`, `templates/base/language/data-quality.md`) and unimplemented features (`Resolution: full`, `Extras`, `Platform`) with current `py tools/resolve.py` output
- **PLAYBOOK.md** — removed hardcoded counts ("12 structural checks", "30 files") that go stale on every addition

## Test plan
- [x] `py tests/run_smoke.py` — 12/12 pass
- [x] `py tools/sync.py --check` — all in sync

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)