### PR TITLE
fix: add focus-visible rule for anchor elements (#104)

### DIFF
--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -805,6 +805,8 @@ fixing the design fixes the testability.
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1134,6 +1134,8 @@ every project regardless of language or framework.
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1134,6 +1134,8 @@ every project regardless of language or framework.
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -805,6 +805,8 @@ fixing the design fixes the testability.
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1134,6 +1134,8 @@ every project regardless of language or framework.
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy

--- a/templates/frontend/ux.md
+++ b/templates/frontend/ux.md
@@ -24,6 +24,8 @@
   `:focus` shows outlines on mouse clicks (distracting), `:focus-visible`
   shows them only for keyboard navigation
 - Focus indicators must be visible at all times during keyboard navigation
+- All `<a>` elements and nav links MUST have a visible `:focus-visible`
+  outline — links often lack focus styles even when buttons have them
 - No content that relies on colour alone to convey meaning
 - Images must have descriptive `alt` text; decorative images use `alt=""`
 - Semantic HTML: correct landmark elements and heading hierarchy


### PR DESCRIPTION
## Summary

Closes #104. Also closes #131 (already present).

Adds explicit MUST rule to `frontend/ux.md` requiring `:focus-visible` outlines on all `<a>` elements and nav links. The existing generic `:focus-visible` rule didn't call out anchors specifically.

## Test plan
- [x] `py tests/run_smoke.py` — 13/13 pass

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)