### PR TITLE
feat(workflow): rewrite end-of-session step 6 around content rules (#355)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,8 +353,18 @@ summarize — visible sequential execution prevents missed steps.
    `docs/decisions/`
 6. **Smoke tests** — run `py tests/run_smoke.py` and confirm all
    checks pass
-7. **CLAUDE.md** — for each new convention or rule introduced,
-   does it belong here? Name the section.
+7. **CLAUDE.md** — for each new convention/rule, apply the
+   doc-placement decision tree in
+   `templates/base/workflow/ai-workflow.md` (Doc placement decision
+   tree section): evaluate code → ADR → README → PLAYBOOK →
+   CLAUDE.md → memory in order. CLAUDE.md is the home ONLY if the
+   agent MUST apply the rule on every turn.
+
+   CLAUDE.md contains rules only — not changelogs, package
+   architecture, per-feature progress, or session logs. Each rule
+   fits on one line; if it needs a paragraph, write an ADR and
+   leave a one-line pointer here. Evaluate items individually; do
+   not batch-dismiss.
 8. **README.md** — for each new command, dependency, or structural
    change, is it reflected? Name the section.
 9. **docs/SPEC.md** — for each change to composition model or ID

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -102,9 +102,16 @@ summarize — visible sequential execution prevents missed steps.
 5. **ADRs** — record any architectural decisions in `docs/decisions/`.
    Check: were any new directories created or content moved between
    documents? Each one needs an ADR.
-6. **CLAUDE.md** — list each new convention/rule by name, then evaluate
-   individually: does it belong here? Name the section. Do not
-   batch-dismiss.
+6. **CLAUDE.md** — for each new convention/rule, apply the doc-placement
+   decision tree in `ai-workflow.md` (Doc placement decision tree
+   section): evaluate code → ADR → README → PLAYBOOK → CLAUDE.md →
+   memory in order. CLAUDE.md is the home ONLY if the agent MUST
+   apply the rule on every turn.
+
+   CLAUDE.md contains rules only — not changelogs, package architecture,
+   per-feature progress, or session logs. Each rule fits on one line;
+   if it needs a paragraph, write an ADR and leave a one-line pointer
+   here. Evaluate items individually; do not batch-dismiss.
 7. **README.md** — for each new command, dependency, or structural
    change, is it reflected? Name the section.
 8. **ONBOARDING.md** — for each new tool, prerequisite, or setup step,


### PR DESCRIPTION
## Summary

- Rewrites end-of-session step 6 in \`templates/base/workflow/scope.md\`
  to apply the doc-placement decision tree (from #354) rather than
  asking \"does it belong in CLAUDE.md?\"
- CLAUDE.md is the home ONLY if the agent MUST apply the rule on
  every turn — otherwise route to code, ADR, README, PLAYBOOK, or
  memory
- Adds the operational gate: CLAUDE.md contains rules only, not
  changelogs, package architecture, per-feature progress, or session
  logs. Each rule fits on one line; paragraph-length rules belong in
  an ADR with a one-line pointer
- Mirrored the same change in this project's own \`CLAUDE.md\` step 7
  (same wording, offset numbering)

Closes #355.

## Side discovery

Smoke check SYS-02 treats inline \`[ID: ...]\` prose references as
duplicate declarations. Filed as #364; worked around in this PR by
referencing the section by name instead.

## Cross-references

- Builds on #354 (PR #363) — the doc-placement decision tree this
  step 6 now points to
- May affect #327 (\"Strengthen wrap-up checklist steps 6 and 9 with
  explicit enumeration\") — the new wording preserves \"Evaluate
  items individually; do not batch-dismiss,\" so #327's intent is
  retained, but its scope may want re-checking after this lands

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses RFC 2119 keywords (MUST / ONLY) consistent with the
  decision tree it points to
- [x] Both scope.md and this project's CLAUDE.md updated to keep
  wording in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)