### PR TITLE
feat(quality): probe scripts convention (#360)

### DIFF
--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -126,6 +126,21 @@
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
+### Probe scripts
+
+- Probe scripts are throwaway tooling: a small file that measures or
+  inspects something (data shape, file structure, runtime behaviour)
+  and prints findings to inform a source change
+- Name them so they are obviously temporary: `probe_*.py`, `_probe.sh`,
+  `scratch_*.ts`, or equivalent
+- A probe script MUST be deleted before the commit that uses its
+  findings — the script itself never lands on `main`
+- Findings worth keeping go into source comments, ADRs, or docs —
+  not the probe script
+- Probe scripts are the antidote to guessing: prefer writing one
+  over inferring data shape or runtime behaviour from incomplete
+  evidence
+
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via


### PR DESCRIPTION
## Summary

- Adds a `### Probe scripts` subsection under `## Debug code` in `templates/base/core/quality.md`
- Names probe scripts as throwaway investigation tooling (`probe_*.py`, `_probe.sh`, etc.)
- Requires deletion before the commit that uses the findings — probe script never lands on main
- Routes keepable findings into source comments, ADRs, or docs rather than the script itself
- Frames probe scripts as the antidote to guessing about data shape or runtime behaviour

Fixes #360.

## Why

Recurring pattern in real work that was undocumented — without naming it, agents either leave probe scripts polluting the tree or skip the probe step and guess. The convention closes both failure modes.

## Placement decision

Placed inside the existing `## Debug code` section rather than a new section. Probe scripts are temporary investigation tooling, sibling to the existing rules on debug statements, breakpoints, and gated debug helpers. No `manifest.yaml` update needed (no new file or top-level section).

## Test plan

- [x] `py tests/run_smoke.py` → 17/17 pass
- [x] Rule follows authoring conventions: imperative voice, RFC 2119 keywords, concrete naming examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)