### PR TITLE
feat(workflow): add agent output style rule (#351)

### DIFF
--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -196,6 +196,23 @@ This prevents CLAUDE.md and memory from silently absorbing content
 that belongs in code, ADRs, READMEs, or PLAYBOOK — which dilutes
 attention on rules that genuinely need to fire on every turn.
 
+### Agent output style
+[ID: ai-workflow-output-style]
+
+Output to the user MUST be terse and scannable. Optimize for the
+reader skimming the screen, not the writer covering all bases.
+
+- Short sections with clear headings
+- Bullets over paragraphs; one sentence per point where possible
+- Tables and lists over prose when comparing options
+- State the recommendation directly; reserve rationale for when asked
+- Skip throat-clearing ("Good call", "Fair enough", "Great question")
+- Skip restating the problem — the user already knows it
+- Match the response shape to the request: a one-line question gets
+  a one-line answer, not a structured document
+
+The aim is the reader's time, not the writer's thoroughness.
+
 ### Decide before delegating
 
 The agent will build whatever you ask. The expensive mistake is building the wrong thing fast. Spend time on:


### PR DESCRIPTION
## Summary

- Adds **Agent output style** section to
  \`templates/base/workflow/ai-workflow.md\`, next to the
  doc-placement decision tree from #354
- Rules: short sections + headings, bullets over paragraphs,
  recommendation first / rationale on request, no throat-clearing,
  no restating the problem, response shape matches request shape
- Tagged \`[ID: ai-workflow-output-style]\`

Closes #351.

## File location rationale

Extends \`ai-workflow.md\` rather than creating a new file
(\`agent-output.md\`) or sectioning \`quality.md\`:

- Third agent-behavior rule alongside doc placement (#354) and
  end-of-session content rules (#355); keeping the cluster in one
  place
- \`ai-workflow.md\` is explicitly about agent-collaboration
  practices; \`quality.md\` is about code quality (different concern)
- No manifest update, no sync, no chain change
- YAGNI: if \`ai-workflow.md\` outgrows itself later, extract then

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses RFC 2119 keyword (MUST)
- [x] \`[ID: ...]\` tag added per template authoring rules (CLAUDE.md §2.7)
- [x] Rules model the style they prescribe — short, imperative, no filler

🤖 Generated with [Claude Code](https://claude.com/claude-code)