### PR TITLE
docs: mention codified industry standards in README overview (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # SOLID-AI Templates
 
+Five developers with five agents produce five coding styles — unless they
+share the same context file.
+
 Your AI agent writes better code when it has good instructions — but most
 teams write CLAUDE.md and AGENTS.md files from scratch, and they quickly
 fall out of sync.
@@ -17,13 +20,11 @@ consistent context files for any stack and any agent.
 
 ## Overview
 
-Most AI context files are written from scratch for each project and quickly
-fall out of sync. This repository provides a reusable template system —
-structured like object-oriented design — where base rules are defined once
-and composed with stack-specific extensions to build a context file
-for any project type. Templates codify industry standards (12-factor app,
-OWASP, SOLID, SemVer, conventional commits) into actionable rules your
-agent can follow.
+This repository provides a reusable template system — structured like
+object-oriented design — where base rules are defined once and composed
+with stack-specific extensions to build a context file for any project
+type. Templates codify industry standards (12-factor app, OWASP, SOLID,
+SemVer, conventional commits) into actionable rules your agent can follow.
 
 Works for new projects and refactoring alike — the context file
 describes how code *should be written*, giving your agent a consistent

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Most AI context files are written from scratch for each project and quickly
 fall out of sync. This repository provides a reusable template system —
 structured like object-oriented design — where base rules are defined once
 and composed with stack-specific extensions to build a context file
-for any project type.
+for any project type. Templates codify industry standards (12-factor app,
+OWASP, SOLID, SemVer, conventional commits) into actionable rules your
+agent can follow.
 
 Works for new projects and refactoring alike — the context file
 describes how code *should be written*, giving your agent a consistent


### PR DESCRIPTION
## Summary

- Add a line to the README Overview section mentioning codified standards (12-factor, OWASP, SOLID, SemVer, conventional commits)
- Repo topics updated separately (not in diff): removed generic topics (`templates`, `devtools`, `ai-tools`), added targeted ones (`12-factor`, `owasp`, `codex-cli`, `copilot`, `coding-standards`, `ai-workflow`, `code-quality`)

Closes #210

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Confirm repo topics appear on the repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)