### PR TITLE
docs(quality): diagnose-before-tuning + calibration-aid rules (#431, #443)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -166,6 +166,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -160,6 +160,36 @@ that runs the tool. The rules below address each.
   out of scope — this rule covers reference *outputs* compared
   against tool *outputs*, not test inputs
 
+### Diagnose before tuning
+
+- Before changing a parameter whose value was set by a calibration
+  step or carries a tuning rationale, first PROBE to confirm the
+  parameter is the actual constraint — do not tune-and-see
+- Trace the value where it is computed and read the real intermediate
+  inputs from a real sample (a probe script, or a trace-not-propose
+  investigation), never a synthetic case
+- Tuning is valid once the probe shows the parameter is genuinely the
+  constraint; the wasteful move is changing code on "this might help"
+  without probing, which burns time and risks regressing unrelated
+  calibrated anchors
+
+### Calibration aids MUST NOT depict the system's own output
+
+- Any artifact that informs a human-verifies-machine signal (eye-read
+  against a chart, code review against a generated patch, audit grading
+  against a candidate report) MUST render only the reference data plus
+  the maintainer's reading guides
+- The candidate output goes in a separate artifact, opened only after
+  the independent reading is captured — surfacing it alongside the
+  reading task biases the reading toward the candidate and turns the
+  calibration into a self-confirming loop
+- Name the candidate-output artifact distinctly (`*-overlay.png`,
+  `*-trace.svg`, `*-prediction.md`) so it cannot be confused with the
+  reading aid
+- Comparison views opened AFTER the independent reading is captured
+  (diff viewers, side-by-side dispute resolution) are out of scope —
+  they are downstream of the signal and do not bias it
+
 ## Cross-validation and tool trust
 
 [ID: quality-cross-validation]


### PR DESCRIPTION
## What

Two calibration-family rules added as subsections of the now-core **Calibration discipline** section in `base/core/quality.md`:

- **Diagnose before tuning** (#431) — probe to confirm a calibrated parameter is the actual constraint before changing it; don't tune-and-see.
- **Calibration aids MUST NOT depict the system's own output** (#443) — keeps the human-verifies-machine signal independent (separate the candidate output from the reading aid).

## Home note

#431's issue suggested `ai-workflow.md`. Per the #424 finding (PR #534), `ai-workflow.md` reaches no generated stack. Both rules are calibration-family and belong with the calibration discipline now in core `quality.md`, which reaches all 30 stacks. #431 is phrased as a project-quality rule (probe before tuning) rather than agent-mechanism-specific. The optional `scope.md` companion entry from #431 is omitted to keep one rule, one home.

## Verification

- `py tools/sync.py --check` clean (all 30 chains regenerated).
- `py tests/run_smoke.py` — 18/18 pass.

Closes #431
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)