### PR TITLE
feat(workflow): add match-document-convention rule (#357)

### DIFF
--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -150,6 +150,10 @@ Before every commit, update all relevant documentation:
 - Do not duplicate content that belongs elsewhere — link to ADRs for
   decisions, link to issues for task tracking, do not repeat data model
   specs that live in code
+- When writing a new entry, follow the document-convention-matching
+  rule in `templates/base/workflow/ai-workflow.md` (Match document
+  convention section) — read prior entries and copy their skeleton
+  exactly; the prior entry is the authoritative structural template
 
 ### Post-mortems
 

--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -213,6 +213,25 @@ reader skimming the screen, not the writer covering all bases.
 
 The aim is the reader's time, not the writer's thoroughness.
 
+### Match document convention
+[ID: ai-workflow-match-convention]
+
+Before appending to or editing any document with an established
+format (dev journal, ADRs, README, changelog, specs-log,
+scoring-log, etc.), the agent MUST read the most recent 1–2 prior
+entries and copy their skeleton: heading levels, section order,
+label style (e.g. `#### PRs` vs `**PRs:**`), bullet vs paragraph
+form, and presence/absence of preamble.
+
+This applies even when a project's CLAUDE.md or PLAYBOOK names the
+required *content* but not the exact *format* — the prior entry is
+the authoritative structural template. Do not let stylistic choices
+from the current chat session bleed into documents with their own
+convention.
+
+If the prior format is genuinely problematic and worth changing,
+raise it explicitly — never silently deviate.
+
 ### Decide before delegating
 
 The agent will build whatever you ask. The expensive mistake is building the wrong thing fast. Spend time on:


### PR DESCRIPTION
## Summary

- Adds **Match document convention** section to
  \`templates/base/workflow/ai-workflow.md\` — fourth and last
  agent-behavior rule alongside doc placement (#354), end-of-session
  content (#355), and output style (#351)
- Before appending to a structured document, the agent MUST read
  the most recent 1–2 prior entries and copy their skeleton exactly
- Cross-referenced from \`templates/base/core/docs.md\` Development
  journal section so the format rule surfaces wherever the journal
  is discussed

Closes #357.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses RFC 2119 keyword (MUST)
- [x] \`[ID: ai-workflow-match-convention]\` added per template
  authoring rules
- [x] Cross-reference added without restating the rule (DRY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)