### PR TITLE
docs(core): add Markdown style rules (emphasis, code density, diagrams, ADR tables) (#505)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -425,6 +425,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -570,6 +572,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -578,6 +586,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -92,6 +92,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -237,6 +239,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -245,6 +253,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 


### PR DESCRIPTION
Adds documentation conventions to `base/core/docs.md` (Writing style /
Diagrams and assets / Decision logs), hardened during an arc42 readability
pass on a downstream project.

- Writing style: minimize bold/italic; code-format only identifiers, not whole
  commands; summarize intent + link to source over transcription.
- Diagrams: uniform node shapes; split multi-purpose diagrams; Mermaid note
  gotchas (`;` separator, bare `<` in `<br/>` notes).
- Decision logs: ADR Alternatives/Consequences as tables.

Regenerated the 30 affected chains (`py tools/sync.py`); smoke 18/18.

Closes #505