### PR TITLE
docs(git): prefer single focused commit over per-folder commits (#409)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -216,6 +216,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -53,6 +53,12 @@ remaining commits are silently lost.
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
   settings to prevent stale branches from accumulating
+- SHOULD use one focused commit per scope-slice on the branch
+  rather than per-folder atomic commits. The squash collapses
+  them on merge, so the per-folder narrative is wasted effort —
+  only the squash commit lands on main. Document the per-folder
+  breakdown in the PR description, where it stays after merge.
+  Use path globs in `git add` for staging hygiene when needed.
 
 ### De-stacking a dependent branch
 


### PR DESCRIPTION
## Summary
- Adds a `SHOULD` rule to the Squash-merge safety section of `base/core/git.md`: prefer one focused commit per scope-slice over per-folder atomic commits, since the squash collapses them on merge.
- Directs the per-folder narrative to the PR description, where it survives the merge.
- References `git add` path globs as the staging-hygiene tool when slicing.

Closes #409

## Test plan
- [x] `py tests/run_smoke.py` — 18/18 pass
- [x] Review reads cleanly in context of the existing "all branch commits accounted for" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)