### PR TITLE
feat(git): de-stack a PR by branching fresh + cherry-pick (#336)

### DIFF
--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -54,6 +54,21 @@ remaining commits are silently lost.
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
 
+### De-stacking a dependent branch
+
+When branch B was stacked on branch A and A has squash-merged to main,
+B still contains A's now-duplicate commit. The tempting fix is to
+rebase B onto main — but B is already pushed, so this requires a
+force-push, which is forbidden.
+
+- MUST NOT rebase the already-pushed B to drop A's commit
+- MUST branch fresh off the updated main and cherry-pick only B's
+  own commits; open the PR from the new branch
+- Delete the old stacked branch once its superseded PR is closed
+
+This keeps remote history intact and yields a clean,
+dependency-free diff.
+
 ## README
 - Every repository MUST contain a `README.md`
 - The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`


### PR DESCRIPTION
## Summary

- Adds a **De-stacking a dependent branch** subsection under
  Squash-merge safety in \`templates/base/core/git.md\`
- Covers the stacked-PR scenario: when B was stacked on A and A
  merged to main, do not rebase the pushed B — branch fresh off
  updated main and cherry-pick B's own commits
- Complements the no-force-push rule (#329) and squash-merge-safety
  rules by addressing the gap both leave open

Closes #336.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses RFC 2119 keywords (MUST / MUST NOT) consistent with
  neighboring rules
- [x] Placed as sibling subsection to Squash-merge safety — groups
  the three "shared-history" rules together

🤖 Generated with [Claude Code](https://claude.com/claude-code)