### PR TITLE
docs(workflow): Dependabot weekly-batch triage + co-dependent rebase (#509, #438)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1524,6 +1524,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1638,6 +1644,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2195,6 +2201,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2736,6 +2742,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1352,6 +1352,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2736,6 +2742,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2736,6 +2742,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1414,6 +1420,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1414,6 +1420,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1414,6 +1420,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1414,6 +1420,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2135,6 +2141,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1352,6 +1352,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2061,6 +2061,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1414,6 +1420,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -2736,6 +2742,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1300,6 +1300,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -2054,6 +2054,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1524,6 +1524,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 
@@ -1638,6 +1644,16 @@ quality scoring for web projects, docstring enforcement for Python).
 - **eslint-plugin-sonarjs** — detects cognitive complexity, duplicate
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
+
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
 
 ---
 

--- a/templates/base/core/config.md
+++ b/templates/base/core/config.md
@@ -90,6 +90,12 @@ Sources override in this order (highest wins):
 - Never rely on system-wide packages — the app MUST run with only
   its declared dependencies installed
 - Separate production dependencies from dev/test dependencies
+- When an updater splits interlocked packages (caret-ranged pairs like
+  `react`/`react-dom` or an ESLint plugin/parser) into separate PRs,
+  rebase the co-dependent PRs against current `main` before merging the
+  second — or group them in `.github/dependabot.yml` (`groups`) so they
+  ship as one PR. Each passes CI alone, yet a lone merge can leave the
+  lockfile with mismatched pins
 
 ## Port binding
 

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -88,6 +88,16 @@ quality scoring for web projects, docstring enforcement for Python).
   branches, identical expressions, and other code smells that standard
   ESLint rules miss; SHOULD be added to any TypeScript/JavaScript project
 
+### Lint-rule bumps: fix the source on its own PR first
+
+When a dependency bump adds a lint rule that flags existing source:
+
+- Write the fix in the older rule's API (usually forward-compatible)
+  on its own branch, and merge that fix-PR to `main` first
+- Then `@dependabot rebase` the bump PR so it lands clean on green
+- Do NOT push the fix onto Dependabot's branch — keep the bump as
+  Dependabot's own commit so it stays recreatable on future runs
+
 ---
 
 ## Thresholds

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -129,6 +129,17 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 - Group related dependencies to reduce PR noise
 - Combine with auto-merge for patch and minor updates: a GitHub
   Actions workflow that merges passing `dependabot/` branches
+- **Weekly-batch triage** — when a scheduled run opens several PRs at
+  once:
+  - Scan the queue without opening run pages:
+    `for pr in <ids>; do gh pr checks $pr; done`
+  - Expect a **lockfile-conflict cascade**: each squash-merge bumps the
+    lockfile and conflicts every open sibling PR. Merge in small
+    parallel batches (expect 1–2 race-losers), `@dependabot rebase` the
+    losers, repeat. Generic to any lockfile ecosystem (npm, pnpm,
+    cargo, poetry)
+  - Dependabot **auto-supersedes** — it closes a PR once its target is
+    reached transitively via sibling merges; do not manually reopen
 
 ---
 
@@ -166,6 +177,11 @@ paths. Without it, links like `/about` produce false errors:
   with:
     args: --offline --no-progress --root-dir dist dist/
 ```
+
+**Aggregator timing:** when branch protection requires an aggregator
+`gate` job that runs after its sub-checks, a merge issued in the gap
+returns `the base branch policy prohibits the merge`. Merge waiters
+MUST target the aggregator job by name, not the individual sub-checks.
 
 ---
 


### PR DESCRIPTION
Closes #509. Closes #438.

Operational patterns for running Dependabot under branch protection, surfaced from real downstream triage sessions.

## Changes

**`templates/platform/github.md` — Dependency management**
- Weekly-batch triage: scan the queue with `for pr in <ids>; do gh pr checks $pr; done`; handle the **lockfile-conflict cascade** (each squash-merge conflicts open siblings → merge in small batches, `@dependabot rebase` losers); note **auto-supersede** (don't manually reopen).

**`templates/platform/github.md` — Quality gate integration**
- Aggregator-timing footnote: a merge issued in the gap between sub-checks and the aggregator `gate` job returns `the base branch policy prohibits the merge`; waiters MUST target the aggregator by name.

**`templates/base/workflow/quality-gates.md` — Gate categories**
- Fix-PR-first pattern for lint-rule bumps: merge the source fix to `main` first, then `@dependabot rebase` the bump; never push the fix onto Dependabot's branch.

**`templates/base/core/config.md` — Dependencies** (#438)
- Rebase co-dependent (caret-ranged) PRs against `main` before the second merge, or group them in `.github/dependabot.yml`.

**`generated/`** — regenerated the chains embedding `base-config` / `base-quality-gates`.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync

Third and last of the three v2.13 PRs touching `platform/github.md` (after #499, #510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)