### PR TITLE
docs(platform): CI workflow authoring rules from a real outage (#499)

### DIFF
--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -349,6 +349,7 @@ Confirm, before acting:
 - **The target is the real project** — search ranking and name collisions lie. Verify against the README, the canonical source, or the site the dependency claims to be.
 - **The repo is live** — not archived, read-only, or migrated. An archived repo silently rejects new issues; a moved one routes your action to a dead fork.
 - **The channel is open** — issues are enabled, the branch accepts PRs, the package version still exists.
+- **The terms fit your repo** — an "official" or "recommended" action/tool's pricing and license model fits your repo's org type. "Official" is not always "drop-in": `gitleaks/gitleaks-action` is free on personal repos but requires a paid license secret on organization repos. Verify the pricing model before switching, not on the first failing run.
 
 When a check fails, treat it as a signal about your own source of truth, not just a one-off filing problem. A repo that turns out archived, renamed, or wrong means the ADR, README, or memory that pointed there is stale — fix the pointer (or drop the dead trigger) in the same task, rather than working around the single blocked action.
 

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -15,6 +15,33 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 - Pipeline definitions: `.github/workflows/*.yml`
 - Trigger: `on: pull_request` for validation, `on: push` for main branch
 - Actions marketplace for reusable steps
+- **Authenticate GitHub API calls**, even for public-data reads. Any
+  `api.github.com` call in a workflow MUST send
+  `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}`. Unauthenticated
+  calls are rate-limited to 60/hour per source IP, and Actions runners
+  share IP pools — so an innocent `curl .../releases/latest` for
+  version resolution can return an empty body under load, with no
+  curl error.
+- **Fail loud on resolved shell values.** Any step that resolves a
+  value via a pipeline (`curl | grep | cut`, `jq`, etc.) MUST
+  `set -euo pipefail` AND check the result before use. Pipelines exit
+  0 on empty intermediates, so `v${VERSION}_linux_x64.tar.gz` silently
+  becomes `v_linux_x64.tar.gz` → 404, far from the real failure.
+
+  ```yaml
+  - name: Resolve version
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    run: |
+      set -euo pipefail
+      VERSION=$(curl -sSf -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        https://api.github.com/repos/owner/foo/releases/latest \
+        | grep tag_name | cut -d '"' -f 4 | sed 's/v//')
+      if [ -z "${VERSION}" ]; then
+        echo "Failed to resolve VERSION" >&2
+        exit 1
+      fi
+  ```
 
 ---
 
@@ -63,7 +90,11 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 
 - **GitHub push protection** — native, blocks pushes containing known
   secret patterns; enable via Settings → Code security
-- **gitleaks** — `gitleaks/gitleaks-action` in CI for additional coverage
+- **gitleaks** — `gitleaks/gitleaks-action` in CI for additional
+  coverage. Free on personal repos; on **organization** repos it
+  requires a paid `GITLEAKS_LICENSE` secret. For org repos, consider
+  the authenticated curl-install pattern instead (see CI section,
+  workflow authoring rules) to avoid the paywall.
 - Both SHOULD be enabled — push protection catches on push, gitleaks
   catches in PR validation
 


### PR DESCRIPTION
Closes #499.

Three reusable CI-authoring rules surfaced from a single ~2h gitleaks outage on me-fuji, all generalizing to any GitHub Actions workflow.

## Changes

**`templates/platform/github.md` — CI section**
- Authenticate `api.github.com` calls with `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}` even for public reads — unauthenticated calls share a 60/hour-per-IP bucket across runners and silently return empty under load.
- Fail loud on shell-pipeline-resolved values: `set -euo pipefail` + explicit empty-check, so an empty version no longer interpolates into a 404 URL far from the real failure. One worked `yaml` example shows both patterns.

**`templates/platform/github.md` — Secret detection**
- Qualify the `gitleaks/gitleaks-action` recommendation: free on personal repos, requires a paid `GITLEAKS_LICENSE` secret on org repos; point org repos at the authenticated curl-install pattern.

**`templates/base/workflow/ai-workflow.md` — Lessons Learned**
- Add a "terms fit your repo" bullet to **Verify external state before a visible action**. The issue suggested "Decide before delegating", but this section (added v2.12) is the stronger semantic home — verifying a tool's pricing/license before adopting it is verifying external state before a public action. Keeps the lesson consolidated rather than fragmented.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync

## Note
This is the first of three v2.13 PRs that edit `platform/github.md` (also #510 SHA-pinning, #509 Dependabot triage). They will merge sequentially with rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)