### PR TITLE
feat(testing): rule on import-time env mutation across test process (#341)

### DIFF
--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -192,6 +192,16 @@ fixing the design fixes the testability.
   problem
 - Test behaviour, not implementation details
 - Each test MUST be independent — no shared mutable state between tests
+- Environment variables and other process-global state are shared
+  across the entire test process. A module that mutates the
+  environment (or any global) at *import time* leaks the change into
+  every test, and import order is not guaranteed. Tests that depend
+  on a variable being a specific value — including *unset* — MUST
+  set or clear it explicitly per test (e.g. `pytest`'s
+  `monkeypatch.setenv` / `monkeypatch.delenv`, equivalents in other
+  frameworks), never rely on the ambient process state. A test that
+  passes or fails depending on run order is an isolation bug, not
+  flakiness
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when


### PR DESCRIPTION
## Summary

- Strengthens \`templates/base/core/testing.md\` \"no shared mutable
  state\" rule with the specific case of process-global state
  (environment variables) leaking when mutated at import time
- Tests MUST set or clear the variable explicitly per test, never
  rely on ambient process state
- A test that passes or fails depending on run order is an
  isolation bug, not flakiness

Closes #341.

## Stack-agnostic framing

Kept the rule stack-agnostic per \`base/core/\` conventions: \`pytest\`'s
\`monkeypatch.setenv\` / \`monkeypatch.delenv\` is cited as an example,
not as the required tool. Equivalents apply in other frameworks
(Go's \`t.Setenv\`, JUnit's \`@SetEnvironmentVariable\`, etc.).
Language-specific guidance can live in stack templates if needed.

## Test plan

- [x] Smoke tests pass (17/17)
- [x] RFC 2119 keyword (MUST) consistent with neighboring rules
- [x] Added immediately after the general \"no shared mutable state\"
  rule, so the specific case follows the principle

🤖 Generated with [Claude Code](https://claude.com/claude-code)