### PR TITLE
docs(platform): pin third-party GitHub Actions to commit SHAs (#510)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2100,6 +2100,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/base/workflow/quality-gates.md -->

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2360,6 +2360,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/base/data/data-modeling.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2595,6 +2595,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/node-express.md -->

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2360,6 +2360,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/base/data/data-modeling.md -->

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2360,6 +2360,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/base/data/data-modeling.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2910,6 +2910,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/go-service.md -->

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2910,6 +2910,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/go-service.md -->

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2584,6 +2584,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/go-grpc.md -->

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -2203,6 +2203,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/java-grpc.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2606,6 +2606,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/python-grpc.md -->

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2595,6 +2595,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/node-nestjs.md -->

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2656,6 +2656,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/full-nextjs.md -->

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2360,6 +2360,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/base/data/data-modeling.md -->

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -2543,6 +2543,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/java-spring-boot.md -->

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -2413,6 +2413,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/full-sveltekit.md -->

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1365,6 +1365,9 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector
 
 
 <!-- templates/stack/iac-terraform.md -->

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -79,3 +79,6 @@ not after deployment.
 - Keep dependencies up to date — unpatched dependencies are a security risk
 - Remove unused dependencies promptly
 - Prefer dependencies that are actively maintained and widely adopted
+- Pin third-party GitHub Actions to a full commit SHA, not a mutable
+  tag, with the version in a trailing comment so Dependabot still bumps
+  them — a moved tag is a supply-chain attack vector

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -42,6 +42,15 @@ gate categories to GitHub Actions workflows and GitHub-native features.
         exit 1
       fi
   ```
+- **Pin third-party actions to a full commit SHA**, with the
+  human-readable version in a trailing comment so Dependabot still
+  bumps them. A tag can be moved to point at different code; a commit
+  SHA cannot — SHA-pinning is the standard supply-chain control for
+  third-party actions.
+
+  ```yaml
+  - uses: actions/checkout@<commit-sha>  # v4
+  ```
 
 ---
 
@@ -73,7 +82,7 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 
   ```yaml
   # .github/workflows/codeql.yml
-  - uses: github/codeql-action/init@v4
+  - uses: github/codeql-action/init@<commit-sha>  # v4
     with:
       languages: javascript-typescript
       config-file: ./.github/codeql-config.yml
@@ -153,7 +162,7 @@ output, MUST use `--root-dir <build-dir>` to resolve root-relative
 paths. Without it, links like `/about` produce false errors:
 
 ```yaml
-- uses: lycheeverse/lychee-action@v2
+- uses: lycheeverse/lychee-action@<commit-sha>  # v2
   with:
     args: --offline --no-progress --root-dir dist dist/
 ```


### PR DESCRIPTION
Closes #510.

A mutable tag can be repointed at different code; a commit SHA cannot — SHA-pinning is the standard supply-chain control for third-party actions, while the trailing version comment keeps Dependabot bumping them.

## Changes

**`templates/platform/github.md` — CI**
- Add the convention: third-party actions SHOULD be pinned to a full commit SHA with the human-readable version in a trailing comment.
- Convert the `codeql-action` and `lychee-action` examples to the `@<commit-sha>  # vN` form.

**`templates/base/security/devsecops.md` — Dependency hygiene**
- Add a supply-chain bullet for the same control.

**`generated/`** — regenerated the 16 stack chains that embed `base-devsecops`.

## Note on placeholders
Examples use `@<commit-sha>` as an explicit placeholder rather than a fabricated 40-char SHA — a baked-in real SHA would be unverifiable offline and would go stale. The trailing `# vN` comment carries the human-readable version.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync

Second of three v2.13 PRs touching `platform/github.md` (after #499, before #509).

🤖 Generated with [Claude Code](https://claude.com/claude-code)