### PR TITLE
docs(core): dev-journal casing split + contents schema (#500)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -514,6 +514,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -694,12 +699,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -32,6 +32,11 @@ levels. Every rule MUST use one of these words:
 | `docs/dev-journal.md` | Development history and session log (MUST for agent-assisted projects) |
 | `docs/SPEC.md`        | System design, architecture rules, composition model (SHOULD for complex projects) |
 
+Guide-doc filenames follow a deliberate casing split: single-word guide
+docs use SHOUT-case (`README.md`, `CLAUDE.md`, `ONBOARDING.md`,
+`PLAYBOOK.md`, `SPEC.md`); multi-word descriptive docs use lower
+kebab-case (`dev-journal.md`). This is intentional, not drift.
+
 ## Numbering
 
 - Use numbered headings (1, 1.1, 1.2, 2, 2.1, etc.) in PLAYBOOK and
@@ -212,12 +217,17 @@ Example skeleton:
   `docs/dev-journal.md`
 - Agents have no persistent memory across sessions — the journal provides
   continuity by recording what was done, what changed, and why
-- Structure: architecture overview at the top, then chronological session
-  entries (newest last)
-- Each session entry records: date, tool used, key changes, decisions made
-- Session entry heading format: `### Session N — Short Theme Description`
-  (3-6 words describing what was done; no dates or tool names in the
+- Structure: architecture overview at the top, then session entries in
+  reverse-chronological order (newest first, directly under the top
   heading)
+- Session entry heading format: `## YYYY-MM-DD — Short theme` (3-6 word
+  theme; a parenthetical qualifier such as `(evening)` is allowed when a
+  single day has multiple sessions)
+- Each session entry MUST record, as bold-labelled fields: **Tool** used,
+  **Key changes**, **PRs merged**, **Issues closed/created**, and
+  **Lesson** or decisions made (linking ADRs for any decision); the date
+  lives in the heading. Add a **post-mortem** when the session shipped a
+  P0/P1 fix or handled an incident (see below)
 - When milestones or phases are renamed or renumbered in the issue tracker,
   the dev journal architecture overview MUST be updated in the same PR
 - Do not duplicate content that belongs elsewhere — link to ADRs for


### PR DESCRIPTION
## Decision

**Keep `dev-journal.md`** — renaming to `SESSIONS.md` is a system-wide breaking change (every generated context file, `manifest.yaml`, `examples/`), deferred to v3.0 per the issue.

## What

- **Casing split documented** — single-word guide docs use SHOUT-case (`README.md`, `CLAUDE.md`, …); multi-word descriptive docs use lower kebab-case (`dev-journal.md`). Intentional, not drift.
- **Required-contents entry schema** — Tool, Key changes, PRs merged, Issues closed/created, Lesson/decisions (link ADRs), post-mortem if P0/P1.
- **Reconciled docs.md to the actual format** — the dogfooded journal is **newest-first** with `## YYYY-MM-DD — Theme` headings, but docs.md said "newest last" / "### Session N". Updated docs.md to match the file (the authoritative example per the match-convention rule); zero churn to the 25 existing entries.

## Verification

- `py tools/sync.py --check` clean; `py tests/run_smoke.py` 18/18.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)