### PR TITLE
docs(review): distinguish CI infra failure from diff failure (#497)

### DIFF
--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -47,6 +47,25 @@ Use `templates/base/core/quality.md` (and any language-specific quality template
       must not silently change edge-case behavior (null handling, sort
       direction, boundary values)
 
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
 ## SHOULD checklist
 
 - [ ] Non-trivial functions have a unit test for each relevant variant


### PR DESCRIPTION
Closes #497.

When a PR has a red CI check, an **infra failure** (the action could not run) is a signal about the workflow, not the diff. Treating it as a diff failure blocks ready work forever; silently retrying until green hides the infra gap. Both are worse than honest acknowledgment.

## Change

**`templates/base/core/review.md` — new "CI signals" section**
- MUST checklist item: separate infra failures (network, missing release, broken pinning, runner OOM) from diff failures (check ran, flagged the diff).
- Practical guidance: read the log before calling green/red; file a separate task for infra failures; never retry-until-green or `--no-verify`/admin-merge around them without explicit maintainer sign-off.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync (`base-review` is reference-only — like `base-ai-workflow`, no stack chain embeds it, so no `generated/` change).

Independent PR — final issue in the v2.13 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)