### PR TITLE
docs(readme): emphasize fork-and-extend over stack coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ consistent context files for any stack and any agent.
 ## What it does
 
 - Build `CLAUDE.md` or `AGENTS.md` from reusable layers — base, backend/frontend, stack
-- Cover Python, Go, Java, Node, Rust, mobile, and DevOps stacks
+- Fork and extend — layer your team's conventions on top of the base without modifying it
 - Output `CLAUDE.md` for Claude Code or `AGENTS.md` for Cursor, Copilot, Codex CLI
 - Codify industry standards — 12-factor app, OWASP, SOLID, SemVer, conventional commits
 - Run a 360-degree project assessment across four perspectives


### PR DESCRIPTION
## Summary

Swap the "Cover Python, Go, Java, Node, Rust, mobile, and DevOps stacks" bullet in `## What it does` for a fork-and-extend bullet that names the value: layer team conventions on top of the base without modifying it.

Same 6-bullet shape, one bullet swapped. Reader's takeaway shifts from "covers my stack" to "I can build my company conventions on top of this."

## Why

Aligns the top-of-page pitch with ADR-009 (stack scope cap + fork-and-extend model). Stack coverage is becoming a v3.0 restructure topic; the headline emphasis was creating expectations the project no longer wants to make. The supported-stacks table remains further down the README for users searching for specific stack support.

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass
- [x] One-line diff, no other content moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)