### PR TITLE
docs(core): ADR one-concern rule + same-day supersession guidance (#489, #533)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,8 @@ base/ ──┬── frontend/ ──┐
   `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered,
   consequences
+- Each ADR addresses exactly one concern — a separate concern gets
+  its own ADR (multi-part decisions allowed within one concern)
 - ADRs are immutable once merged — create a new ADR to supersede
   an old one. The ONE exception: `superseded_by` / `status` /
   `date` frontmatter fields on a previously-merged ADR MAY be

--- a/docs/decisions/014-one-concern-per-adr.md
+++ b/docs/decisions/014-one-concern-per-adr.md
@@ -1,0 +1,47 @@
+---
+id: "014"
+status: Accepted
+date: 2026-06-24
+category: process
+supersedes: []
+superseded_by: []
+---
+
+# ADR-014: One concern per ADR
+
+## Context
+
+The "one concern, one PR" rule is explicit for pull requests but only
+implicit for ADRs. The single `category` field, the singular framing in
+the ADR template, atomic supersession, and the self-sufficiency
+requirement all imply it, yet no written rule states it. When an ADR
+grows to cover two concerns — for example a content-layout decision and
+a build-output decision — there is nothing to cite when splitting the
+second concern into its own record.
+
+## Decision
+
+1. **One concern per ADR** — each ADR MUST address exactly one concern.
+   A separate concern gets its own ADR, cross-linked or superseding via
+   the frontmatter `supersedes` / `superseded_by` fields as needed.
+2. **One concern is not one rule** — a single ADR MAY number multiple
+   related decisions (1., 2., …) within its one concern. The constraint
+   is on the topic, not the count of rule statements.
+
+## Alternatives considered
+
+- **Leave it implicit** — rejected; unenforceable in review with no
+  written rule to cite when a multi-concern ADR appears.
+- **One rule per ADR** — rejected; over-fragments governance ADRs that
+  legitimately bundle related sub-decisions under a single concern.
+
+## Consequences
+
+- `base/core/docs.md`, `CLAUDE.md` §2.9, and `docs/decisions/TEMPLATE.md`
+  state the rule; the template note clarifies that one concern is not
+  one rule.
+- No schema change; the smoke `ADR-01` check is unaffected.
+
+## Related
+
+- #489 — the task this ADR records

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -31,6 +31,8 @@ MAY) for the rule statements. Number multi-part decisions:
 
 1. **Short label** — the rule
 2. **Short label** — the next rule
+
+One concern per ADR; multi-part decisions are allowed within it.
 -->
 
 ## Alternatives considered

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -574,9 +574,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -92,9 +92,20 @@ Before every commit, update all relevant documentation:
 - Significant architectural decisions MUST be recorded as Architecture Decision
   Records (ADR) in `docs/decisions/`
 - Each ADR documents: context, decision, alternatives considered, consequences
+- Each ADR MUST address exactly one concern — a separate concern gets its
+  own ADR. One concern is not one rule: a single ADR MAY number multiple
+  related decisions (1., 2., …) within its one concern
 - Render "Alternatives considered" and "Consequences" as tables where the
   content fits — they scan faster than prose lists
 - ADRs are immutable once merged — create a new ADR to supersede an old one
+- When an ADR's premise is refuted shortly after it merges (typically by
+  data that should have informed it), prefer a same-day or same-week
+  supersession ADR documenting the post-mortem over silently closing the
+  follow-up issues — an `Accepted` ADR describing code that does not exist
+  is documentation-vs-code drift. The supersession ADR records the refuting
+  evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
+  Prevention) if the original shipped any change; the superseded ADR's
+  status flips to `Superseded by ADR-NNN` in the same PR
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:


### PR DESCRIPTION
## What

Two ADR-authoring rules in `base/core/docs.md` (Decision logs):

- **#489 — one concern per ADR**: each ADR MUST address exactly one concern; a separate concern gets its own ADR. *One concern is not one rule* — multi-part decisions are allowed within it. Stated authoritatively in `docs.md`, summarized in `CLAUDE.md` §2.9, noted in `docs/decisions/TEMPLATE.md`, and recorded as **ADR-014**.
- **#533 — same-day supersession**: when an ADR's premise is refuted shortly after merge, prefer a same-day/same-week supersession ADR (with refuting evidence + post-mortem) over silently closing follow-ups. An `Accepted` ADR describing code that doesn't exist is doc-vs-code drift.

## Self-referential note

By #489's own rule, these are two concerns — so #489 gets its own ADR-014 and #533 stays docs-only guidance. (A single PR may still carry both.)

## Verification

- `py tools/sync.py --check` clean; `py tests/run_smoke.py` 18/18 (ADR-01 validates ADR-014).

Closes #489
Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)