### PR TITLE
docs: ADR governance summary in CLAUDE.md + PLAYBOOK (#393)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,16 @@ base/ ──┬── frontend/ ──┐
 - Each ADR documents: context, decision, alternatives considered,
   consequences
 - ADRs are immutable once merged — create a new ADR to supersede
-  an old one
+  an old one. The ONE exception: `superseded_by` / `status` /
+  `date` frontmatter fields on a previously-merged ADR MAY be
+  updated when a new ADR supersedes it
+- ADR schema is governed by ADR-010 — YAML frontmatter required
+  (`id` as quoted string, `status` in {Proposed, Accepted,
+  Superseded}, `date` YYYY-MM-DD, `category` in {composition,
+  templates, tooling, process, release}, reciprocal `supersedes` /
+  `superseded_by` links). Copy `docs/decisions/TEMPLATE.md` when
+  authoring a new ADR; `py tests/run_smoke.py ADR-01` enforces
+  the schema
 
 #### Rule language
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -77,6 +77,44 @@ composition model.
 
 ---
 
+## Author a new ADR
+
+ADRs live in `docs/decisions/` and follow the schema defined in
+`docs/decisions/010-adr-governance.md` (ADR-010). Use this workflow
+for any significant architectural decision (new layer, naming
+convention change, override model change, governance rule, etc.).
+
+1. Copy the template:
+   ```bash
+   NNN=$(printf "%03d" $(($(ls docs/decisions/[0-9]*.md | wc -l) + 1)))
+   cp docs/decisions/TEMPLATE.md docs/decisions/${NNN}-<slug>.md
+   ```
+   Slug is kebab-case, sentence-meaningful (e.g. `011-provenance-principle`).
+2. Fill in the frontmatter — `id` (quoted string matching `NNN`),
+   `status: Proposed` (or `Accepted` if the decision is already
+   ratified), `date` (today, `YYYY-MM-DD`), `category` from the
+   closed set in ADR-010, and `supersedes` / `superseded_by` lists.
+3. Replace `# ADR-NNN: Title in sentence case` with the real title
+   (colon form, sentence case).
+4. Write the four sections in order — **Context** (why this
+   decision is needed), **Decision** (what was decided, with
+   RFC 2119 keywords), **Alternatives considered** (what was
+   rejected and why), **Consequences** (downstream effects).
+   Non-trivial decisions SHOULD include an inline ASCII diagram
+   in the Decision section.
+5. If this ADR supersedes an existing one: update the old ADR's
+   frontmatter in the same PR — set its `status: Superseded`,
+   refresh `date`, and add this ADR's id to its `superseded_by`
+   list. This metadata-only update is the ONE allowed exception
+   to ADR immutability; the prose body of the superseded ADR
+   stays untouched.
+6. Run `py tests/run_smoke.py ADR-01` to validate the frontmatter
+   schema before opening the PR.
+7. Open the PR. After merge, the ADR is immutable except for
+   future supersession metadata updates.
+
+---
+
 ## Generate a context file for a project
 
 ### Interview path


### PR DESCRIPTION
## Summary

- `CLAUDE.md` §2.9 Decision logs — extends the immutability rule with the metadata-only exception from ADR-010, adds a bullet summarizing the schema (closed status / category sets, reciprocal supersession links) and pointing to `TEMPLATE.md` + the smoke check command
- `docs/PLAYBOOK.md` — adds an `## Author a new ADR` section in the "modify the repo structure" cluster (after `Rename a section ID`, before `Generate a context file`). Step-by-step: copy TEMPLATE.md → fill frontmatter → write the four sections → handle supersession metadata update → run smoke check → open PR

Fixes #393.

## Why two files but no duplication

CLAUDE.md is rules-only ("agent MUST apply on every turn"); PLAYBOOK is workflows ("here's how you do X"). Both point to the source of truth (ADR-010 + TEMPLATE.md) rather than copy its prose. Per the project's no-duplication-across-documents rule.

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass (ADR-01 still green; no schema changes)
- [x] CLAUDE.md addition stays in §2.9 (Documentation), follows the existing bullet style
- [x] PLAYBOOK section follows the existing imperative-numbered-step shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)