### PR TITLE
docs(quality,testing): fail-loud auto-derivation + coverage-by-cohort (#435, #434)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/frontend/static-site.md -->

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/stack/c-embedded.md -->

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/security/security.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/frontend/static-site.md -->

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/oop.md -->

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/stack/rust-lib.md -->

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/config.md -->

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/oop.md -->

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/language/typescript.md -->

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/infra/cicd.md -->

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/frontend/static-site.md -->

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -95,6 +95,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction
@@ -1079,6 +1086,25 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept
 
 
 <!-- templates/base/core/oop.md -->

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -89,6 +89,13 @@
   duplicated logic
 - **Fail Fast**: validate inputs at boundaries and throw immediately on
   invalid state; do not propagate bad data through the system
+- **Fail loud, not silent on auto-derivation**: when a value can be
+  either derived algorithmically (from a slug, name, hash) or read from
+  a source-of-truth field, prefer the read; when the field is missing,
+  raise/error rather than fall back to the derived value. A
+  wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
+  without warning is worse than a script that refuses to run until the
+  data is correct
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -209,3 +209,22 @@ fixing the design fixes the testability.
   concluding the code under test is at fault
 - Integration tests MUST use real dependencies for the boundary under test —
   not hand-written mocks
+
+---
+
+## Data validation tests
+[ID: base-testing-data-validation]
+
+Per-record validation (no duplicates, required fields present, range
+and enum checks) confirms each entry is well-formed but cannot see a
+partial migration — orphan keys and missing entries are individually
+valid. A cohort-level assertion catches what per-record checks miss.
+
+- **Coverage-by-cohort** — when a bulk migration writes N records keyed
+  by a derived slug, assert that the set of written keys equals the set
+  of expected slugs derived independently from the source-of-truth.
+  Catches orphan entries (key with no consumer) and missing entries
+  (consumer with no key); one assertion replaces ad-hoc post-merge
+  spot-checks
+- The pattern generalizes to any bulk migration where producer and
+  consumer derive keys independently from a shared concept


### PR DESCRIPTION
## What

Two bulk-data correctness rules, both in core templates (reach all stacks):

- **#435 fail-loud on auto-derivation** → `base/core/quality.md`, near Fail Fast. When a value can be derived algorithmically or read from a source-of-truth field, prefer the read and raise on a missing field rather than fall back to a derived-and-wrong value.
- **#434 coverage-by-cohort** → `base/core/testing.md`, new "Data validation tests" section. Assert the set of written keys equals the set of expected source-of-truth slugs, catching orphan and missing entries that per-record validation can't see.

## Verification

- `py tools/sync.py --check` clean (all 30 chains regenerated).
- `py tests/run_smoke.py` — 18/18 pass.

Closes #434
Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)