### PR TITLE
docs: establish issue and PR naming conventions (#233)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ py tools/resolve.py --generate               # regenerate all cached files
   `chore/<scope>`
 - Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
   docs, refactor
+- PR titles: `<type>(<scope>): <summary> (#issue)` — same format
+  as commits, with issue number(s) at the end
+- Issue titles: sentence case, imperative verb — no type prefix
+  (labels carry the type)
 - PRs are small and focused — one concern per PR; one approval
   required to merge
 - After a PR is merged, delete branch and pull main before starting

--- a/docs/decisions/008-naming-conventions.md
+++ b/docs/decisions/008-naming-conventions.md
@@ -1,0 +1,53 @@
+# ADR-008: Issue and PR Naming Conventions
+
+## Status
+
+Accepted
+
+## Context
+
+There was no documented convention for issue titles or PR titles.
+Some PRs included ticket numbers, others did not. Squash-merge
+commit messages derive from PR titles, so inconsistency in titles
+creates inconsistency in the git log.
+
+## Decision
+
+### Issue titles
+
+- Sentence case, imperative verb: "Add X", "Fix Y", "Remove Z"
+- No type prefix — the issue label carries the type
+- No ticket number — it is assigned by GitHub
+
+### PR titles
+
+- Conventional Commits format: `<type>(<scope>): <summary>`
+- Types: `feat`, `fix`, `chore`, `docs`, `refactor`
+- Include the issue number(s) at the end: `(#123)` or `(#123, #456)`
+- Summary in lowercase, imperative, under 70 characters
+- Examples:
+  - `feat(stack): add python-celery-worker template (#180)`
+  - `fix: correct dependency chains across stacks (#271, #274)`
+  - `docs: add terminology review checklist (#285)`
+
+### Squash-merge commit messages
+
+- PR title becomes the commit subject line (automatic with squash)
+- PR body becomes the commit body (automatic with squash)
+- No manual editing of the squash commit message needed
+
+## Alternatives considered
+
+1. **No convention** — status quo; leads to inconsistent git log
+2. **Conventional Commits for issues too** — adds noise; issue
+   titles are read by non-developers; labels serve the same purpose
+3. **No ticket number in PR title** — loses traceability in
+   `git log --oneline`; the number is the cheapest link back to
+   the discussion
+
+## Consequences
+
+- Git log reads cleanly: every line has type, scope, summary,
+  and ticket reference
+- Issue titles remain human-readable without prefix noise
+- No CI enforcement needed — this is a guideline, not a gate


### PR DESCRIPTION
## Summary

Closes #233.

Creates ADR-008 documenting naming conventions for issues and PRs:
- **Issue titles**: sentence case, imperative verb, no type prefix
- **PR titles**: Conventional Commits format with issue number(s)
- **Squash commits**: inherit PR title automatically

Also adds the conventions to CLAUDE.md §2.1 Git section.

## Test plan
- [x] `py tools/sync.py --check` — all in sync

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)