### PR TITLE
feat(git): add GitHub Release step to with-manifest release path (#338)

### DIFF
--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -100,11 +100,14 @@ dependency-free diff.
   7. Push, open PR, merge
   8. `git checkout main && git pull`
   9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  10. SHOULD create a GitHub Release from the tag:
+      `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
+      — a pushed tag alone does NOT create a Releases page entry.
 
 ### Post-release verification
-  10. Verify the manifest version matches the tag — e.g.
+  11. Verify the manifest version matches the tag — e.g.
       `grep '"version"' package.json` matches `git describe --tags`
-  11. A mismatch means the bump was missed or the wrong commit was
+  12. A mismatch means the bump was missed or the wrong commit was
       tagged — fix before announcing the release
 
 ### Projects without a version manifest (no-build)


### PR DESCRIPTION
## Summary

- Adds step 10 (SHOULD) to the with-manifest release path in
  \`templates/base/core/git.md\`: \`gh release create vX.Y.Z\`
- Clarifies in-line that a pushed tag and a GitHub Release are
  separate artifacts — a tag alone does not create a Releases page
- Renumbers Post-release verification to steps 11–12 (no cross-refs
  to the old numbers exist in the repo, verified by grep)

Closes #338.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses SHOULD (RFC 2119) — stronger than the issue's "Optional"
  framing, justified because the no-manifest path makes it a default
  step and the two paths should be symmetric
- [x] Grep confirmed no documentation cross-references the old
  step numbers (10/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)