### PR TITLE
docs(core): expand PLAYBOOK structure to 5 sections with extensibility

### DIFF
--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -61,8 +61,14 @@ levels. Every rule MUST use one of these words:
 1. **Git workflow** — branch, commit, PR, merge, issues
 2. **Domain operations** — how to add/modify the project's core data or
    entities (project-specific — e.g. "add a new lens", "add a migration")
-3. **Maintenance** — update dependencies, quality conventions, ADRs
-4. **Release and deploy** — release process, tagging, deployment
+3. **Quality** — testing, CI checks, linting, link checking, secret
+   scanning, and other quality verification workflows
+4. **Maintenance** — update dependencies, quality conventions, ADRs
+5. **Release and deploy** — release process, tagging, deployment
+
+Projects MAY add sections beyond these five (e.g. "Observability",
+"Infrastructure") — append them before Release and deploy, which MUST
+remain the last section.
 
 ## Documentation rule
 


### PR DESCRIPTION
## Summary
- Add section 3 (Quality) between Domain operations and Maintenance
- Renumber Maintenance to 4, Release and deploy to 5
- Add extensibility clause: projects MAY add sections beyond the base five; Release and deploy MUST remain last

Motivated by wuseria project where testing, Lighthouse, lychee, gitleaks, CodeQL, Dependabot, and analytics verification were awkwardly placed under Domain operations. Quality is a distinct operational concern that deserves its own chapter.

Consumed by wuseria PR Imbra-Ltd/wuseria#673.

## Test plan
- [x] Structural change only — no code affected
- [x] Rule language follows RFC 2119 conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)