### PR TITLE
feat(quality): require concrete revisit trigger on YAGNI deferrals (#340)

### DIFF
--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -10,7 +10,12 @@
   complexity must be justified by a requirement, not by elegance
 - **YAGNI — You Aren't Gonna Need It**: do not build for hypothetical
   future requirements; build what is needed now, refactor when the
-  need is real
+  need is real. When YAGNI defers a dependency, abstraction, or
+  feature, record the concrete *revisit trigger* alongside the
+  deferral (e.g. "when this grows to N config values," "when this
+  is extracted to its own repo," "when a second call site appears").
+  A deferral without a trigger gets re-argued every time it comes up
+  or quietly forgotten; a deferral with a trigger is a decision.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Extends the YAGNI core-principle bullet in
  \`templates/base/core/quality.md\` to require a concrete *revisit
  trigger* alongside any deferral
- Examples: \"when this grows to N config values,\" \"when this is
  extracted to its own repo,\" \"when a second call site appears\"
- Without a trigger, deferrals get re-argued every time or quietly
  forgotten; with a trigger, the deferral is a real decision

Closes #340.

## Placement rationale

Inline extension of the existing YAGNI bullet rather than a separate
section or a docs.md addition:

- Keeps the principle and its discipline together (one rule, one
  place — same logic as the squash-merge-safety + de-stack-PR
  grouping in #336)
- YAGNI is the trigger for the deferral; the revisit-trigger rule
  is the discipline that prevents YAGNI from becoming silent debt
- No new section, no manifest change, no chain change

## Test plan

- [x] Smoke tests pass (17/17)
- [x] Uses concrete examples without being prescriptive about format
- [x] Rule reads as imperative (\"record the concrete revisit
  trigger\") consistent with neighboring DRY/KISS bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)