### PR TITLE
feat(data-quality): calibration discipline triad (#344, #346, #381)

### DIFF
--- a/templates/base/data/data-quality.md
+++ b/templates/base/data/data-quality.md
@@ -61,6 +61,64 @@ first-class concern.
 
 ---
 
+## Calibration discipline
+[ID: data-quality-calibration]
+
+When a tool is calibrated against reference data (test fixtures with
+known-correct outputs, benchmark expected results, eval data, decision
+thresholds), three failure modes silently invalidate the calibration:
+suspect data treated as ground truth, the threshold tuned to mask a
+broken measurement, and reference values produced by the same actor
+that runs the tool. The rules below address each.
+
+### Ground truth comes from raw artifacts, not suspect data
+
+- When calibrating a pipeline against existing committed data, verify
+  the data was not produced by an earlier version of the same pipeline
+- If it was, and the pipeline has known or suspected bugs, the
+  committed data is NOT ground truth — calibrating against it bakes
+  the existing bugs into the new gate
+- Build the calibration set from raw artifacts (source images, raw
+  exports, captured fixtures), recording the verified value alongside
+  each entry
+- A small hand-built reference set from raw artifacts beats a large
+  set carried over from a suspect pipeline
+
+### Thresholds move, not the measurement
+
+- When a measurement and a threshold disagree, the threshold is the
+  cheaper thing to change — but ONLY after the measurement is verified
+  sound
+- Order of operations on disagreement: (1) verify the measurement
+  against an independent check, (2) tune the threshold if the
+  measurement is sound, (3) change the measurement implementation
+  ONLY when steps 1 and 2 fail to resolve the disagreement
+- A threshold picked from theory and never validated against data is
+  not a calibrated threshold — it is a guess; tuning it against the
+  data on first disagreement just hides the original guess
+- This rule applies wherever measurements meet thresholds: CI quality
+  gates, performance budgets, ML decision boundaries, extractor
+  agreement scores
+
+### Reference data MUST carry provenance
+
+- Each entry in a reference set MUST record `source: agent | user |
+  external` (who produced the value) and `verified: true | false`
+  (whether a human has reviewed it)
+- An agent MAY produce reference values to speed calibration, but
+  MUST set `source: agent` and `verified: false` until the user
+  reviews — the user MAY veto, replace, or accept; accepting flips
+  `verified: true`
+- Calibration metrics computed against the reference set MUST report
+  a coverage caveat alongside the headline numbers (e.g.
+  "verified: 12/40"), so unverified reference data cannot silently
+  dominate the metric
+- Synthetic test inputs (faker-style data, generated fixtures) are
+  out of scope — this rule covers reference *outputs* compared
+  against tool *outputs*, not test inputs
+
+---
+
 ## Scoring and derived fields
 [ID: data-quality-scoring]
 


### PR DESCRIPTION
## Summary

Adds a "Calibration discipline" section to `templates/base/data/data-quality.md` covering three sister rules for tools calibrated against reference data:

- **Ground truth comes from raw artifacts, not suspect data** (#344) — if the committed data was produced by an earlier version of the pipeline with known/suspected bugs, it is not ground truth; build the calibration set from raw artifacts instead.
- **Thresholds move, not the measurement** (#346) — on disagreement, verify the measurement first, tune the threshold second, change the measurement implementation last. Tuning a threshold against the same data that exposed it just hides the original guess.
- **Reference data MUST carry provenance** (#381) — `source: agent | user | external` + `verified: true | false`. Agent MAY produce reference values but marks them `source: agent, verified: false` until the user reviews. Metrics MUST report a coverage caveat so unverified rows cannot silently dominate the headline.

The three rules share a failure-mode family — calibration metrics that *look* trustworthy because the inputs that calibrated them weren't independent of the thing being calibrated. They read better together than apart, so they land in one section.

Note: #381 was redrafted from a prohibition ("agent MUST NOT produce GT") to the provenance approach after discussion — the prohibition was too strict and would have wasted the user's time on the 90% of cases where agent eye-reads are fine. See [#381 redraft comment](https://github.com/braboj/solid-ai-templates/issues/381#issuecomment-4606392124).

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass
- [x] `py tools/resolve.py --check` → all generated files up to date
- [ ] CI green

Closes #344.
Closes #346.
Closes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)