### PR TITLE
docs(core): add Markdown style rules — ADR tables, visual restraint, diagrams (#505)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -574,6 +574,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -719,6 +721,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -727,6 +735,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -92,6 +92,8 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Render "Alternatives considered" and "Consequences" as tables where the
+  content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
@@ -237,6 +239,12 @@ is incomplete.
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
 - Use full, grammatically correct sentences — enumerations are exempt
+- Use bold and italic sparingly — never bold inline code or a whole sentence,
+  and use at most one short bold label per list item
+- Code-format only identifiers (file names, paths, env vars); summarize whole
+  commands and flags in prose rather than transcribing them as inline code
+- Summarize intent and link to the source — do not transcribe methods,
+  constants, or flags into prose
 
 ## Diagrams and assets
 
@@ -245,6 +253,10 @@ is incomplete.
 - Commit all raw editable sources alongside rendered outputs
 - Do not use proprietary formats (Word, Illustrator, Affinity Designer)
 - Diagrams MUST be version-controlled — binary-only diagrams are not acceptable
+- Use uniform node shapes; split a diagram that serves two purposes (e.g.
+  happy path vs error path, or build vs runtime)
+- In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
+  tag inside `<br/>` notes) — both silently break rendering
 
 ## Docs-as-code
 


### PR DESCRIPTION
## What

General documentation-style rules added to `base/core/docs.md`:
- ADR **Alternatives considered** / **Consequences** render as tables where content fits.
- **Visual restraint** (Writing style): sparing bold/italic, code-format only identifiers, summarize intent over transcribing commands/methods.
- **Diagrams**: uniform node shapes, split dual-purpose diagrams, Mermaid note gotchas (`;` separator, bare `<` in `<br/>`).

## Provenance

Re-applied on current main from the stale `docs/markdown-style-rules` branch — its `generated/` diff predated the v2.10 regeneration, so I re-applied the source hunks cleanly and regenerated. The old branch will be deleted.

## Dedup note

The visual-restraint and Mermaid-gotcha rules here overlap with #513's arc42 proposal. This PR owns the **general** rules; #513 will be trimmed to arc42-chapter-specific conventions only.

## Verification

- `py tools/sync.py --check` clean; `py tests/run_smoke.py` 18/18.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)