### PR TITLE
feat(quality-gates): gate scope agreement section (#334)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1441,6 +1441,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1990,6 +1990,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2250,6 +2250,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2250,6 +2250,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2250,6 +2250,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1217,6 +1217,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1217,6 +1217,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1217,6 +1217,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1217,6 +1217,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1938,6 +1938,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1217,6 +1217,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2250,6 +2250,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1441,6 +1441,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -167,6 +167,56 @@ sometimes doesn't run.
 
 ---
 
+## Gate scope agreement
+
+[ID: quality-gates-scope-agreement]
+
+In a polyglot repo where a secondary toolchain lives in a subdirectory
+(e.g. a Python `tools/` directory inside a TypeScript static site), or
+where captured test fixtures (scraped HTML/JSON representing real
+external byte sequences) live in-tree, three failure modes silently
+break the gate: the formatter walks files it should not touch, the
+PR gate skips work the deploy gate runs unconditionally, and an
+aggregated `gate` job reports success on skipped checks. The rules
+below close those gaps.
+
+### Ignore lists and CI path-filter MUST agree
+
+- The formatter/linter ignore lists and the CI path-filter that
+  triggers the gate MUST cover the same set of paths — a directory
+  excluded from one MUST be excluded from the other
+- A secondary toolchain with its own test runner is verified by that
+  runner, not the primary stack's gate. Document the split in an ADR
+- Captured test fixtures (scraped HTML/JSON representing real external
+  byte sequences) MUST be excluded from the formatter — they must
+  stay byte-for-byte, and reformatting them changes the test input
+
+### Skipped is not passed
+
+- When a code-touching change would skip the build job via a
+  path-filter, the aggregation / `gate` job MUST NOT report success
+  by default
+- Distinguish "skipped because out of scope" from "skipped
+  erroneously" — the former is a pass equivalent, the latter is a
+  gap. An aggregator that treats them identically is the
+  gate-by-omission anti-pattern
+- A passing-because-skipped check looks identical to a passing
+  check in the GitHub UI; the difference MUST be encoded in the
+  workflow, not left to reviewer attention
+
+### PR gate MUST mirror the deploy gate
+
+- Any check the deploy/release workflow runs unconditionally MUST
+  also run on the PR that could break it
+- A gate that runs only post-merge is not a gate — it is a failure
+  notification. By the time it fires, the broken code is already on
+  the main branch
+- When the deploy workflow runs `validate` (or equivalent) on every
+  push to main, the PR workflow MUST run the same `validate` on
+  every PR, regardless of which paths changed
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]


### PR DESCRIPTION
## Summary

Adds a "Gate scope agreement" section to `templates/base/workflow/quality-gates.md` covering three failure modes that silently break the gate in polyglot repos:

- **Ignore lists and CI path-filter MUST agree** — formatter/linter ignore lists and the CI path-filter that triggers the gate cover the same set of paths. A secondary toolchain with its own runner is verified by that runner, not the primary gate. Captured test fixtures (scraped HTML/JSON representing real external byte sequences) MUST be excluded from the formatter to stay byte-for-byte.
- **Skipped is not passed** — the aggregation / `gate` job MUST NOT report success by default when a path-filter skips the build. Distinguish "out of scope" from "skipped erroneously" — the gate-by-omission anti-pattern (a passing-because-skipped check looks identical to a passing check in the GitHub UI).
- **PR gate MUST mirror the deploy gate** — any check the deploy/release workflow runs unconditionally MUST also run on the PR that could break it. A gate that runs only post-merge is a failure notification, not a gate.

Surfaced from a downstream project where a deploy workflow's unconditional `validate` broke production three times on `tools/`-only PRs that the PR workflow had skipped — the gate showed all-green pre-merge.

## Test plan

- [x] `py tests/run_smoke.py` → 18/18 pass
- [x] `py tools/resolve.py --check` → all generated files up to date (14 stacks depend on this file; regenerated in this PR)
- [ ] CI green

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)