### PR TITLE
feat(git): close-and-resubmit pattern for drifted PRs (#382)

### DIFF
--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -69,6 +69,29 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Close-and-resubmit when framing drifts
+
+When a PR's framing turns out to be wrong mid-review — the rule it
+amends should be superseded, the feature it adds belongs on a
+different layer, the bug it fixes is a symptom of a deeper issue —
+the title, branch name, body, and commit messages no longer match
+the actual decision.
+
+- SHOULD close the PR and open a new one with the correct framing,
+  rather than rewriting title, body, and commit history in place
+- The closed PR remains as the record of the rejected framing —
+  leave a comment pointing at the replacement
+- The new PR is internally consistent end-to-end: title, branch,
+  commits, and body all describe the actual decision
+- Indicator that close-and-resubmit is the right move: the branch
+  name is no longer accurate
+
+When NOT to close-and-resubmit:
+- Trivial title/body wording fixes — just amend
+- Scope additions during review that align with the original
+  framing — push more commits to the same branch
+- Renamed-but-equivalent decisions — just amend
+
 ## README
 - Every repository MUST contain a `README.md`
 - The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`


### PR DESCRIPTION
## Summary

- Adds a `### Close-and-resubmit when framing drifts` subsection to `templates/base/core/git.md` under `## Pull requests`, between the existing `### Squash-merge safety` and `### De-stacking a dependent branch` rules
- Codifies when to close-and-resubmit a PR vs. amend it: SHOULD close-and-resubmit when title/branch/body/commits no longer match the actual decision; SHOULD amend for trivial wording fixes, scope additions, or renames
- Captures the trigger indicator from the issue: *"the branch name is no longer accurate"*

Fixes #382.

## Why

Agent-assisted sessions are prone to mid-review framing drift, and without an explicit rule the natural path is to keep editing the in-flight PR, leaving a confusing trail. The pattern was used cleanly in the 2026-06-02 session that opened the issue.

## Test plan

- [x] `py tests/run_smoke.py` → 17/17 pass
- [x] Rule follows authoring conventions: imperative voice, RFC 2119 keywords, no explanatory prose in bullets
- [x] Placement is contextual — adjacent to the two other "PR/branch turned out wrong" patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)