### PR TITLE
docs: document user paths and model limitations (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ model and prompt size.
 
 ## How to use
 
-**Prerequisites:** an AI coding agent (Claude Code, Cursor, Copilot,
-Codex CLI) and a project you want to generate conventions for.
+**Prerequisites:** any LLM interface — local agent (Claude Code,
+Cursor, Codex CLI), web portal (Claude.ai, ChatGPT, Gemini), or
+REST API (Anthropic, OpenAI).
 
 **Output:** a `CLAUDE.md` or `AGENTS.md` file placed at your project
 root, containing coding conventions tailored to your stack.
@@ -57,6 +58,11 @@ database: PostgreSQL, auth: JWT.
 
 The agent drafts a context file. Review it, adjust as needed, and
 place it at your project root.
+
+> **Web portal or API?** Use a pre-resolved file from `generated/`
+> instead of a single stack template — it includes the full
+> dependency chain in one file. See
+> [model limitations](#model-limitations) for token guidance.
 
 ### Use it — clone and run the interview
 
@@ -96,6 +102,22 @@ git submodule add https://github.com/braboj/solid-ai-templates.git .ai-templates
 To update templates: `git submodule update --remote`. Then
 re-run the interview to regenerate your context file with the
 latest rules.
+
+## Model limitations
+
+| Stack category | Prompt size | Min context window |
+|----------------|-------------|-------------------|
+| Library / CLI | ~12K tokens | 32K |
+| Static site | ~15K tokens | 32K |
+| Backend service | ~25–50K tokens | 128K |
+| Full-stack | ~40–60K tokens | 128K |
+
+- **Output token limit < 16K** (e.g. GPT-4o default): generated file
+  may be truncated — generate section by section or set `max_tokens`
+  to the model maximum
+- **Output token limit 32K+**: full inline file fits in one pass
+- **Free tier rate limits**: use a local agent or a pre-resolved file
+  to minimise round trips
 
 ## Supported stacks
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -106,6 +106,26 @@ If the agent cannot run scripts, use the pre-resolved files in
 2. Attach `templates/base/core/agents.md` (output format)
 3. Provide your answers and ask the agent to generate the file
 
+### Path selection guide
+
+| Interface | Recommended path | Why |
+|-----------|-----------------|-----|
+| Local agent (Claude Code, Codex CLI) | Interview or direct | Agent reads files from disk |
+| Web portal (Claude.ai, ChatGPT) | Pre-resolved | Upload one file, no shell needed |
+| REST API | Pre-resolved | Include `generated/<stack>.md` in prompt |
+
+### Model limitations
+
+| Stack category | Prompt size | Min context window |
+|----------------|-------------|-------------------|
+| Library / CLI | ~12K tokens | 32K |
+| Static site | ~15K tokens | 32K |
+| Backend service | ~25–50K tokens | 128K |
+| Full-stack | ~40–60K tokens | 128K |
+
+- Output token limit < 16K: generate section by section
+- Output token limit 32K+: full inline file fits in one pass
+
 ---
 
 ## Validate a template change


### PR DESCRIPTION
## Summary

Closes #237 (partially — agent-based e2e test deferred).

- **README.md**: prerequisites updated to mention web portal and API paths; added callout for pre-resolved files; new "Model limitations" section with token estimates per stack category and output token guidance
- **PLAYBOOK.md**: added path selection guide table (local agent / web portal / API) and model limitations after the generation workflow

Agent-based e2e test (using `claude -p`) deferred as it requires live agent execution and is out of scope for structural changes.

## Test plan
- [x] `py tests/run_smoke.py` — 13/13 pass
- [x] `py tools/sync.py --check` — all in sync

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)