### PR TITLE
feat(git): forbid force-push, even with --force-with-lease (#329)

### DIFF
--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -26,6 +26,14 @@
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
   pushing to a stale one.
+- **Never force-push a branch**, including with `--force-with-lease`.
+  Force-push rewrites shared history and can clobber upstream commits
+  (collaborators, agents, CI bots) that haven't been fetched locally.
+  - When a PR branch is behind `main`, merge `main` into the branch —
+    do not rebase and force-push. On GitHub, use the "Update branch"
+    button or `gh pr update-branch <N>`.
+  - Squash-merge collapses the merge commit on merge, so local branch
+    shape does not pollute `main` history.
 - **After a PR is merged**, delete both remote and local branch, then pull main:
   ```
   git branch -d <branch>


### PR DESCRIPTION
## Summary

- Adds a rule to \`templates/base/core/git.md\` under **Pull requests**:
  never force-push a branch, including with \`--force-with-lease\`
- Documents the practical alternative — merge \`main\` into the branch,
  or use \`gh pr update-branch\` on GitHub
- Notes that squash-merge collapses the merge commit, so local branch
  shape does not pollute \`main\` history

Closes #329.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses RFC 2119-style imperative wording consistent with neighboring
  rules in the same file
- [x] Placed under **Pull requests**, before the "After a PR is merged"
  step where it's most discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)