### PR TITLE
feat(frontend): upstream frontend conventions from wuseria

### DIFF
--- a/templates/frontend/quality.md
+++ b/templates/frontend/quality.md
@@ -88,5 +88,18 @@ Rules:
 - `robots.txt`, Open Graph, and Twitter Card meta tags required for
   server-rendered and static pages
 - Canonical URLs required for publicly indexed pages
+- MUST pick a trailing slash convention (with or without) and enforce it
+  across all internal links, canonical URLs, and sitemap entries — redirect
+  chains waste crawl budget, split link equity, and can prevent indexing
+- Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+
+## Structured data (if applicable)
+
+- Schema `@type` MUST match the page's actual role — do not use
+  `Product` + `Offer` on informational pages that do not sell anything
+- Fields MUST NOT imply capabilities the site lacks (e.g. `availability`
+  implies commerce, `priceValidUntil` implies a store)
+- Review schema choice when site role differs from template examples —
+  e-commerce examples applied to editorial sites produce misleading markup

--- a/templates/frontend/static-site.md
+++ b/templates/frontend/static-site.md
@@ -130,6 +130,17 @@ to change.
 
 ---
 
+## Trailing slash
+[ID: static-site-trailing-slash]
+
+- MUST verify the trailing slash convention matches the hosting platform's
+  behavior (e.g. GitHub Pages forces trailing slashes, Netlify and Vercel
+  are configurable)
+- SHOULD add a CI check that scans built HTML output for internal hrefs
+  violating the convention
+
+---
+
 ## SEO
 [ID: static-site-seo]
 [EXTEND: frontend-quality]

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -65,6 +65,17 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 
 ---
 
+## GitHub Pages
+
+[ID: platform-github-pages]
+
+- MUST enable "Enforce HTTPS" in repository Settings → Pages for custom
+  domains — GitHub Pages does not enforce HTTPS by default
+- HTTP requests MUST 301 redirect to HTTPS — without enforcement, HTTP
+  serves content with 200 OK, causing duplicate content and SEO penalties
+
+---
+
 ## Quality gate integration
 
 [ID: platform-github-gates]

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -204,6 +204,13 @@ files into `src/content/`.
 - **ESLint** with `@typescript-eslint/recommended` and
   `eslint-plugin-sonarjs` for any `.ts` / `.tsx` files —
   configured in `eslint.config.js`, run on save
+- Enable `parserOptions.projectService` for type-checked linting — many
+  `sonarjs` rules (e.g. `no-alphabetical-sort`) require type info and are
+  silently inert without it; use `recommended` not `recommendedTypeChecked`
+  (the latter enables `no-unsafe-*` rules that break on CSS module imports
+  and Astro content collection types)
+- `eslint-plugin-unicorn` SHOULD be added for rules not covered by sonarjs
+  (e.g. `no-zero-fractions`, `prefer-number-properties`)
 - **Prettier** owns all formatting — commit `.prettierrc`; no style debates
   in code review
 - `.astro` files formatted with the official Prettier Astro plugin
@@ -273,6 +280,14 @@ Rules:
 - Hook framework: `husky` + `lint-staged` — config in `package.json`
 - Lighthouse thresholds: accessibility ≥ 90 (error), performance / SEO /
   best practices ≥ 90 (warn)
+
+---
+
+## Trailing slash
+[EXTEND: static-site-trailing-slash]
+
+- MUST set `trailingSlash` in `astro.config.mjs` to match hosting platform
+  (`"always"` for GitHub Pages, `"never"` for Netlify/Vercel defaults)
 
 ---
 


### PR DESCRIPTION
## Summary

- **#310** — HTTPS enforcement for GitHub Pages (new section in `platform/github.md`)
- **#309** — Trailing slash consistency guidance (`frontend/quality.md`, `frontend/static-site.md`, `stack/static-site-astro.md`)
- **#319** — Structured data semantic accuracy check (`frontend/quality.md`)
- **#318** — Type-checked ESLint + unicorn plugin for Astro (`stack/static-site-astro.md`)
- **#133** — Boolean sort descending first click (already implemented at `frontend/ux.md:79`)

## Files changed

- `templates/platform/github.md` — GitHub Pages HTTPS section (#310)
- `templates/frontend/quality.md` — trailing slash rule, structured data section (#309, #319)
- `templates/frontend/static-site.md` — trailing slash platform verification (#309)
- `templates/stack/static-site-astro.md` — trailing slash config, type-checked ESLint (#309, #318)

## Test plan

- [x] `py tests/run_smoke.py` — 17/17 pass

Closes #310, closes #309, closes #319, closes #318, closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)