### PR TITLE
docs(core): add arc42 authoring conventions (#513)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -740,6 +740,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -258,6 +258,56 @@ is incomplete.
 - In Mermaid notes, avoid `;` (a statement separator) and a bare `<` (opens a
   tag inside `<br/>` notes) — both silently break rendering
 
+## arc42 architecture documentation (if applicable)
+
+[ID: docs-arc42]
+
+For projects documenting architecture with arc42, these conventions keep
+chapters consistent and prevent the common cross-section leaks. The
+general writing-style and diagram rules above still apply.
+
+### Chapter boundaries
+
+- **§2 Constraints vs §4 Solution Strategy** — §2 holds only *givens*
+  (language, OS/platform, environment and resource limits, licensing,
+  process and tooling). Technology *selections* (frameworks, libraries,
+  servers, algorithms, protocols, patterns) are §4 decisions, not §2
+  constraints. Tell: a "constraint" carrying a justification ("…because
+  X is hard") is a decision
+- §2 constraints are forward-stated — never reverse-engineered from
+  code; no file/line citations and no "source" column
+- §3 Context stays high-level — no source-file paths, tool names, or
+  registry/platform names (those live in §7/§9). §3.2 technical-context
+  channels are external partners only — an in-process library is not a
+  channel. §3.3 "In scope" lists project deliverables, not a re-list of
+  the §1 functional requirements
+- §3 diagrams are black-box — use the arc42 partner / input / output
+  table and distinguish human actors from systems
+- Chapters cite no ADRs — keep inline `AD-N` citations and generic
+  "ADR" / "decision record" mentions out of chapter bodies; §9 is the
+  single ADR index
+
+### IDs and register
+
+- Functional requirements use `FR01…` in shall-form (IEEE 29148);
+  quality goals use `QG01…` with ISO 25010 names (Correctness,
+  Reliability, Maintainability, Portability, Compatibility, Usability) —
+  distinct from the `Q1…` quality scenarios in §10
+- Requirements use "shall"; constraints and other givens stay
+  declarative — avoid all-caps RFC 2119 keywords in arc42 prose
+- A per-section purpose line only where it adds meaning (define a term
+  or draw a distinction such as FR vs NFR) — never restate the heading
+- No forward cross-references to later-numbered sections (a section is
+  authored before they exist); back-references are fine
+
+### Concept sections
+
+- Describe the idea in prose, then give a `Concept | Implementation`
+  table mapping it to concrete identifiers — rather than inlining
+  identifiers throughout the prose
+- A glossary entry is a **bold term** followed by plain text — no
+  inline-code monospacing of the term
+
 ## Docs-as-code
 
 - Technical documentation lives in the repository alongside the code


### PR DESCRIPTION
## What

New **arc42 architecture documentation (if applicable)** section in `base/core/docs.md`:
- **Chapter boundaries** — §2 constraints (givens) vs §4 decisions (selections); §2 forward-stated; §3 stays high-level + black-box (external partners only); chapters cite no ADRs (§9 is the index).
- **IDs and register** — `FR01…` shall-form (IEEE 29148), `QG01…` ISO 25010 names (distinct from §10 `Q1…`); declarative constraints; purpose lines only where meaningful; no forward cross-refs.
- **Concept sections** — prose + `Concept | Implementation` table; glossary = bold term + plain text.

## Dedup

Deduped against #505 (merged): visual restraint, Mermaid gotchas, and intent-over-transcription are general rules that live above and are **not** repeated here. Folds in #503's unique arc42 points (ID schemes, §3 partner table). #503's OpenAPI/CD candidates remain separate Backlog work.

## Verification

- `py tools/sync.py --check` clean; `py tests/run_smoke.py` 18/18.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)