### PR TITLE
docs(readme): swap intro to variant F (solidarity voice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,22 @@
 *Forged in real work, not theorized — every rule here came from a real
 AI-assisted project.*
 
-Five developers with five agents produce five coding styles — unless they
-share the same context file.
+You've shipped the same CLAUDE.md three times this quarter. Each copy is
+slightly different, none of them are right, and the agent still doesn't
+know your team's conventions.
 
-Your AI agent writes better code when it has good instructions — but most
-teams write CLAUDE.md and AGENTS.md files from scratch, and they quickly
-fall out of sync.
+You're not alone, and it's not negligence — writing context files from
+scratch is the quiet cost of every agent-assisted team. Everyone pays
+it, few teams have a system for it, and the codebase drifts a little
+further from your standards every sprint.
 
-This repo gives you composable, SOLID-inspired templates for building
-consistent context files for any stack and any agent.
+This repo gives you composable templates that codify your team's
+conventions once — base rules, stack rules, company rules — and feed
+them to every agent on every project. Tax paid. Move on.
+
+Back to the work that actually moves the product. The spikes, the design
+conversations, the reviews that catch bugs instead of style nits. That's
+what your team's time is for.
 
 ## What it does
 


### PR DESCRIPTION
## Summary

Replace the three-paragraph neutral intro with the four-paragraph team-voice variant (F) from `docs/drafts/readme-intro-variants.md`.

Subtitle, `## What it does`, and `## How to use` sections are unchanged. The full draft with all seven variants (0, A–F) and reject reasons remains under `docs/drafts/` for future tone work.

## Before / after

**Before** (3 paragraphs, neutral observation voice):

> Five developers with five agents produce five coding styles — unless they share the same context file.
>
> Your AI agent writes better code when it has good instructions — but most teams write CLAUDE.md and AGENTS.md files from scratch, and they quickly fall out of sync.
>
> This repo gives you composable, SOLID-inspired templates for building consistent context files for any stack and any agent.

**After** (4 paragraphs, solidarity / freed-attention voice):

> You've shipped the same CLAUDE.md three times this quarter. Each copy is slightly different, none of them are right, and the agent still doesn't know your team's conventions.
>
> You're not alone, and it's not negligence — writing context files from scratch is the quiet cost of every agent-assisted team. Everyone pays it, few teams have a system for it, and the codebase drifts a little further from your standards every sprint.
>
> This repo gives you composable templates that codify your team's conventions once — base rules, stack rules, company rules — and feed them to every agent on every project. Tax paid. Move on.
>
> Back to the work that actually moves the product. The spikes, the design conversations, the reviews that catch bugs instead of style nits. That's what your team's time is for.

## Why F

Audience is indie devs and solo builders first, corporate second. F is built for first thought; the neutral variant was built for second.

- The opener names a specific, recognizable, slightly embarrassing experience that establishes the author has lived this — the strongest hook across all seven drafted variants
- The "Tax paid. Move on." closer is quotable
- The P4 freed-attention beat names what the product is actually for — your team's energy goes to spikes, design, and bug-catching reviews, not to rediscovering conventions

## Refinements applied vs. the original F

- **P1 language-agnostic.** Original had "the agent keeps using `console.log` anyway." Replaced with "still doesn't know your team's conventions." Reason: `console.log` is JS-only and caught by every modern linter — not a real failure mode templates fix.
- **P2 softened by one degree.** Original had "silent tax / nobody talks about it." Replaced with "quiet cost / few teams have a system for it." Preserves the solidarity but removes the phrasing a corporate reader could trip on. ~5% less punch, ~50% less corporate friction.

Both earlier P1 and P2 versions are preserved in the draft under `docs/drafts/readme-intro-variants.md` as reference.

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass
- [x] Intro is language-agnostic (no `console.log`, `pytest`, `snake_case`, or similar ecosystem-specific examples)
- [x] Subtitle, capability bullets, and How to use section unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)