### PR TITLE
docs: milestone-on-purpose + upstream-flag + layer-aligned identifiers (#529, #507, #515)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1505,6 +1505,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1576,6 +1576,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2075,6 +2075,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1576,6 +1576,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1576,6 +1576,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2043,6 +2043,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2043,6 +2043,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2075,6 +2075,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1497,6 +1497,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1576,6 +1576,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1229,6 +1229,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -2023,6 +2023,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1229,6 +1229,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1497,6 +1497,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2444,11 +2444,14 @@ summarize — visible sequential execution prevents missed steps.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
-    introduced, explicitly state whether it is project-specific or
-    reusable; if reusable, name the upstream template file it would
-    go in
-12. **Flag gaps** — if any of the above cannot be completed, flag it
-    to the user before closing
+    introduced, state whether it is project-specific or reusable. If
+    reusable, name the upstream template file and file an issue on the
+    upstream repo (not a downstream note) — naming a candidate is not
+    contributing it
+12. **Flag gaps** — if any item cannot be completed this session, report
+    it as pending (never as done) before closing — including deferred
+    cross-repo work, such as an upstream contribution that was flagged
+    but not yet landed
 13. **Summary** — summarize what was done and what's next
 
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1229,6 +1229,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/templates/base/core/oop.md
+++ b/templates/base/core/oop.md
@@ -29,6 +29,11 @@ Apply SOLID at the class, module, and service level:
   types
 - Keep class hierarchies shallow — more than two levels of inheritance is a
   signal to refactor towards composition
+- **Internal identifiers must align with their layer** — a module or class
+  whose name implies a role it does not hold (an `endpoints.py` with no
+  routes, a `*RestApi` class that is not the REST API) misleads readers and
+  forces clarifying asides; when the layering and the name disagree, rename
+  to match the layer
 
 ## Design patterns
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -125,9 +125,12 @@ summarize — visible sequential execution prevents missed steps.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
-    introduced, explicitly state whether it is project-specific or
-    reusable; if reusable, name the upstream template file it would
-    go in
-12. **Flag gaps** — if any of the above cannot be completed, flag it
-    to the user before closing
+    introduced, state whether it is project-specific or reusable. If
+    reusable, name the upstream template file and file an issue on the
+    upstream repo (not a downstream note) — naming a candidate is not
+    contributing it
+12. **Flag gaps** — if any item cannot be completed this session, report
+    it as pending (never as done) before closing — including deferred
+    cross-repo work, such as an upstream contribution that was flagged
+    but not yet landed
 13. **Summary** — summarize what was done and what's next

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -150,6 +150,14 @@ and out when shipped. Use `Expedite` instead of `Backlog` when the
 work is small, urgent, or out-of-cycle and does not fit the current
 versioned milestone's theme.
 
+Milestones are forward-looking planning; GitHub Releases are the
+backward-looking shipped record. Create a versioned milestone (e.g.
+`v1.0.0`) only for a deliberately planned, scoped release. Routine or
+emergent releases cut from `Backlog` / `Expedite` get no versioned
+milestone — the Release is their shipped record. Do NOT backfill empty
+per-version milestones after the fact; a planning artifact created
+retroactively carries no information.
+
 Colors follow the Atlassian design system palette. Type labels use
 saturated hues; priority labels use a warm-to-cool gradient to
 remain visually distinct when displayed side by side.


### PR DESCRIPTION
## What

Three convention rules across three files:

- **#529** → `platform/github.md`: milestones are forward-looking planning, GitHub Releases are the backward-looking shipped record. Create a versioned milestone only for a deliberately-planned, scoped release; emergent releases get none; don't backfill empty per-version milestones.
- **#507** → `base/workflow/scope.md`: end-of-session template-feedback step now requires *filing an upstream issue* (not a downstream note — naming a candidate isn't contributing it); flag-gaps reports deferred cross-repo work as **pending**, never done. (Re-applied from the stale `docs/tighten-session-upstream-flag` branch.)
- **#515** → `base/core/oop.md`: internal identifiers must align with their layer — rename when name and layer disagree (`endpoints.py` with no routes, `*RestApi` that isn't the REST API).

## Verification

- `py tools/sync.py --check` clean; `py tests/run_smoke.py` 18/18.

Closes #529
Closes #507
Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)