### PR TITLE
fix(stacks): wire base-data-quality into stack-python-service (#418)

### DIFF
--- a/docs/decisions/012-data-quality-wiring.md
+++ b/docs/decisions/012-data-quality-wiring.md
@@ -1,0 +1,86 @@
+---
+id: "012"
+status: Accepted
+date: 2026-06-03
+category: composition
+supersedes: []
+superseded_by: []
+---
+
+# ADR-012: Wire base-data-quality into stack-python-service only
+
+## Context
+
+`templates/base/data/data-quality.md` was added in v2.8 with four
+sections — calibration discipline, cross-validation and tool trust,
+data-research workflow, gate scope agreement. The file is registered
+in `manifest.yaml` as `base-data-quality` (depends_on:
+`base-data-modeling`).
+
+No stack declared `base-data-quality` in its `[DEPENDS ON: ...]`
+chain. The rules were discoverable when browsing `templates/base/`
+but never reached `generated/<stack-id>.md` — projects generating
+context from a stack pre-resolved chain never saw them. The v2.8
+milestone summary flagged this as a gap and deferred the fix to
+v2.9 (#418).
+
+Two architectural paths existed:
+
+1. Wire the data layer into existing backend stacks now.
+2. Defer to the planned `data-heavy` stack (#298) and keep
+   `base-data-quality` opt-in via fork-and-extend.
+
+Path 2 is the cleaner long-term shape but leaves the v2.8 content
+unreachable until v3.0. Path 1 closes the gap immediately.
+
+The four sections in `data-quality.md` are not strictly about
+data — calibration, cross-validation, and research-workflow rules
+apply to any project where an agent does investigative work. The
+file naming overstates the data-heavy framing. Splitting the file
+is future work, out of scope for #418.
+
+## Decision
+
+1. **Wire only via stack-python-service** — `base-data-quality`
+   MUST appear in the `depends_on` list of `stack-python-service`
+   and in the `[DEPENDS ON: ...]` header of
+   `templates/stack/python-service.md`. It MUST NOT be added to
+   other stacks in this change.
+2. **Propagation is transitive** — Flask, FastAPI, and Django
+   inherit `base-data-quality` automatically via their dependence
+   on `stack-python-service`. No direct edits to those stacks.
+3. **Other backend stacks remain unwired** — Go, Node, Java, and
+   Celery stacks do NOT gain `base-data-quality` in this ADR.
+   Wiring them is a separate decision, gated on either a file
+   split or an explicit broader-rollout ADR.
+
+## Alternatives considered
+
+- **Wire into all backend stacks** — rejected; pulls
+  data-modeling rules into stateless services and forces a
+  broader rollout decision before the file-naming question is
+  settled.
+- **Defer to #298 data-heavy stack** — rejected; leaves v2.8
+  content unreachable until v3.0 with no interim mitigation, and
+  the four sections apply more broadly than a single data-heavy
+  variant.
+- **Split data-quality.md first** — rejected as scope creep for
+  #418; the split is recorded as follow-up work.
+
+## Consequences
+
+- `generated/stack-python-service.md`, `generated/stack-flask.md`,
+  `generated/stack-fastapi.md`, and `generated/stack-django.md`
+  include data-quality content after `py tools/sync.py`.
+- The v2.8 memory note about the gap is resolved for Python
+  service stacks.
+- A follow-up issue tracks the file-naming and split question
+  (calibration/research rules vs. true data-heavy rules).
+- Go, Node, Java, and Celery stacks remain in the gap until the
+  follow-up decision lands.
+
+## Related
+
+- #418 — wiring task this ADR records
+- #298 — `data-heavy` stack proposal, still in v3.0 milestone
+- ADR-009 — stack scope cap, fork-and-extend model

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2101,6 +2101,389 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/data/data-modeling.md -->
+# Base — Data Modeling
+[ID: base-data-modeling]
+
+Rules for schema design, naming, normalization, and relationships.
+Applies to relational databases, document stores, and static data
+files alike.
+
+---
+
+## Naming conventions
+[ID: data-modeling-naming]
+
+- Table and collection names MUST be lowercase, plural, snake_case
+  (e.g. `order_items`, `user_roles`)
+- Column and field names MUST be lowercase snake_case
+  (e.g. `created_at`, `unit_price`)
+- Boolean columns MUST use `is_`, `has_`, or `can_` prefix
+  (e.g. `is_active`, `has_discount`)
+- Foreign keys MUST follow `<referenced_table_singular>_id`
+  (e.g. `user_id`, `order_id`)
+- Junction tables MUST combine both table names alphabetically
+  (e.g. `products_tags`, not `tags_products`)
+- Index names MUST follow `ix_<table>_<columns>`; unique index
+  `ux_<table>_<columns>`
+
+---
+
+## Normalization
+[ID: data-modeling-normalization]
+
+- Default to third normal form (3NF) — denormalize only when
+  measured read performance requires it
+- Every table MUST have a primary key — prefer surrogate keys
+  (`id`) for internal use, natural keys for external-facing APIs
+- No multi-valued columns — use a related table instead of
+  comma-separated values or JSON arrays in relational stores
+- Repeated groups of columns (e.g. `phone1`, `phone2`, `phone3`)
+  signal a missing child table
+- Document the rationale when intentionally denormalizing
+
+---
+
+## Relationships
+[ID: data-modeling-relationships]
+
+- Define foreign keys explicitly — do not rely on application-level
+  enforcement alone
+- Choose cascade behavior deliberately:
+  - `CASCADE` for strong ownership (delete parent → delete children)
+  - `SET NULL` for weak references
+  - `RESTRICT` when orphans indicate a bug
+- Many-to-many relationships MUST use a junction table with
+  composite primary key
+- Self-referencing relationships (e.g. `parent_id`) MUST document
+  maximum depth and cycle prevention strategy
+
+---
+
+## Schema evolution
+[ID: data-modeling-evolution]
+
+- Schema changes MUST go through versioned migrations — never
+  apply DDL manually in production
+- Additive changes (new column, new table) are safe — prefer them
+- Destructive changes (drop column, rename) require a migration
+  plan: add new → migrate data → drop old
+- Every migration MUST be reversible — include both up and down
+  steps
+- Test migrations against a production-like dataset before deploying
+
+---
+
+## Data types
+[ID: data-modeling-types]
+
+- Use the most specific type available — `DATE` not `VARCHAR` for
+  dates, `DECIMAL` not `FLOAT` for money
+- Store timestamps in UTC — convert to local time at the
+  presentation layer
+- Store monetary values as integers (cents) or `DECIMAL` — never
+  floating point
+- Use `UUID` or `ULID` for distributed ID generation — auto-increment
+  is acceptable for single-database systems
+- Text fields MUST have a documented maximum length — unbounded text
+  invites abuse and complicates indexing
+
+
+<!-- templates/base/data/data-quality.md -->
+# Base — Data Quality
+[ID: base-data-quality]
+[DEPENDS ON: templates/base/data/data-modeling.md]
+
+Rules for projects where content or data accuracy matters as much as
+code quality. Applies to lens databases, product catalogs, tutorial
+content, wiki entries, and any project that declares data as a
+first-class concern.
+
+---
+
+## Data sourcing
+[ID: data-quality-sourcing]
+
+- Every data point MUST trace to a named source (URL, publication,
+  manufacturer spec sheet)
+- Record the source alongside the data — not in a separate document
+- Prefer primary sources (manufacturer, official docs) over aggregators
+- When multiple sources conflict, document the conflict and the chosen
+  value with rationale
+- Never fabricate or estimate values without marking them as estimates
+
+---
+
+## Completeness tracking
+[ID: data-quality-completeness]
+
+- Define a completeness score for each entry: fields populated / total
+  fields (e.g. `14/14`)
+- Track completeness at the entry level, not just the collection level
+- Incomplete entries MUST be queryable — add a `completeness` or
+  `dataStatus` field
+- Set a minimum completeness threshold for publishing (e.g. 80%)
+- Entries below the threshold MAY exist in the database but MUST NOT
+  appear in user-facing views
+
+---
+
+## Freshness
+[ID: data-quality-freshness]
+
+- Record when each entry was last verified: `lastVerified` date field
+- Define a freshness window per collection (e.g. prices: 30 days,
+  specs: 12 months)
+- Entries beyond their freshness window SHOULD be flagged for review
+- Price data MUST include a `priceDate` field — never show a price
+  without indicating when it was captured
+- Discontinued or unavailable items MUST be marked, not deleted
+
+---
+
+## Exact vs estimated values
+[ID: data-quality-precision]
+
+- Distinguish exact values (from specs or measurements) from estimates
+  (derived, rounded, or interpolated)
+- Use a naming convention or field suffix to mark estimates (e.g.
+  `weightEstimated: true` or `~` prefix in display)
+- Default to realistic/pessimistic estimates — never optimistic
+- Document the estimation method when not obvious
+
+---
+
+## Calibration discipline
+[ID: data-quality-calibration]
+
+When a tool is calibrated against reference data (test fixtures with
+known-correct outputs, benchmark expected results, eval data, decision
+thresholds), three failure modes silently invalidate the calibration:
+suspect data treated as ground truth, the threshold tuned to mask a
+broken measurement, and reference values produced by the same actor
+that runs the tool. The rules below address each.
+
+### Ground truth comes from raw artifacts, not suspect data
+
+- When calibrating a pipeline against existing committed data, verify
+  the data was not produced by an earlier version of the same pipeline
+- If it was, and the pipeline has known or suspected bugs, the
+  committed data is NOT ground truth — calibrating against it bakes
+  the existing bugs into the new gate
+- Build the calibration set from raw artifacts (source images, raw
+  exports, captured fixtures), recording the verified value alongside
+  each entry
+- A small hand-built reference set from raw artifacts beats a large
+  set carried over from a suspect pipeline
+
+### Thresholds move, not the measurement
+
+- When a measurement and a threshold disagree, the threshold is the
+  cheaper thing to change — but ONLY after the measurement is verified
+  sound
+- Order of operations on disagreement: (1) verify the measurement
+  against an independent check, (2) tune the threshold if the
+  measurement is sound, (3) change the measurement implementation
+  ONLY when steps 1 and 2 fail to resolve the disagreement
+- A threshold picked from theory and never validated against data is
+  not a calibrated threshold — it is a guess; tuning it against the
+  data on first disagreement just hides the original guess
+- This rule applies wherever measurements meet thresholds: CI quality
+  gates, performance budgets, ML decision boundaries, extractor
+  agreement scores
+
+### Reference data MUST carry provenance
+
+- Each entry in a reference set MUST record `source: agent | user |
+  external` (who produced the value) and `verified: true | false`
+  (whether a human has reviewed it)
+- An agent MAY produce reference values to speed calibration, but
+  MUST set `source: agent` and `verified: false` until the user
+  reviews — the user MAY veto, replace, or accept; accepting flips
+  `verified: true`
+- Calibration metrics computed against the reference set MUST report
+  a coverage caveat alongside the headline numbers (e.g.
+  "verified: 12/40"), so unverified reference data cannot silently
+  dominate the metric
+- Synthetic test inputs (faker-style data, generated fixtures) are
+  out of scope — this rule covers reference *outputs* compared
+  against tool *outputs*, not test inputs
+
+---
+
+## Cross-validation and tool trust
+[ID: data-quality-cross-validation]
+
+When stored data is cross-validated against an external source (vendor
+page, API, spec sheet, scrape), two distinct failure modes produce
+misleading divergence reports: a buggy validation tool that misreads
+the source, and a semantic mismatch between *stored default* and
+*source silence*. Both look like "the data is wrong" and waste
+maintainer time on phantom fixes.
+
+### Verify the tool before trusting its output
+
+- When a validation, scraping, or migration tool drives a bulk data
+  change, confirm the tool is correct BEFORE acting on its output
+- A systematic tool bug masquerades as data divergence — applying
+  the tool's values blindly corrupts correct stored data
+- Treat a physically implausible output value as a tool defect:
+  fix, re-run, then apply
+- When the external source itself looks wrong (stale page, wrong
+  record served), cross-check an independent source before
+  overwriting stored data
+- Applies to scrapers, importers, schema-migration verifiers, and
+  lint-driven codemods — any automated diff that drives a bulk
+  change
+
+### Distinguish source-silent from source-says-false
+
+- A stored default (e.g. `absent boolean = false`) and source
+  silence (the source did not mention the field) are NOT the same
+  thing — treating them as equivalent produces a flood of
+  false-positive mismatches that bury real errors
+- The extractor MUST return a field ONLY when the source
+  affirmatively states it
+- The differ MUST compare a field ONLY when present on both the
+  stored and source sides — source-silence skips comparison, never
+  becomes a confirmed value
+- This keeps stored-default conventions (`absent = false`,
+  `null = unknown`) intact while making cross-validation meaningful
+- The trap is non-obvious: the stored-default convention and the
+  verification semantics pull in opposite directions, and the naive
+  implementation looks correct until run against real data
+
+---
+
+## Data research workflow
+[ID: data-quality-research]
+
+When data enters the system from external sources (official pages,
+lab reviews, retailers, scraped documents, public APIs), the
+research workflow itself can introduce systematic errors that
+later validation cannot detect. The rules below cover gathering
+facts from multiple sources of differing authority, auditing whole
+records rather than spot fields, extracting figures from composite
+images, and caching fetched content.
+
+### Source-conflict resolution
+
+- The most-authoritative source (official publisher, manufacturer
+  spec sheet, primary documentation) wins on any contested field
+- If a secondary source is provably wrong on one verifiable field,
+  treat ALL its unverified fields for that record as suspect — it
+  is likely mis-cataloged or mismatched. Do NOT cherry-pick its
+  other figures
+- Prefer leaving a field unresolved-and-flagged over overwriting it
+  with a contradicted source — a known gap is more useful than a
+  confidently-wrong value
+- When two sources of equivalent authority disagree, record the
+  conflict, the chosen value, and the rationale alongside the
+  entry (see [ID: data-quality-sourcing])
+
+### Full-record audit, not target-field audit
+
+- When verifying a record against a source, cross-check EVERY
+  field — not only the fields that prompted the verification
+- Copy-derived records frequently inherit stale values in fields
+  nobody re-checked (e.g. a "v2" entry retaining the v1 release
+  date or dimensions)
+- A spot-fix audit confirms the target field while leaving silent
+  drift in the rest of the record; a full-record audit catches
+  the drift
+
+### Content-aware figure cropping
+
+- When extracting a figure from a composite image (marketing
+  layout, manual page, dashboard screenshot), detect the content
+  bounding box programmatically — e.g. corner-median background
+  subtraction — rather than hand-guessing crop coordinates
+- Hand-picked coordinates silently truncate or off-center the
+  artifact; the error is caught only by a human eyeballing the
+  output
+- Keep automated edge-touch checks advisory (a tight axis box or
+  wide subject legitimately reaches the margin) and always have
+  a human review the crop before publishing
+
+### Cache validity: content checks, not blind TTL
+
+- For a research-time fetch/scrape cache (NOT the live request
+  path), decide cache validity by the content of a cached
+  response, not its age
+- Never cache non-content responses — bot/throttle interstitials,
+  4xx/gone error pages, implausibly short stubs. Detect and skip
+  them on write
+- Self-heal on read: if a cached body is recognizably junk
+  (bot/404/empty), ignore and re-fetch rather than re-serving the
+  bad cache
+- Refresh deliberately via an explicit `--no-cache` / force flag,
+  NOT on a timer
+- Add a time-based TTL only when there is evidence that content
+  goes stale in a way the content checks do not catch — a timer
+  cannot distinguish a value change from a resource removal (the
+  latter surfaces as 4xx and is handled above), and it slows every
+  session re-fetching unchanged data
+- Live request-path caches (Cache-Control, CDN, browser cache)
+  are out of scope — those have their own TTL semantics
+
+---
+
+## Scoring and derived fields
+[ID: data-quality-scoring]
+
+- Scoring formulas MUST be documented — not buried in code
+- All inputs to a score MUST be traceable to source data
+- Scores MUST be reproducible: same inputs always produce the same
+  output
+- Define the scoring scale once (e.g. 1–5, step 0.5) and use it
+  consistently
+- Features (boolean attributes like "weather sealed") are UI filter
+  badges, not scoring inputs — keep them separate
+
+---
+
+## Data changelog
+[ID: data-quality-changelog]
+
+- Changes to source data MUST be committed with a message explaining
+  what changed and why (e.g. "fix: update lens weight — manufacturer
+  corrected spec sheet")
+- When a scoring input changes, note that derived scores will change
+- Do not batch unrelated data changes into a single commit — one
+  entry or one field correction per commit
+- For bulk imports or migrations, document the source and method in
+  the commit message
+
+---
+
+## Identity and deduplication
+[ID: data-quality-identity]
+
+- Every entry MUST have a stable unique identifier that does not
+  change when other fields are updated
+- Define what makes two entries "the same" — document the identity
+  key (e.g. manufacturer + model name + variant)
+- Near-duplicates (regional names, revised versions, bundles) MUST
+  be distinct entries with a relationship field linking them
+- Never merge near-duplicates silently — flag for manual review
+- Discontinued items that are replaced by a successor SHOULD link
+  to the successor via a `replacedBy` field
+
+---
+
+## Validation
+[ID: data-quality-validation]
+
+- Validate data at ingest time — reject or flag entries that fail
+  schema validation
+- Use typed schemas (Zod, JSON Schema, TypeScript interfaces) for all
+  data collections
+- Range checks for numeric fields (e.g. weight > 0, price > 0)
+- Enum checks for constrained fields (e.g. mount type, category)
+- Build-time validation is acceptable for static sites — runtime
+  validation for APIs
+
+
 <!-- templates/base/workflow/quality-gates.md -->
 # Base — Quality Gates
 
@@ -2485,7 +2868,7 @@ python -m build           # build distribution
 
 <!-- templates/stack/python-service.md -->
 # Stack — Python Web Service
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md, templates/base/data/data-quality.md]
 
 Abstract rules for any Python web service or API. Never used directly —
 always extended by a framework-specific stack (Flask, FastAPI, Django).

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2101,6 +2101,389 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/data/data-modeling.md -->
+# Base — Data Modeling
+[ID: base-data-modeling]
+
+Rules for schema design, naming, normalization, and relationships.
+Applies to relational databases, document stores, and static data
+files alike.
+
+---
+
+## Naming conventions
+[ID: data-modeling-naming]
+
+- Table and collection names MUST be lowercase, plural, snake_case
+  (e.g. `order_items`, `user_roles`)
+- Column and field names MUST be lowercase snake_case
+  (e.g. `created_at`, `unit_price`)
+- Boolean columns MUST use `is_`, `has_`, or `can_` prefix
+  (e.g. `is_active`, `has_discount`)
+- Foreign keys MUST follow `<referenced_table_singular>_id`
+  (e.g. `user_id`, `order_id`)
+- Junction tables MUST combine both table names alphabetically
+  (e.g. `products_tags`, not `tags_products`)
+- Index names MUST follow `ix_<table>_<columns>`; unique index
+  `ux_<table>_<columns>`
+
+---
+
+## Normalization
+[ID: data-modeling-normalization]
+
+- Default to third normal form (3NF) — denormalize only when
+  measured read performance requires it
+- Every table MUST have a primary key — prefer surrogate keys
+  (`id`) for internal use, natural keys for external-facing APIs
+- No multi-valued columns — use a related table instead of
+  comma-separated values or JSON arrays in relational stores
+- Repeated groups of columns (e.g. `phone1`, `phone2`, `phone3`)
+  signal a missing child table
+- Document the rationale when intentionally denormalizing
+
+---
+
+## Relationships
+[ID: data-modeling-relationships]
+
+- Define foreign keys explicitly — do not rely on application-level
+  enforcement alone
+- Choose cascade behavior deliberately:
+  - `CASCADE` for strong ownership (delete parent → delete children)
+  - `SET NULL` for weak references
+  - `RESTRICT` when orphans indicate a bug
+- Many-to-many relationships MUST use a junction table with
+  composite primary key
+- Self-referencing relationships (e.g. `parent_id`) MUST document
+  maximum depth and cycle prevention strategy
+
+---
+
+## Schema evolution
+[ID: data-modeling-evolution]
+
+- Schema changes MUST go through versioned migrations — never
+  apply DDL manually in production
+- Additive changes (new column, new table) are safe — prefer them
+- Destructive changes (drop column, rename) require a migration
+  plan: add new → migrate data → drop old
+- Every migration MUST be reversible — include both up and down
+  steps
+- Test migrations against a production-like dataset before deploying
+
+---
+
+## Data types
+[ID: data-modeling-types]
+
+- Use the most specific type available — `DATE` not `VARCHAR` for
+  dates, `DECIMAL` not `FLOAT` for money
+- Store timestamps in UTC — convert to local time at the
+  presentation layer
+- Store monetary values as integers (cents) or `DECIMAL` — never
+  floating point
+- Use `UUID` or `ULID` for distributed ID generation — auto-increment
+  is acceptable for single-database systems
+- Text fields MUST have a documented maximum length — unbounded text
+  invites abuse and complicates indexing
+
+
+<!-- templates/base/data/data-quality.md -->
+# Base — Data Quality
+[ID: base-data-quality]
+[DEPENDS ON: templates/base/data/data-modeling.md]
+
+Rules for projects where content or data accuracy matters as much as
+code quality. Applies to lens databases, product catalogs, tutorial
+content, wiki entries, and any project that declares data as a
+first-class concern.
+
+---
+
+## Data sourcing
+[ID: data-quality-sourcing]
+
+- Every data point MUST trace to a named source (URL, publication,
+  manufacturer spec sheet)
+- Record the source alongside the data — not in a separate document
+- Prefer primary sources (manufacturer, official docs) over aggregators
+- When multiple sources conflict, document the conflict and the chosen
+  value with rationale
+- Never fabricate or estimate values without marking them as estimates
+
+---
+
+## Completeness tracking
+[ID: data-quality-completeness]
+
+- Define a completeness score for each entry: fields populated / total
+  fields (e.g. `14/14`)
+- Track completeness at the entry level, not just the collection level
+- Incomplete entries MUST be queryable — add a `completeness` or
+  `dataStatus` field
+- Set a minimum completeness threshold for publishing (e.g. 80%)
+- Entries below the threshold MAY exist in the database but MUST NOT
+  appear in user-facing views
+
+---
+
+## Freshness
+[ID: data-quality-freshness]
+
+- Record when each entry was last verified: `lastVerified` date field
+- Define a freshness window per collection (e.g. prices: 30 days,
+  specs: 12 months)
+- Entries beyond their freshness window SHOULD be flagged for review
+- Price data MUST include a `priceDate` field — never show a price
+  without indicating when it was captured
+- Discontinued or unavailable items MUST be marked, not deleted
+
+---
+
+## Exact vs estimated values
+[ID: data-quality-precision]
+
+- Distinguish exact values (from specs or measurements) from estimates
+  (derived, rounded, or interpolated)
+- Use a naming convention or field suffix to mark estimates (e.g.
+  `weightEstimated: true` or `~` prefix in display)
+- Default to realistic/pessimistic estimates — never optimistic
+- Document the estimation method when not obvious
+
+---
+
+## Calibration discipline
+[ID: data-quality-calibration]
+
+When a tool is calibrated against reference data (test fixtures with
+known-correct outputs, benchmark expected results, eval data, decision
+thresholds), three failure modes silently invalidate the calibration:
+suspect data treated as ground truth, the threshold tuned to mask a
+broken measurement, and reference values produced by the same actor
+that runs the tool. The rules below address each.
+
+### Ground truth comes from raw artifacts, not suspect data
+
+- When calibrating a pipeline against existing committed data, verify
+  the data was not produced by an earlier version of the same pipeline
+- If it was, and the pipeline has known or suspected bugs, the
+  committed data is NOT ground truth — calibrating against it bakes
+  the existing bugs into the new gate
+- Build the calibration set from raw artifacts (source images, raw
+  exports, captured fixtures), recording the verified value alongside
+  each entry
+- A small hand-built reference set from raw artifacts beats a large
+  set carried over from a suspect pipeline
+
+### Thresholds move, not the measurement
+
+- When a measurement and a threshold disagree, the threshold is the
+  cheaper thing to change — but ONLY after the measurement is verified
+  sound
+- Order of operations on disagreement: (1) verify the measurement
+  against an independent check, (2) tune the threshold if the
+  measurement is sound, (3) change the measurement implementation
+  ONLY when steps 1 and 2 fail to resolve the disagreement
+- A threshold picked from theory and never validated against data is
+  not a calibrated threshold — it is a guess; tuning it against the
+  data on first disagreement just hides the original guess
+- This rule applies wherever measurements meet thresholds: CI quality
+  gates, performance budgets, ML decision boundaries, extractor
+  agreement scores
+
+### Reference data MUST carry provenance
+
+- Each entry in a reference set MUST record `source: agent | user |
+  external` (who produced the value) and `verified: true | false`
+  (whether a human has reviewed it)
+- An agent MAY produce reference values to speed calibration, but
+  MUST set `source: agent` and `verified: false` until the user
+  reviews — the user MAY veto, replace, or accept; accepting flips
+  `verified: true`
+- Calibration metrics computed against the reference set MUST report
+  a coverage caveat alongside the headline numbers (e.g.
+  "verified: 12/40"), so unverified reference data cannot silently
+  dominate the metric
+- Synthetic test inputs (faker-style data, generated fixtures) are
+  out of scope — this rule covers reference *outputs* compared
+  against tool *outputs*, not test inputs
+
+---
+
+## Cross-validation and tool trust
+[ID: data-quality-cross-validation]
+
+When stored data is cross-validated against an external source (vendor
+page, API, spec sheet, scrape), two distinct failure modes produce
+misleading divergence reports: a buggy validation tool that misreads
+the source, and a semantic mismatch between *stored default* and
+*source silence*. Both look like "the data is wrong" and waste
+maintainer time on phantom fixes.
+
+### Verify the tool before trusting its output
+
+- When a validation, scraping, or migration tool drives a bulk data
+  change, confirm the tool is correct BEFORE acting on its output
+- A systematic tool bug masquerades as data divergence — applying
+  the tool's values blindly corrupts correct stored data
+- Treat a physically implausible output value as a tool defect:
+  fix, re-run, then apply
+- When the external source itself looks wrong (stale page, wrong
+  record served), cross-check an independent source before
+  overwriting stored data
+- Applies to scrapers, importers, schema-migration verifiers, and
+  lint-driven codemods — any automated diff that drives a bulk
+  change
+
+### Distinguish source-silent from source-says-false
+
+- A stored default (e.g. `absent boolean = false`) and source
+  silence (the source did not mention the field) are NOT the same
+  thing — treating them as equivalent produces a flood of
+  false-positive mismatches that bury real errors
+- The extractor MUST return a field ONLY when the source
+  affirmatively states it
+- The differ MUST compare a field ONLY when present on both the
+  stored and source sides — source-silence skips comparison, never
+  becomes a confirmed value
+- This keeps stored-default conventions (`absent = false`,
+  `null = unknown`) intact while making cross-validation meaningful
+- The trap is non-obvious: the stored-default convention and the
+  verification semantics pull in opposite directions, and the naive
+  implementation looks correct until run against real data
+
+---
+
+## Data research workflow
+[ID: data-quality-research]
+
+When data enters the system from external sources (official pages,
+lab reviews, retailers, scraped documents, public APIs), the
+research workflow itself can introduce systematic errors that
+later validation cannot detect. The rules below cover gathering
+facts from multiple sources of differing authority, auditing whole
+records rather than spot fields, extracting figures from composite
+images, and caching fetched content.
+
+### Source-conflict resolution
+
+- The most-authoritative source (official publisher, manufacturer
+  spec sheet, primary documentation) wins on any contested field
+- If a secondary source is provably wrong on one verifiable field,
+  treat ALL its unverified fields for that record as suspect — it
+  is likely mis-cataloged or mismatched. Do NOT cherry-pick its
+  other figures
+- Prefer leaving a field unresolved-and-flagged over overwriting it
+  with a contradicted source — a known gap is more useful than a
+  confidently-wrong value
+- When two sources of equivalent authority disagree, record the
+  conflict, the chosen value, and the rationale alongside the
+  entry (see [ID: data-quality-sourcing])
+
+### Full-record audit, not target-field audit
+
+- When verifying a record against a source, cross-check EVERY
+  field — not only the fields that prompted the verification
+- Copy-derived records frequently inherit stale values in fields
+  nobody re-checked (e.g. a "v2" entry retaining the v1 release
+  date or dimensions)
+- A spot-fix audit confirms the target field while leaving silent
+  drift in the rest of the record; a full-record audit catches
+  the drift
+
+### Content-aware figure cropping
+
+- When extracting a figure from a composite image (marketing
+  layout, manual page, dashboard screenshot), detect the content
+  bounding box programmatically — e.g. corner-median background
+  subtraction — rather than hand-guessing crop coordinates
+- Hand-picked coordinates silently truncate or off-center the
+  artifact; the error is caught only by a human eyeballing the
+  output
+- Keep automated edge-touch checks advisory (a tight axis box or
+  wide subject legitimately reaches the margin) and always have
+  a human review the crop before publishing
+
+### Cache validity: content checks, not blind TTL
+
+- For a research-time fetch/scrape cache (NOT the live request
+  path), decide cache validity by the content of a cached
+  response, not its age
+- Never cache non-content responses — bot/throttle interstitials,
+  4xx/gone error pages, implausibly short stubs. Detect and skip
+  them on write
+- Self-heal on read: if a cached body is recognizably junk
+  (bot/404/empty), ignore and re-fetch rather than re-serving the
+  bad cache
+- Refresh deliberately via an explicit `--no-cache` / force flag,
+  NOT on a timer
+- Add a time-based TTL only when there is evidence that content
+  goes stale in a way the content checks do not catch — a timer
+  cannot distinguish a value change from a resource removal (the
+  latter surfaces as 4xx and is handled above), and it slows every
+  session re-fetching unchanged data
+- Live request-path caches (Cache-Control, CDN, browser cache)
+  are out of scope — those have their own TTL semantics
+
+---
+
+## Scoring and derived fields
+[ID: data-quality-scoring]
+
+- Scoring formulas MUST be documented — not buried in code
+- All inputs to a score MUST be traceable to source data
+- Scores MUST be reproducible: same inputs always produce the same
+  output
+- Define the scoring scale once (e.g. 1–5, step 0.5) and use it
+  consistently
+- Features (boolean attributes like "weather sealed") are UI filter
+  badges, not scoring inputs — keep them separate
+
+---
+
+## Data changelog
+[ID: data-quality-changelog]
+
+- Changes to source data MUST be committed with a message explaining
+  what changed and why (e.g. "fix: update lens weight — manufacturer
+  corrected spec sheet")
+- When a scoring input changes, note that derived scores will change
+- Do not batch unrelated data changes into a single commit — one
+  entry or one field correction per commit
+- For bulk imports or migrations, document the source and method in
+  the commit message
+
+---
+
+## Identity and deduplication
+[ID: data-quality-identity]
+
+- Every entry MUST have a stable unique identifier that does not
+  change when other fields are updated
+- Define what makes two entries "the same" — document the identity
+  key (e.g. manufacturer + model name + variant)
+- Near-duplicates (regional names, revised versions, bundles) MUST
+  be distinct entries with a relationship field linking them
+- Never merge near-duplicates silently — flag for manual review
+- Discontinued items that are replaced by a successor SHOULD link
+  to the successor via a `replacedBy` field
+
+---
+
+## Validation
+[ID: data-quality-validation]
+
+- Validate data at ingest time — reject or flag entries that fail
+  schema validation
+- Use typed schemas (Zod, JSON Schema, TypeScript interfaces) for all
+  data collections
+- Range checks for numeric fields (e.g. weight > 0, price > 0)
+- Enum checks for constrained fields (e.g. mount type, category)
+- Build-time validation is acceptable for static sites — runtime
+  validation for APIs
+
+
 <!-- templates/base/workflow/quality-gates.md -->
 # Base — Quality Gates
 
@@ -2485,7 +2868,7 @@ python -m build           # build distribution
 
 <!-- templates/stack/python-service.md -->
 # Stack — Python Web Service
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md, templates/base/data/data-quality.md]
 
 Abstract rules for any Python web service or API. Never used directly —
 always extended by a framework-specific stack (Flask, FastAPI, Django).

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2101,6 +2101,389 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/data/data-modeling.md -->
+# Base — Data Modeling
+[ID: base-data-modeling]
+
+Rules for schema design, naming, normalization, and relationships.
+Applies to relational databases, document stores, and static data
+files alike.
+
+---
+
+## Naming conventions
+[ID: data-modeling-naming]
+
+- Table and collection names MUST be lowercase, plural, snake_case
+  (e.g. `order_items`, `user_roles`)
+- Column and field names MUST be lowercase snake_case
+  (e.g. `created_at`, `unit_price`)
+- Boolean columns MUST use `is_`, `has_`, or `can_` prefix
+  (e.g. `is_active`, `has_discount`)
+- Foreign keys MUST follow `<referenced_table_singular>_id`
+  (e.g. `user_id`, `order_id`)
+- Junction tables MUST combine both table names alphabetically
+  (e.g. `products_tags`, not `tags_products`)
+- Index names MUST follow `ix_<table>_<columns>`; unique index
+  `ux_<table>_<columns>`
+
+---
+
+## Normalization
+[ID: data-modeling-normalization]
+
+- Default to third normal form (3NF) — denormalize only when
+  measured read performance requires it
+- Every table MUST have a primary key — prefer surrogate keys
+  (`id`) for internal use, natural keys for external-facing APIs
+- No multi-valued columns — use a related table instead of
+  comma-separated values or JSON arrays in relational stores
+- Repeated groups of columns (e.g. `phone1`, `phone2`, `phone3`)
+  signal a missing child table
+- Document the rationale when intentionally denormalizing
+
+---
+
+## Relationships
+[ID: data-modeling-relationships]
+
+- Define foreign keys explicitly — do not rely on application-level
+  enforcement alone
+- Choose cascade behavior deliberately:
+  - `CASCADE` for strong ownership (delete parent → delete children)
+  - `SET NULL` for weak references
+  - `RESTRICT` when orphans indicate a bug
+- Many-to-many relationships MUST use a junction table with
+  composite primary key
+- Self-referencing relationships (e.g. `parent_id`) MUST document
+  maximum depth and cycle prevention strategy
+
+---
+
+## Schema evolution
+[ID: data-modeling-evolution]
+
+- Schema changes MUST go through versioned migrations — never
+  apply DDL manually in production
+- Additive changes (new column, new table) are safe — prefer them
+- Destructive changes (drop column, rename) require a migration
+  plan: add new → migrate data → drop old
+- Every migration MUST be reversible — include both up and down
+  steps
+- Test migrations against a production-like dataset before deploying
+
+---
+
+## Data types
+[ID: data-modeling-types]
+
+- Use the most specific type available — `DATE` not `VARCHAR` for
+  dates, `DECIMAL` not `FLOAT` for money
+- Store timestamps in UTC — convert to local time at the
+  presentation layer
+- Store monetary values as integers (cents) or `DECIMAL` — never
+  floating point
+- Use `UUID` or `ULID` for distributed ID generation — auto-increment
+  is acceptable for single-database systems
+- Text fields MUST have a documented maximum length — unbounded text
+  invites abuse and complicates indexing
+
+
+<!-- templates/base/data/data-quality.md -->
+# Base — Data Quality
+[ID: base-data-quality]
+[DEPENDS ON: templates/base/data/data-modeling.md]
+
+Rules for projects where content or data accuracy matters as much as
+code quality. Applies to lens databases, product catalogs, tutorial
+content, wiki entries, and any project that declares data as a
+first-class concern.
+
+---
+
+## Data sourcing
+[ID: data-quality-sourcing]
+
+- Every data point MUST trace to a named source (URL, publication,
+  manufacturer spec sheet)
+- Record the source alongside the data — not in a separate document
+- Prefer primary sources (manufacturer, official docs) over aggregators
+- When multiple sources conflict, document the conflict and the chosen
+  value with rationale
+- Never fabricate or estimate values without marking them as estimates
+
+---
+
+## Completeness tracking
+[ID: data-quality-completeness]
+
+- Define a completeness score for each entry: fields populated / total
+  fields (e.g. `14/14`)
+- Track completeness at the entry level, not just the collection level
+- Incomplete entries MUST be queryable — add a `completeness` or
+  `dataStatus` field
+- Set a minimum completeness threshold for publishing (e.g. 80%)
+- Entries below the threshold MAY exist in the database but MUST NOT
+  appear in user-facing views
+
+---
+
+## Freshness
+[ID: data-quality-freshness]
+
+- Record when each entry was last verified: `lastVerified` date field
+- Define a freshness window per collection (e.g. prices: 30 days,
+  specs: 12 months)
+- Entries beyond their freshness window SHOULD be flagged for review
+- Price data MUST include a `priceDate` field — never show a price
+  without indicating when it was captured
+- Discontinued or unavailable items MUST be marked, not deleted
+
+---
+
+## Exact vs estimated values
+[ID: data-quality-precision]
+
+- Distinguish exact values (from specs or measurements) from estimates
+  (derived, rounded, or interpolated)
+- Use a naming convention or field suffix to mark estimates (e.g.
+  `weightEstimated: true` or `~` prefix in display)
+- Default to realistic/pessimistic estimates — never optimistic
+- Document the estimation method when not obvious
+
+---
+
+## Calibration discipline
+[ID: data-quality-calibration]
+
+When a tool is calibrated against reference data (test fixtures with
+known-correct outputs, benchmark expected results, eval data, decision
+thresholds), three failure modes silently invalidate the calibration:
+suspect data treated as ground truth, the threshold tuned to mask a
+broken measurement, and reference values produced by the same actor
+that runs the tool. The rules below address each.
+
+### Ground truth comes from raw artifacts, not suspect data
+
+- When calibrating a pipeline against existing committed data, verify
+  the data was not produced by an earlier version of the same pipeline
+- If it was, and the pipeline has known or suspected bugs, the
+  committed data is NOT ground truth — calibrating against it bakes
+  the existing bugs into the new gate
+- Build the calibration set from raw artifacts (source images, raw
+  exports, captured fixtures), recording the verified value alongside
+  each entry
+- A small hand-built reference set from raw artifacts beats a large
+  set carried over from a suspect pipeline
+
+### Thresholds move, not the measurement
+
+- When a measurement and a threshold disagree, the threshold is the
+  cheaper thing to change — but ONLY after the measurement is verified
+  sound
+- Order of operations on disagreement: (1) verify the measurement
+  against an independent check, (2) tune the threshold if the
+  measurement is sound, (3) change the measurement implementation
+  ONLY when steps 1 and 2 fail to resolve the disagreement
+- A threshold picked from theory and never validated against data is
+  not a calibrated threshold — it is a guess; tuning it against the
+  data on first disagreement just hides the original guess
+- This rule applies wherever measurements meet thresholds: CI quality
+  gates, performance budgets, ML decision boundaries, extractor
+  agreement scores
+
+### Reference data MUST carry provenance
+
+- Each entry in a reference set MUST record `source: agent | user |
+  external` (who produced the value) and `verified: true | false`
+  (whether a human has reviewed it)
+- An agent MAY produce reference values to speed calibration, but
+  MUST set `source: agent` and `verified: false` until the user
+  reviews — the user MAY veto, replace, or accept; accepting flips
+  `verified: true`
+- Calibration metrics computed against the reference set MUST report
+  a coverage caveat alongside the headline numbers (e.g.
+  "verified: 12/40"), so unverified reference data cannot silently
+  dominate the metric
+- Synthetic test inputs (faker-style data, generated fixtures) are
+  out of scope — this rule covers reference *outputs* compared
+  against tool *outputs*, not test inputs
+
+---
+
+## Cross-validation and tool trust
+[ID: data-quality-cross-validation]
+
+When stored data is cross-validated against an external source (vendor
+page, API, spec sheet, scrape), two distinct failure modes produce
+misleading divergence reports: a buggy validation tool that misreads
+the source, and a semantic mismatch between *stored default* and
+*source silence*. Both look like "the data is wrong" and waste
+maintainer time on phantom fixes.
+
+### Verify the tool before trusting its output
+
+- When a validation, scraping, or migration tool drives a bulk data
+  change, confirm the tool is correct BEFORE acting on its output
+- A systematic tool bug masquerades as data divergence — applying
+  the tool's values blindly corrupts correct stored data
+- Treat a physically implausible output value as a tool defect:
+  fix, re-run, then apply
+- When the external source itself looks wrong (stale page, wrong
+  record served), cross-check an independent source before
+  overwriting stored data
+- Applies to scrapers, importers, schema-migration verifiers, and
+  lint-driven codemods — any automated diff that drives a bulk
+  change
+
+### Distinguish source-silent from source-says-false
+
+- A stored default (e.g. `absent boolean = false`) and source
+  silence (the source did not mention the field) are NOT the same
+  thing — treating them as equivalent produces a flood of
+  false-positive mismatches that bury real errors
+- The extractor MUST return a field ONLY when the source
+  affirmatively states it
+- The differ MUST compare a field ONLY when present on both the
+  stored and source sides — source-silence skips comparison, never
+  becomes a confirmed value
+- This keeps stored-default conventions (`absent = false`,
+  `null = unknown`) intact while making cross-validation meaningful
+- The trap is non-obvious: the stored-default convention and the
+  verification semantics pull in opposite directions, and the naive
+  implementation looks correct until run against real data
+
+---
+
+## Data research workflow
+[ID: data-quality-research]
+
+When data enters the system from external sources (official pages,
+lab reviews, retailers, scraped documents, public APIs), the
+research workflow itself can introduce systematic errors that
+later validation cannot detect. The rules below cover gathering
+facts from multiple sources of differing authority, auditing whole
+records rather than spot fields, extracting figures from composite
+images, and caching fetched content.
+
+### Source-conflict resolution
+
+- The most-authoritative source (official publisher, manufacturer
+  spec sheet, primary documentation) wins on any contested field
+- If a secondary source is provably wrong on one verifiable field,
+  treat ALL its unverified fields for that record as suspect — it
+  is likely mis-cataloged or mismatched. Do NOT cherry-pick its
+  other figures
+- Prefer leaving a field unresolved-and-flagged over overwriting it
+  with a contradicted source — a known gap is more useful than a
+  confidently-wrong value
+- When two sources of equivalent authority disagree, record the
+  conflict, the chosen value, and the rationale alongside the
+  entry (see [ID: data-quality-sourcing])
+
+### Full-record audit, not target-field audit
+
+- When verifying a record against a source, cross-check EVERY
+  field — not only the fields that prompted the verification
+- Copy-derived records frequently inherit stale values in fields
+  nobody re-checked (e.g. a "v2" entry retaining the v1 release
+  date or dimensions)
+- A spot-fix audit confirms the target field while leaving silent
+  drift in the rest of the record; a full-record audit catches
+  the drift
+
+### Content-aware figure cropping
+
+- When extracting a figure from a composite image (marketing
+  layout, manual page, dashboard screenshot), detect the content
+  bounding box programmatically — e.g. corner-median background
+  subtraction — rather than hand-guessing crop coordinates
+- Hand-picked coordinates silently truncate or off-center the
+  artifact; the error is caught only by a human eyeballing the
+  output
+- Keep automated edge-touch checks advisory (a tight axis box or
+  wide subject legitimately reaches the margin) and always have
+  a human review the crop before publishing
+
+### Cache validity: content checks, not blind TTL
+
+- For a research-time fetch/scrape cache (NOT the live request
+  path), decide cache validity by the content of a cached
+  response, not its age
+- Never cache non-content responses — bot/throttle interstitials,
+  4xx/gone error pages, implausibly short stubs. Detect and skip
+  them on write
+- Self-heal on read: if a cached body is recognizably junk
+  (bot/404/empty), ignore and re-fetch rather than re-serving the
+  bad cache
+- Refresh deliberately via an explicit `--no-cache` / force flag,
+  NOT on a timer
+- Add a time-based TTL only when there is evidence that content
+  goes stale in a way the content checks do not catch — a timer
+  cannot distinguish a value change from a resource removal (the
+  latter surfaces as 4xx and is handled above), and it slows every
+  session re-fetching unchanged data
+- Live request-path caches (Cache-Control, CDN, browser cache)
+  are out of scope — those have their own TTL semantics
+
+---
+
+## Scoring and derived fields
+[ID: data-quality-scoring]
+
+- Scoring formulas MUST be documented — not buried in code
+- All inputs to a score MUST be traceable to source data
+- Scores MUST be reproducible: same inputs always produce the same
+  output
+- Define the scoring scale once (e.g. 1–5, step 0.5) and use it
+  consistently
+- Features (boolean attributes like "weather sealed") are UI filter
+  badges, not scoring inputs — keep them separate
+
+---
+
+## Data changelog
+[ID: data-quality-changelog]
+
+- Changes to source data MUST be committed with a message explaining
+  what changed and why (e.g. "fix: update lens weight — manufacturer
+  corrected spec sheet")
+- When a scoring input changes, note that derived scores will change
+- Do not batch unrelated data changes into a single commit — one
+  entry or one field correction per commit
+- For bulk imports or migrations, document the source and method in
+  the commit message
+
+---
+
+## Identity and deduplication
+[ID: data-quality-identity]
+
+- Every entry MUST have a stable unique identifier that does not
+  change when other fields are updated
+- Define what makes two entries "the same" — document the identity
+  key (e.g. manufacturer + model name + variant)
+- Near-duplicates (regional names, revised versions, bundles) MUST
+  be distinct entries with a relationship field linking them
+- Never merge near-duplicates silently — flag for manual review
+- Discontinued items that are replaced by a successor SHOULD link
+  to the successor via a `replacedBy` field
+
+---
+
+## Validation
+[ID: data-quality-validation]
+
+- Validate data at ingest time — reject or flag entries that fail
+  schema validation
+- Use typed schemas (Zod, JSON Schema, TypeScript interfaces) for all
+  data collections
+- Range checks for numeric fields (e.g. weight > 0, price > 0)
+- Enum checks for constrained fields (e.g. mount type, category)
+- Build-time validation is acceptable for static sites — runtime
+  validation for APIs
+
+
 <!-- templates/base/workflow/quality-gates.md -->
 # Base — Quality Gates
 
@@ -2485,7 +2868,7 @@ python -m build           # build distribution
 
 <!-- templates/stack/python-service.md -->
 # Stack — Python Web Service
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md, templates/base/data/data-quality.md]
 
 Abstract rules for any Python web service or API. Never used directly —
 always extended by a framework-specific stack (Flask, FastAPI, Django).

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2101,6 +2101,389 @@ not after deployment.
 - Prefer dependencies that are actively maintained and widely adopted
 
 
+<!-- templates/base/data/data-modeling.md -->
+# Base — Data Modeling
+[ID: base-data-modeling]
+
+Rules for schema design, naming, normalization, and relationships.
+Applies to relational databases, document stores, and static data
+files alike.
+
+---
+
+## Naming conventions
+[ID: data-modeling-naming]
+
+- Table and collection names MUST be lowercase, plural, snake_case
+  (e.g. `order_items`, `user_roles`)
+- Column and field names MUST be lowercase snake_case
+  (e.g. `created_at`, `unit_price`)
+- Boolean columns MUST use `is_`, `has_`, or `can_` prefix
+  (e.g. `is_active`, `has_discount`)
+- Foreign keys MUST follow `<referenced_table_singular>_id`
+  (e.g. `user_id`, `order_id`)
+- Junction tables MUST combine both table names alphabetically
+  (e.g. `products_tags`, not `tags_products`)
+- Index names MUST follow `ix_<table>_<columns>`; unique index
+  `ux_<table>_<columns>`
+
+---
+
+## Normalization
+[ID: data-modeling-normalization]
+
+- Default to third normal form (3NF) — denormalize only when
+  measured read performance requires it
+- Every table MUST have a primary key — prefer surrogate keys
+  (`id`) for internal use, natural keys for external-facing APIs
+- No multi-valued columns — use a related table instead of
+  comma-separated values or JSON arrays in relational stores
+- Repeated groups of columns (e.g. `phone1`, `phone2`, `phone3`)
+  signal a missing child table
+- Document the rationale when intentionally denormalizing
+
+---
+
+## Relationships
+[ID: data-modeling-relationships]
+
+- Define foreign keys explicitly — do not rely on application-level
+  enforcement alone
+- Choose cascade behavior deliberately:
+  - `CASCADE` for strong ownership (delete parent → delete children)
+  - `SET NULL` for weak references
+  - `RESTRICT` when orphans indicate a bug
+- Many-to-many relationships MUST use a junction table with
+  composite primary key
+- Self-referencing relationships (e.g. `parent_id`) MUST document
+  maximum depth and cycle prevention strategy
+
+---
+
+## Schema evolution
+[ID: data-modeling-evolution]
+
+- Schema changes MUST go through versioned migrations — never
+  apply DDL manually in production
+- Additive changes (new column, new table) are safe — prefer them
+- Destructive changes (drop column, rename) require a migration
+  plan: add new → migrate data → drop old
+- Every migration MUST be reversible — include both up and down
+  steps
+- Test migrations against a production-like dataset before deploying
+
+---
+
+## Data types
+[ID: data-modeling-types]
+
+- Use the most specific type available — `DATE` not `VARCHAR` for
+  dates, `DECIMAL` not `FLOAT` for money
+- Store timestamps in UTC — convert to local time at the
+  presentation layer
+- Store monetary values as integers (cents) or `DECIMAL` — never
+  floating point
+- Use `UUID` or `ULID` for distributed ID generation — auto-increment
+  is acceptable for single-database systems
+- Text fields MUST have a documented maximum length — unbounded text
+  invites abuse and complicates indexing
+
+
+<!-- templates/base/data/data-quality.md -->
+# Base — Data Quality
+[ID: base-data-quality]
+[DEPENDS ON: templates/base/data/data-modeling.md]
+
+Rules for projects where content or data accuracy matters as much as
+code quality. Applies to lens databases, product catalogs, tutorial
+content, wiki entries, and any project that declares data as a
+first-class concern.
+
+---
+
+## Data sourcing
+[ID: data-quality-sourcing]
+
+- Every data point MUST trace to a named source (URL, publication,
+  manufacturer spec sheet)
+- Record the source alongside the data — not in a separate document
+- Prefer primary sources (manufacturer, official docs) over aggregators
+- When multiple sources conflict, document the conflict and the chosen
+  value with rationale
+- Never fabricate or estimate values without marking them as estimates
+
+---
+
+## Completeness tracking
+[ID: data-quality-completeness]
+
+- Define a completeness score for each entry: fields populated / total
+  fields (e.g. `14/14`)
+- Track completeness at the entry level, not just the collection level
+- Incomplete entries MUST be queryable — add a `completeness` or
+  `dataStatus` field
+- Set a minimum completeness threshold for publishing (e.g. 80%)
+- Entries below the threshold MAY exist in the database but MUST NOT
+  appear in user-facing views
+
+---
+
+## Freshness
+[ID: data-quality-freshness]
+
+- Record when each entry was last verified: `lastVerified` date field
+- Define a freshness window per collection (e.g. prices: 30 days,
+  specs: 12 months)
+- Entries beyond their freshness window SHOULD be flagged for review
+- Price data MUST include a `priceDate` field — never show a price
+  without indicating when it was captured
+- Discontinued or unavailable items MUST be marked, not deleted
+
+---
+
+## Exact vs estimated values
+[ID: data-quality-precision]
+
+- Distinguish exact values (from specs or measurements) from estimates
+  (derived, rounded, or interpolated)
+- Use a naming convention or field suffix to mark estimates (e.g.
+  `weightEstimated: true` or `~` prefix in display)
+- Default to realistic/pessimistic estimates — never optimistic
+- Document the estimation method when not obvious
+
+---
+
+## Calibration discipline
+[ID: data-quality-calibration]
+
+When a tool is calibrated against reference data (test fixtures with
+known-correct outputs, benchmark expected results, eval data, decision
+thresholds), three failure modes silently invalidate the calibration:
+suspect data treated as ground truth, the threshold tuned to mask a
+broken measurement, and reference values produced by the same actor
+that runs the tool. The rules below address each.
+
+### Ground truth comes from raw artifacts, not suspect data
+
+- When calibrating a pipeline against existing committed data, verify
+  the data was not produced by an earlier version of the same pipeline
+- If it was, and the pipeline has known or suspected bugs, the
+  committed data is NOT ground truth — calibrating against it bakes
+  the existing bugs into the new gate
+- Build the calibration set from raw artifacts (source images, raw
+  exports, captured fixtures), recording the verified value alongside
+  each entry
+- A small hand-built reference set from raw artifacts beats a large
+  set carried over from a suspect pipeline
+
+### Thresholds move, not the measurement
+
+- When a measurement and a threshold disagree, the threshold is the
+  cheaper thing to change — but ONLY after the measurement is verified
+  sound
+- Order of operations on disagreement: (1) verify the measurement
+  against an independent check, (2) tune the threshold if the
+  measurement is sound, (3) change the measurement implementation
+  ONLY when steps 1 and 2 fail to resolve the disagreement
+- A threshold picked from theory and never validated against data is
+  not a calibrated threshold — it is a guess; tuning it against the
+  data on first disagreement just hides the original guess
+- This rule applies wherever measurements meet thresholds: CI quality
+  gates, performance budgets, ML decision boundaries, extractor
+  agreement scores
+
+### Reference data MUST carry provenance
+
+- Each entry in a reference set MUST record `source: agent | user |
+  external` (who produced the value) and `verified: true | false`
+  (whether a human has reviewed it)
+- An agent MAY produce reference values to speed calibration, but
+  MUST set `source: agent` and `verified: false` until the user
+  reviews — the user MAY veto, replace, or accept; accepting flips
+  `verified: true`
+- Calibration metrics computed against the reference set MUST report
+  a coverage caveat alongside the headline numbers (e.g.
+  "verified: 12/40"), so unverified reference data cannot silently
+  dominate the metric
+- Synthetic test inputs (faker-style data, generated fixtures) are
+  out of scope — this rule covers reference *outputs* compared
+  against tool *outputs*, not test inputs
+
+---
+
+## Cross-validation and tool trust
+[ID: data-quality-cross-validation]
+
+When stored data is cross-validated against an external source (vendor
+page, API, spec sheet, scrape), two distinct failure modes produce
+misleading divergence reports: a buggy validation tool that misreads
+the source, and a semantic mismatch between *stored default* and
+*source silence*. Both look like "the data is wrong" and waste
+maintainer time on phantom fixes.
+
+### Verify the tool before trusting its output
+
+- When a validation, scraping, or migration tool drives a bulk data
+  change, confirm the tool is correct BEFORE acting on its output
+- A systematic tool bug masquerades as data divergence — applying
+  the tool's values blindly corrupts correct stored data
+- Treat a physically implausible output value as a tool defect:
+  fix, re-run, then apply
+- When the external source itself looks wrong (stale page, wrong
+  record served), cross-check an independent source before
+  overwriting stored data
+- Applies to scrapers, importers, schema-migration verifiers, and
+  lint-driven codemods — any automated diff that drives a bulk
+  change
+
+### Distinguish source-silent from source-says-false
+
+- A stored default (e.g. `absent boolean = false`) and source
+  silence (the source did not mention the field) are NOT the same
+  thing — treating them as equivalent produces a flood of
+  false-positive mismatches that bury real errors
+- The extractor MUST return a field ONLY when the source
+  affirmatively states it
+- The differ MUST compare a field ONLY when present on both the
+  stored and source sides — source-silence skips comparison, never
+  becomes a confirmed value
+- This keeps stored-default conventions (`absent = false`,
+  `null = unknown`) intact while making cross-validation meaningful
+- The trap is non-obvious: the stored-default convention and the
+  verification semantics pull in opposite directions, and the naive
+  implementation looks correct until run against real data
+
+---
+
+## Data research workflow
+[ID: data-quality-research]
+
+When data enters the system from external sources (official pages,
+lab reviews, retailers, scraped documents, public APIs), the
+research workflow itself can introduce systematic errors that
+later validation cannot detect. The rules below cover gathering
+facts from multiple sources of differing authority, auditing whole
+records rather than spot fields, extracting figures from composite
+images, and caching fetched content.
+
+### Source-conflict resolution
+
+- The most-authoritative source (official publisher, manufacturer
+  spec sheet, primary documentation) wins on any contested field
+- If a secondary source is provably wrong on one verifiable field,
+  treat ALL its unverified fields for that record as suspect — it
+  is likely mis-cataloged or mismatched. Do NOT cherry-pick its
+  other figures
+- Prefer leaving a field unresolved-and-flagged over overwriting it
+  with a contradicted source — a known gap is more useful than a
+  confidently-wrong value
+- When two sources of equivalent authority disagree, record the
+  conflict, the chosen value, and the rationale alongside the
+  entry (see [ID: data-quality-sourcing])
+
+### Full-record audit, not target-field audit
+
+- When verifying a record against a source, cross-check EVERY
+  field — not only the fields that prompted the verification
+- Copy-derived records frequently inherit stale values in fields
+  nobody re-checked (e.g. a "v2" entry retaining the v1 release
+  date or dimensions)
+- A spot-fix audit confirms the target field while leaving silent
+  drift in the rest of the record; a full-record audit catches
+  the drift
+
+### Content-aware figure cropping
+
+- When extracting a figure from a composite image (marketing
+  layout, manual page, dashboard screenshot), detect the content
+  bounding box programmatically — e.g. corner-median background
+  subtraction — rather than hand-guessing crop coordinates
+- Hand-picked coordinates silently truncate or off-center the
+  artifact; the error is caught only by a human eyeballing the
+  output
+- Keep automated edge-touch checks advisory (a tight axis box or
+  wide subject legitimately reaches the margin) and always have
+  a human review the crop before publishing
+
+### Cache validity: content checks, not blind TTL
+
+- For a research-time fetch/scrape cache (NOT the live request
+  path), decide cache validity by the content of a cached
+  response, not its age
+- Never cache non-content responses — bot/throttle interstitials,
+  4xx/gone error pages, implausibly short stubs. Detect and skip
+  them on write
+- Self-heal on read: if a cached body is recognizably junk
+  (bot/404/empty), ignore and re-fetch rather than re-serving the
+  bad cache
+- Refresh deliberately via an explicit `--no-cache` / force flag,
+  NOT on a timer
+- Add a time-based TTL only when there is evidence that content
+  goes stale in a way the content checks do not catch — a timer
+  cannot distinguish a value change from a resource removal (the
+  latter surfaces as 4xx and is handled above), and it slows every
+  session re-fetching unchanged data
+- Live request-path caches (Cache-Control, CDN, browser cache)
+  are out of scope — those have their own TTL semantics
+
+---
+
+## Scoring and derived fields
+[ID: data-quality-scoring]
+
+- Scoring formulas MUST be documented — not buried in code
+- All inputs to a score MUST be traceable to source data
+- Scores MUST be reproducible: same inputs always produce the same
+  output
+- Define the scoring scale once (e.g. 1–5, step 0.5) and use it
+  consistently
+- Features (boolean attributes like "weather sealed") are UI filter
+  badges, not scoring inputs — keep them separate
+
+---
+
+## Data changelog
+[ID: data-quality-changelog]
+
+- Changes to source data MUST be committed with a message explaining
+  what changed and why (e.g. "fix: update lens weight — manufacturer
+  corrected spec sheet")
+- When a scoring input changes, note that derived scores will change
+- Do not batch unrelated data changes into a single commit — one
+  entry or one field correction per commit
+- For bulk imports or migrations, document the source and method in
+  the commit message
+
+---
+
+## Identity and deduplication
+[ID: data-quality-identity]
+
+- Every entry MUST have a stable unique identifier that does not
+  change when other fields are updated
+- Define what makes two entries "the same" — document the identity
+  key (e.g. manufacturer + model name + variant)
+- Near-duplicates (regional names, revised versions, bundles) MUST
+  be distinct entries with a relationship field linking them
+- Never merge near-duplicates silently — flag for manual review
+- Discontinued items that are replaced by a successor SHOULD link
+  to the successor via a `replacedBy` field
+
+---
+
+## Validation
+[ID: data-quality-validation]
+
+- Validate data at ingest time — reject or flag entries that fail
+  schema validation
+- Use typed schemas (Zod, JSON Schema, TypeScript interfaces) for all
+  data collections
+- Range checks for numeric fields (e.g. weight > 0, price > 0)
+- Enum checks for constrained fields (e.g. mount type, category)
+- Build-time validation is acceptable for static sites — runtime
+  validation for APIs
+
+
 <!-- templates/base/workflow/quality-gates.md -->
 # Base — Quality Gates
 
@@ -2485,7 +2868,7 @@ python -m build           # build distribution
 
 <!-- templates/stack/python-service.md -->
 # Stack — Python Web Service
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md, templates/base/data/data-quality.md]
 
 Abstract rules for any Python web service or API. Never used directly —
 always extended by a framework-specific stack (Flask, FastAPI, Django).

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -288,6 +288,7 @@ stacks:
       - backend-messaging
       - base-cicd
       - base-devsecops
+      - base-data-quality
       - stack-python-lib
 
   - id: stack-flask

--- a/templates/stack/python-service.md
+++ b/templates/stack/python-service.md
@@ -1,5 +1,5 @@
 # Stack — Python Web Service
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/config.md, templates/backend/http.md, templates/backend/database.md, templates/backend/observability.md, templates/backend/quality.md, templates/backend/features.md, templates/backend/messaging.md, templates/stack/python-lib.md, templates/base/infra/cicd.md, templates/base/security/devsecops.md, templates/base/data/data-quality.md]
 
 Abstract rules for any Python web service or API. Never used directly —
 always extended by a framework-specific stack (Flask, FastAPI, Django).


### PR DESCRIPTION
## Summary

- Closes #418 — wires `base-data-quality` into `stack-python-service`, propagating transitively to Flask, FastAPI, and Django generated chains.
- Adds ADR-012 recording the decision and bounding scope to python-service only (other backend stacks remain unwired pending #424).
- Files #424 as follow-up to audit and split `data-quality.md` — the file's calibration/research sections apply more broadly than its name suggests.

## Test plan

- [x] `py tools/sync.py` regenerates 30 stacks, 4 affected (python-service, flask, fastapi, django)
- [x] `py tests/run_smoke.py` — 18/18 pass
- [x] Verified `generated/stack-fastapi.md` contains `base-data-quality` section
- [x] ADR-01 schema check passes for ADR-012

🤖 Generated with [Claude Code](https://claude.com/claude-code)