### PR TITLE
docs(readme): tighten subtitle, drop ADR-011 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SOLID-AI Templates
 
 *Forged in real work, not theorized — every rule here came from a real
-AI-assisted project. See
-[ADR-011](docs/decisions/011-provenance-principle.md).*
+AI-assisted project.*
 
 Five developers with five agents produce five coding styles — unless they
 share the same context file.


### PR DESCRIPTION
## Summary

One-line change: subtitle drops the `See [ADR-011]` tail.

Before:
> *Forged in real work, not theorized — every rule here came from a real AI-assisted project. See [ADR-011](docs/decisions/011-provenance-principle.md).*

After:
> *Forged in real work, not theorized — every rule here came from a real AI-assisted project.*

ADR-011 stays discoverable via `docs/decisions/`. Subtitle reads cleaner as a tagline rather than a teaser with a link tail.

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)