### PR TITLE
feat(frontend): SEO strategy checks and manual quality tools

### DIFF
--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -62,7 +62,10 @@ levels. Every rule MUST use one of these words:
 2. **Domain operations** — how to add/modify the project's core data or
    entities (project-specific — e.g. "add a new lens", "add a migration")
 3. **Quality** — testing, CI checks, linting, link checking, secret
-   scanning, and other quality verification workflows
+   scanning, and other quality verification workflows; manual verification
+   tools (analytics, search indexing, SEO crawls, performance field data)
+   belong here alongside automated checks — list automated first, manual
+   last
 4. **Maintenance** — update dependencies, quality conventions, ADRs
 5. **Release and deploy** — release process, tagging, deployment
 

--- a/templates/frontend/static-site.md
+++ b/templates/frontend/static-site.md
@@ -156,3 +156,15 @@ to change.
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)
+
+### SEO strategy (structure audit)
+
+- **Title-intent alignment** — page titles SHOULD match the queries users
+  actually type (check GSC or keyword research); include the primary
+  keyword, not just abbreviations or internal jargon; 50–60 characters
+- **Internal linking** — related pages SHOULD link to each other (topical
+  clusters); no orphan pages (every page reachable within 3 clicks from
+  the homepage); content pages SHOULD average 3+ internal links
+- **Content depth** — pages intended for indexing SHOULD exceed ~150 words;
+  pages below threshold are either enriched or noindexed; no
+  duplicate/near-duplicate thin pages


### PR DESCRIPTION
## Summary

- **#321** — SEO strategy checks (title-intent, internal linking, content depth) in `frontend/static-site.md`
- **#317** — Manual verification tools guidance in PLAYBOOK Quality section in `base/core/docs.md`
- **#138** — Already implemented at `docs.md:47-52` (verify step re-check guidance)

## Files changed

- `templates/frontend/static-site.md` — SEO strategy subsection under SEO (#321)
- `templates/base/core/docs.md` — PLAYBOOK Quality description expanded (#317)

## Test plan

- [x] `py tests/run_smoke.py` — 17/17 pass

Closes #321, closes #317, closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)