### PR TITLE
docs(infra): per-tag release record + durable SBOM asset (#528, #531)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2016,6 +2016,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2059,6 +2079,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2276,6 +2276,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2319,6 +2339,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2511,6 +2511,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2554,6 +2574,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2276,6 +2276,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2319,6 +2339,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2276,6 +2276,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2319,6 +2339,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2836,6 +2836,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2879,6 +2899,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2836,6 +2836,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2879,6 +2899,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2510,6 +2510,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2553,6 +2573,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -2119,6 +2119,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2162,6 +2182,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2532,6 +2532,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2575,6 +2595,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2511,6 +2511,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2554,6 +2574,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2572,6 +2572,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2615,6 +2635,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2276,6 +2276,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2319,6 +2339,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -2459,6 +2459,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2502,6 +2522,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -2329,6 +2329,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -2372,6 +2392,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1275,6 +1275,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code
@@ -1318,6 +1338,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection

--- a/templates/base/infra/cicd.md
+++ b/templates/base/infra/cicd.md
@@ -65,6 +65,26 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   new instance
 - Deploy small and often — large infrequent deployments increase risk
 
+## Release record
+
+On a release tag, the pipeline MUST create a durable release record
+(e.g. a GitHub Release), not only publish artifacts — this gives a
+per-version changelog page at near-zero cost. The release job:
+
+- runs only on tag pushes
+  (`if: startsWith(github.ref, 'refs/tags/v')`), so a manual run on a
+  branch is skipped
+- is **independent** of the publish/deploy jobs — the record captures
+  the source at the tag; an artifact hiccup MUST NOT erase it
+- is **idempotent** — skip if the record already exists, so a re-run
+  is safe
+- holds write permission (`contents: write`) at **job** scope only
+- uses the preinstalled CLI, no third-party action:
+  `gh release create "$TAG" --generate-notes`
+
+Backfill an existing repo by running `gh release create` over each
+historical tag with `--notes-start-tag`.
+
 ## Pipeline as code
 
 - Pipeline definitions MUST live in the repository alongside the application code

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -32,6 +32,14 @@ not after deployment.
 - All dependencies MUST be tracked for known vulnerabilities and license risks
 - SCA MUST run on every deployment to QA, staging, and production
 - A SBOM (Software Bill of Materials) MUST be generated per release
+- Attach the SBOM to the per-tag release record as a durable,
+  per-version asset — a CI build artifact expires with run retention.
+  Once the pipeline creates a release record on a tag, upload the SBOM
+  from the advisory scan job (`gh release upload "$TAG" <sbom>
+  --clobber`). Guard the upload (missing release or SBOM → exit 0) and
+  mark the job `continue-on-error` so a scan hiccup never blocks or
+  erases the release — the scan job reaches forward to the release,
+  never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
 ## Secret detection


### PR DESCRIPTION
Closes #528. Closes #531.

Make the per-tag GitHub Release the durable, backward-looking record (notes + SBOM), independent of the publish/deploy path so an artifact hiccup never erases it.

## Changes

**`templates/base/infra/cicd.md` — new "Release record" section** (#528)
- Tag-gated (`if: startsWith(github.ref, 'refs/tags/v')`), idempotent, **independent** of publish/deploy.
- Job-scope `contents: write`; preinstalled `gh` CLI (`gh release create "$TAG" --generate-notes`), no third-party action.
- Backfill guidance via `--notes-start-tag`.

**`templates/base/security/devsecops.md` — SCA** (#531)
- Attach the per-release SBOM to that record (`gh release upload "$TAG" <sbom> --clobber`) — a CI build artifact expires with run retention.
- Upload is guarded (missing release or SBOM → exit 0) and `continue-on-error`: the scan job reaches **forward** to the release, never the reverse, so a scan hiccup can't block or erase it.

**`generated/`** — regenerated the chains embedding `base-cicd` / `base-devsecops`.

## Note
Precondition phrased self-contained ("once the pipeline creates a release record on a tag") rather than as an inline cross-ref to `cicd.md` — this layer expresses relationships through `[DEPENDS ON]` headers, not prose pointers.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync

Independent of the `github.md` PR chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)