### PR TITLE
docs(workflow): probe before acting on a hypothesis (#468, #471, #450, #459, #532, #477, #481, #474)

### DIFF
--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -324,6 +324,22 @@ AI agents can do mental math — and get it wrong. When the agent computes a sco
 
 The build is the source of truth. `npm run build` then check the output. Don't trust "I calculated 7.9" — check what the page actually renders.
 
+### Probe before acting on a hypothesis
+
+A bug ticket, a spike, or a prior-session note often arrives with a hypothesized mechanism, a proposed fix, or an inherited diagnosis. Treat it as a claim to disprove, not a foundation to build on. Before acting, run the cheapest probe — a throwaway script, a data dump, a single query — that would confirm or refute it. One run answers two questions: is the hypothesis correct, and where is the real signal? The frequent outcome is that the probe inverts the framing and the real cause sits in a different region than the text predicted.
+
+Run the probe at whichever decision point comes first:
+
+- **Before coding a fix the issue proposes** — when the body names a specific code surface and a predicted cause, the fix often belongs somewhere the text did not point.
+- **Before drafting an ADR** — when the investigation prompts are cheap to answer against real data, the measurement frequently flips the recommendation an estimate would have reached.
+- **At spike intake** — before treating a spike that asserts a specific failure ("X happens because Y") as actionable, confirm the assertion against the cheapest data dump that would refute it.
+- **At the start of a follow-up session** — re-verify any load-bearing diagnosis inherited from a prior session's memory; a coarse earlier conclusion may not survive a direct probe, and the proposed solution set may be unnecessary.
+- **Before filing a bug** — when a short probe (under ~30 min) costs less than the next agent's cost to orient, it turns a reproduction-only ticket into a root-cause brief with fix options.
+
+Probe the artifact, not your reading of it. When the claim rests on a dense source-of-truth artifact — an overlay image, a generated SVG, a log, a chart, a database row — dump its raw representation (pixel scan, JSON dump, AST walk, `SELECT`) instead of re-interpreting the rendered view. Repeated reading is slower and can yield mutually inconsistent conclusions; one raw dump settles the question.
+
+Skipping the probe has two visible failure modes: a well-reasoned fix built against a wrong premise, and a premature ADR that needs same-day supersession. When the probe inverts the framing, the original text is a useful negative result — record it in the PR description or the ADR's "approaches ruled out." If the project exposes no cheap probe for the claim, surfacing that gap is itself the first output. Probes are throwaway: name them for the issue, delete them before the commit that uses their findings, and keep the findings in the issue, ADR, or PR.
+
 ### Scope creep within sessions
 
 A productive session can cover a lot of ground. But jumping between unrelated topics (feature work, data fixes, epic triage, domain decisions) leads to:


### PR DESCRIPTION
## Summary

Consolidates eight v2.12 *probe-first* lessons into a single new
**Probe before acting on a hypothesis** subsection in
`templates/base/workflow/ai-workflow.md` (Lessons Learned), placed
beside the existing "Verify agent calculations against the system"
rule that several of the issues named as its sibling.

All eight issues are the same lesson at different decision points, so
they collapse into one cohesive subsection rather than eight fragments
(per the no-duplication doc rule; #474 itself suggested "one combined
section").

The subsection covers:
- The principle — treat a hypothesized mechanism / proposed fix /
  inherited diagnosis as a claim to disprove, not a foundation.
- The decision points where it fires: before coding a proposed fix
  (#468, #471, #450), before drafting an ADR (#459), at spike intake
  (#532), on a diagnosis inherited from prior-session memory (#477),
  before filing a bug (#481).
- "Probe the artifact, not your reading of it" corollary (#474).
- Record-the-inversion as a negative result; surface a missing-probe
  gap as the first output; throwaway-probe discipline.

Phrased project-agnostically (no MTF/chart specifics) so it applies
to any stack.

## Decisions
- **No ADR** — template content, not a structural/system decision.
- **No inline `.md` cross-ref** — this layer expresses relationships
  via `[DEPENDS ON]` headers only; the throwaway-probe point is stated
  self-contained.

## Test plan
- `py tests/run_smoke.py` → 18/18 pass.

Closes #468
Closes #471
Closes #450
Closes #459
Closes #532
Closes #477
Closes #481
Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)