### PR TITLE
docs(generator-discipline): regenerate-in-PR + regenerate-not-hand-edit + staleness gate (#444, #437, #445)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1665,6 +1682,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2214,6 +2231,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2755,6 +2772,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2755,6 +2772,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2755,6 +2772,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1441,6 +1458,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1441,6 +1458,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1441,6 +1458,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1441,6 +1458,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2162,6 +2179,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1441,6 +1458,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -2755,6 +2772,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 
@@ -1665,6 +1682,27 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+---
+
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
 
 ---
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -320,6 +320,18 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.
@@ -749,6 +761,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -279,6 +279,11 @@ it as stale.
   paths — otherwise the formatter reformats the file at commit time
   and `--check` then reports a confusing stale-file failure on the
   next run
+- When a generated file's inputs change (a rename, move, or schema
+  bump), re-run the generator rather than string-editing the artifact
+  — the banner's "do not edit" header is a contract, and the next
+  `--check` run flags a hand-edited file as stale against freshly
+  generated content
 
 ## Output file by agent
 

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -20,6 +20,18 @@
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Regenerate derived artifacts in the same PR** — when a change
+  affects generated or derived files committed to the repo (extractor
+  outputs, snapshot fixtures, generated docs), regenerate them in the
+  fixing PR, not a follow-up. A stale artifact is indistinguishable
+  from a regression to the next reviewer. Include a before/after
+  summary (verdict matrix, delta table, screenshot diff) in the PR
+  body so reviewers see the user-visible impact without re-running
+  the pipeline.
+  - When regeneration is too expensive to bundle (e.g. >30s in CI or
+    >100 files), the PR MUST open a tracked follow-up issue AND state
+    the STALE accounting explicitly (N files affected, named or
+    globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness → clarity →
   conventions. Check CI passes. Only merge after the review passes.

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -217,6 +217,27 @@ below close those gaps.
 
 ---
 
+## Generated-file staleness gate
+
+[ID: quality-gates-staleness]
+
+When a project commits generated artifacts (rendered docs, generated
+configs, resolved template chains, code-from-schema output) AND uses
+the `--check` convention from `base-docs`, the `--check` invocation
+MUST be wired into CI as a required status check on the relevant
+paths.
+
+- A banner naming the regenerate command is decorative without the
+  gate — a stale file looks identical to a fresh one, and the
+  regenerator can silently break for months unnoticed
+- A staleness gate that is never run on the relevant paths is the
+  gate-by-omission anti-pattern named in `quality-gates-scope-agreement`
+  — passing-because-skipped is not passing
+- The gate MUST fail when the committed artifact differs from a fresh
+  render, exactly as it fails on lint or type errors
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]


### PR DESCRIPTION
## What

Three rules for projects that commit generated/derived artifacts:

- **#444** → `base/core/git.md` (Pull requests): regenerate derived artifacts in the *fixing* PR (not a follow-up), with a before/after summary in the body; if regeneration is too expensive, open a tracked follow-up AND state the STALE accounting explicitly.
- **#437** → `base/core/docs.md` (Generated files): when a generated file's inputs change (rename, move, schema bump), re-run the generator rather than string-editing the artifact.
- **#445** → `base/workflow/quality-gates.md`: new **Generated-file staleness gate** section — the `--check` invocation MUST be a required CI check; a never-run staleness gate is the gate-by-omission anti-pattern already named in `quality-gates-scope-agreement`.

## Notes

- #445 placed in `quality-gates.md` (the issue's "alternative framing") rather than only extending docs.md, so it sits with the gate model and cross-references the sibling anti-pattern by ID. docs.md's existing `--check` SHOULD-expose bullet is unchanged.

## Verification

- `py tools/sync.py --check` clean (all 30 chains regenerated).
- `py tests/run_smoke.py` — 18/18 pass.

Closes #437
Closes #444
Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)