### PR TITLE
docs(workflow): tighten end-of-session upstream-flag steps (#507)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2177,11 +2177,14 @@ summarize — visible sequential execution prevents missed steps.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
-    introduced, explicitly state whether it is project-specific or
-    reusable; if reusable, name the upstream template file it would
-    go in
-12. **Flag gaps** — if any of the above cannot be completed, flag it
-    to the user before closing
+    introduced, state whether it is project-specific or reusable. If
+    reusable, name the upstream template file and file an issue on the
+    upstream repo (not a downstream note) — naming a candidate is not
+    contributing it
+12. **Flag gaps** — if any item cannot be completed this session, report
+    it as pending (never as done) before closing — including deferred
+    cross-repo work, such as an upstream contribution that was flagged
+    but not yet landed
 13. **Summary** — summarize what was done and what's next
 
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -125,9 +125,12 @@ summarize — visible sequential execution prevents missed steps.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
-    introduced, explicitly state whether it is project-specific or
-    reusable; if reusable, name the upstream template file it would
-    go in
-12. **Flag gaps** — if any of the above cannot be completed, flag it
-    to the user before closing
+    introduced, state whether it is project-specific or reusable. If
+    reusable, name the upstream template file and file an issue on the
+    upstream repo (not a downstream note) — naming a candidate is not
+    contributing it
+12. **Flag gaps** — if any item cannot be completed this session, report
+    it as pending (never as done) before closing — including deferred
+    cross-repo work, such as an upstream contribution that was flagged
+    but not yet landed
 13. **Summary** — summarize what was done and what's next


### PR DESCRIPTION
Sharpens the `workflow/scope.md` end-of-session audit so a flagged-but-unlanded upstream contribution can't be reported as done.

- **Item 11** — file the issue on the upstream repo (not a downstream note); naming a candidate is not contributing it.
- **Item 12** — report any incomplete item as pending (never done), including deferred cross-repo work.

Regenerated the affected chains (`py tools/sync.py`); smoke 18/18.

Closes #507