### PR TITLE
docs(readme): codify hook -> problem -> solution micro-structure (#403)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -642,6 +642,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -15,6 +15,21 @@ Every README MUST contain the following sections, in this order:
 - 2–4 sentences MUST follow the title: what the project does, for whom,
   what problem it solves, and why this solution exists — no preamble, no
   marketing language
+- The summary block SHOULD follow a hook → problem → solution
+  micro-structure:
+  - **Hook paragraph** — 1–2 sentences naming a problem the reader
+    already recognizes, before introducing the product
+  - **Problem paragraph** — 1–3 sentences identifying the specific
+    gap this project fills
+  - **Solution paragraph** — 1–2 sentences describing what the
+    project is
+  - The four content fields (what, for whom, problem, why) MAY be
+    distributed across these paragraphs in any way that reads
+    cleanly. The hook is framing, not marketing — the existing
+    no-marketing rule still applies
+- An italic differentiator subtitle MAY appear directly under the
+  H1, above the hook, when the project has a one-line claim worth
+  elevating
 - A capability list MUST follow the summary — bullet points stating
   what the product can do, written as capabilities not counts (e.g.
   "browse and filter lenses by specs" not "240+ lenses"); this list


### PR DESCRIPTION
## Summary
- Adds a `SHOULD`-level subsection to `base/core/readme.md` §1 codifying the hook → problem → solution micro-structure for the summary block.
- Names the three paragraph beats explicitly (hook, problem, solution) with sentence counts, and treats the italic differentiator subtitle as optional.
- Clarifies the new shape rule does not replace the four-content-fields rule — they coexist.
- Regenerates the 30 stack chains since `base-readme` is in the core tier.

Closes #403
Milestone: v2.9

## Test plan
- [x] `py tools/sync.py` regenerates 30 generated/ files
- [x] `py tests/run_smoke.py` — 18/18 pass
- [ ] Reviewer reads the new subsection and confirms it does not conflict with the existing "no marketing language" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)