### PR TITLE
feat(workflow): pwd check on negative shell result (#358)

### DIFF
--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -232,6 +232,34 @@ convention.
 If the prior format is genuinely problematic and worth changing,
 raise it explicitly — never silently deviate.
 
+### Verify working directory before concluding on a negative
+[ID: ai-workflow-pwd-on-negative]
+
+Agent shell tools persist the working directory across commands
+within a session. An earlier `cd` (yours or implicit from a chained
+command) can change where subsequent relative paths resolve, so a
+diagnostic that returns empty may be false-negative — running from
+the wrong directory rather than the file/entry actually being
+missing.
+
+When a path-based shell query (`test -f`, `ls`, `git -C <path>`,
+`cat`, etc.) returns empty or fails against a path you have reason
+to believe exists, the FIRST diagnostic step MUST be to verify the
+working directory (`pwd` or equivalent). Specifically check `pwd`
+when:
+
+- `test -f X` returns empty for a file you have grounds to expect
+- `git submodule status` returns empty in a repo with known
+  submodules — you may be inside a submodule, where the parent's
+  submodule list does not apply
+- `git ls-tree HEAD <path>` shows no expected entry — you may be
+  in a sibling repo or worktree
+- Any "from the repo root" diagnostic gives an unexpected negative
+
+During investigative work where the conclusion depends on a
+negative result, SHOULD use absolute paths for path-based queries
+to remove ambient-directory dependence entirely.
+
 ### Decide before delegating
 
 The agent will build whatever you ask. The expensive mistake is building the wrong thing fast. Spend time on:


### PR DESCRIPTION
## Summary

- Adds a `### Verify working directory before concluding on a negative` subsection to `templates/base/workflow/ai-workflow.md` under `## Practices for Agent Effectiveness`
- Tagged `[ID: ai-workflow-pwd-on-negative]` — sibling to the four agent-behavior rules added in v2.5 (`Doc placement decision tree`, `Agent output style`, `Match document convention`, `Decide before delegating`)
- Codifies pwd check as the FIRST diagnostic step on an unexpected negative from a path-based shell query, enumerates the specific cases (`test -f`, `git submodule status`, `git ls-tree`, "from the repo root" diagnostics), and recommends absolute paths for investigative work where the conclusion depends on a negative

Fixes #358.

## Placement decision

The issue deferred a choice between adding to `ai-workflow.md` or creating a new `agent-shell-discipline.md`. Chose **sibling rule in `ai-workflow.md`**:

1. Four v2.5 agent-behavior rules already set the precedent for this shape
2. A new file would require a manifest entry, an `[ID]` declaration, and `DEPENDS ON` updates across every stack chain — heavy overhead for one rule
3. The shell-discipline cluster isn't broad enough yet to merit its own file. If/when more shell-related rules accumulate, splitting is easier than merging

## Cross-reference note

The issue's AC asked for a reference from `scope.md`. Per the project's no-inline-cross-references rule (codified in v2.5), this is satisfied via co-presence in the resolved chain — both `ai-workflow.md` and `scope.md` are co-loaded in every base/workflow consumer, so the agent sees both rules together.

## Test plan

- [x] `py tests/run_smoke.py` → 17/17 pass (SYS-02 accepts the new ID declaration cleanly thanks to #364)
- [x] Rule follows authoring conventions: imperative voice, MUST/SHOULD keywords, concrete trigger list
- [x] `[ID: ai-workflow-pwd-on-negative]` declared as sole-line per the new SYS-02 rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)