### PR TITLE
feat(docs): ADRs SHOULD include inline ASCII diagram (#342)

### DIFF
--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -129,6 +129,24 @@ Before every commit, update all relevant documentation:
 - Implementation details (phrase tables, templates, worked examples) belong
   in the ADR itself, not in separate spec files — external specs create
   maintenance burden and go stale
+- Non-trivial ADRs SHOULD include at least one inline ASCII diagram or
+  mockup in the Decision section — a pipeline flow, layout sketch,
+  state transition, or similar — so the concept is scannable without
+  parsing dense prose. Use plain ASCII (`+`, `-`, `|`), not Unicode
+  box-drawing characters, to stay consistent with the ASCII-only
+  source-content rule and keep diffs clean. Example:
+
+  ```
+  +---------------------+---------------------+
+  |   original input    |    rendered output  |
+  +---------------------+---------------------+
+  |        overlay: rendered on original      |
+  +-------------------------------------------+
+  ```
+
+  Use the project's preferred rendered-diagram format (Mermaid,
+  Draw.io) for diagrams that need to be standalone artifacts; inline
+  ASCII is for the quick concept aid that lives inside the ADR
 - Creating a new directory or moving content between documents is an
   architectural decision — write the ADR **at the moment of the decision**,
   before creating the files


### PR DESCRIPTION
## Summary

- Adds a SHOULD-level rule to the `## Decision logs` section in `templates/base/core/docs.md`: non-trivial ADRs include at least one inline ASCII diagram or mockup in the Decision section (pipeline flow, layout sketch, state transition)
- Specifies plain ASCII (`+`, `-`, `|`) rather than Unicode box-drawing characters — matches the existing ASCII-only source-content rule in `base/core/quality.md:108` and keeps diffs clean
- Includes a small synthetic example mockup
- Notes the distinction between inline ASCII (quick concept aid inside the ADR) and the project's rendered-diagram format (Mermaid, Draw.io)

Fixes #342.

## Placement

Added as a bullet inside the existing `## Decision logs` section, between "Implementation details belong in the ADR itself" and "Creating a new directory is an architectural decision." No new section, no manifest update.

## Cross-reference note

The issue's third AC asked for a cross-reference to the "Diagrams and assets" section. Per the project's no-inline-cross-references rule, this is satisfied via co-presence — both sections live in `docs.md` and are loaded together. The rule body explicitly distinguishes inline ASCII (for the ADR) from rendered diagrams (Mermaid/Draw.io), so the reader sees both options.

## Test plan

- [x] `py tests/run_smoke.py` → 17/17 pass
- [x] Example mockup uses pure ASCII characters only
- [x] Rule follows authoring conventions: SHOULD keyword, imperative voice, one concrete example

🤖 Generated with [Claude Code](https://claude.com/claude-code)