### PR TITLE
feat(workflow): add branch cleanup to session startup (#326)

### DIFF
--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -150,6 +150,10 @@ Before every commit, update all relevant documentation:
 - Do not duplicate content that belongs elsewhere — link to ADRs for
   decisions, link to issues for task tracking, do not repeat data model
   specs that live in code
+- When writing a new entry, follow the document-convention-matching
+  rule in `templates/base/workflow/ai-workflow.md` (Match document
+  convention section) — read prior entries and copy their skeleton
+  exactly; the prior entry is the authoritative structural template
 
 ### Post-mortems
 

--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -213,6 +213,25 @@ reader skimming the screen, not the writer covering all bases.
 
 The aim is the reader's time, not the writer's thoroughness.
 
+### Match document convention
+[ID: ai-workflow-match-convention]
+
+Before appending to or editing any document with an established
+format (dev journal, ADRs, README, changelog, specs-log,
+scoring-log, etc.), the agent MUST read the most recent 1–2 prior
+entries and copy their skeleton: heading levels, section order,
+label style (e.g. `#### PRs` vs `**PRs:**`), bullet vs paragraph
+form, and presence/absence of preamble.
+
+This applies even when a project's CLAUDE.md or PLAYBOOK names the
+required *content* but not the exact *format* — the prior entry is
+the authoritative structural template. Do not let stylistic choices
+from the current chat session bleed into documents with their own
+convention.
+
+If the prior format is genuinely problematic and worth changing,
+raise it explicitly — never silently deviate.
+
 ### Decide before delegating
 
 The agent will build whatever you ask. The expensive mistake is building the wrong thing fast. Spend time on:

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -21,12 +21,16 @@ Before starting any work, the agent MUST:
    proceeding
 4. Check `git status` — if uncommitted changes exist, resolve before
    starting new work
-5. Confirm the scope with the user before making changes
-6. If the task is ambiguous, ask: "What is the specific deliverable for
+5. Clean up stale branches: `git fetch --prune` to remove stale
+   remote-tracking refs, then `git branch --merged main | grep -v
+   main | xargs -r git branch -d` to delete local branches whose
+   PRs have squash-merged
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable for
    this session?"
-7. Write down the agreed scope — refer back to it when the session
+8. Write down the agreed scope — refer back to it when the session
    drifts
-8. Review open issues related to the agreed scope before writing code
+9. Review open issues related to the agreed scope before writing code
 
 ## Mandatory startup block
 


### PR DESCRIPTION
## Summary

- Adds step 5 to \`templates/base/workflow/scope.md\` session
  startup: \`git fetch --prune\` + \`git branch --merged main\`
  delete pass
- Renumbers subsequent steps 5–8 → 6–9
- Cross-ref check confirms no other docs reference the old startup
  step numbers (the existing \"step 6\" reference is to the
  end-of-session wrap-up, a different list)

Closes #326.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses imperative wording consistent with neighboring steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)