### PR TITLE
docs(github): document Expedite milestone (#419)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -142,6 +142,13 @@ Every issue MUST also be assigned to a milestone at creation. Issues
 without a target release MUST use the `Backlog` milestone — the
 milestone field MUST NOT be empty.
 
+The `Expedite` milestone is a rolling fast-track lane for work
+shipping between versioned releases — mainly bugs and incidents,
+also small tasks. It never closes; issues move in when expedited
+and out when shipped. Use `Expedite` instead of `Backlog` when the
+work is small, urgent, or out-of-cycle and does not fit the current
+versioned milestone's theme.
+
 Colors follow the Atlassian design system palette. Type labels use
 saturated hues; priority labels use a warm-to-cool gradient to
 remain visually distinct when displayed side by side.

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -138,9 +138,10 @@ GitHub implements issue types and priorities as labels. Every issue
 MUST have exactly one type label and one priority label. Triage
 labels are terminal — applied when closing without action.
 
-Every issue MUST also be assigned to a milestone at creation. Issues
-without a target release MUST use the `Backlog` milestone — the
-milestone field MUST NOT be empty.
+Every issue and pull request MUST also be assigned to a milestone
+at creation. Issues without a target release MUST use the `Backlog`
+milestone — the milestone field MUST NOT be empty. PRs SHOULD inherit
+the milestone of the issue they close.
 
 The `Expedite` milestone is a rolling fast-track lane for work
 shipping between versioned releases — mainly bugs and incidents,


### PR DESCRIPTION
## Summary
- Adds a paragraph to `platform/github.md` Issue labels section describing the `Expedite` milestone: a rolling fast-track lane for bugs, incidents, and small tasks shipping between versioned releases.
- Clarifies when to use `Expedite` vs `Backlog` (Expedite for small/urgent/out-of-cycle that doesn't fit the current versioned milestone's theme).
- Extends the milestone-required rule from "every issue" to "every issue and pull request", and recommends PRs inherit the milestone of the issue they close.

Closes #419

## Test plan
- [x] `py tests/run_smoke.py` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)