### PR TITLE
docs(workflow): verify before relying (#485, #484, #486, #526, #494)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1781,6 +1786,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2366,6 +2371,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2907,6 +2912,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2907,6 +2912,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2907,6 +2912,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1557,6 +1562,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1557,6 +1562,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1557,6 +1562,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1557,6 +1562,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2278,6 +2283,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1557,6 +1562,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -2907,6 +2912,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 
@@ -1781,6 +1786,25 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
 
 ---
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -259,6 +259,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -253,6 +253,11 @@ maintainer time on phantom fixes.
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code
+- A comment that explains *why* something is safe ("X holds because Y") is a
+  load-bearing claim, not documentation — re-verify it against current data the
+  next time the code is read, never rely on it as-is. Reasoning comments rot
+  faster than the code they annotate: the code stays correct while the predicate
+  the comment cites silently goes false
 
 ## Debug code
 

--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -324,6 +324,14 @@ AI agents can do mental math — and get it wrong. When the agent computes a sco
 
 The build is the source of truth. `npm run build` then check the output. Don't trust "I calculated 7.9" — check what the page actually renders.
 
+### Verify before relying on a claim
+
+A claim about current state — a count in a memory note, a changelog's list of breaking changes, the assumption that one fix refreshed every view — is accurate when written and decays after. Before you scope work or declare a fix shipped on the strength of such a claim, re-measure the thing itself. The check is usually one command, and it replaces a guess with proof.
+
+- **Counts in handoff notes decay fast.** A memory note, prior PR body, or journal "follow-ups" line that quantifies backlog ("33 stale logs", "5 open Dependabot PRs") was true at write time; sweep tasks then complete silently as side effects of other work. Re-run the underlying check (`--check`, `gh pr list`, `git log --since=`) before estimating effort, and note any large drift in the session entry — it is signal about which sweeps are finishing on their own. Treat the count as a question, not an answer.
+- **A dependency bump is verified by the gate, not the changelog.** Scanning a major bump's changelog sizes the question; running the project's lint/test/build against the new version answers it. If the local gate passes, the bump is safe regardless of changelog content; if it fails, the changelog names which breaking change fired. Patch and minor bumps may skip the run when the changelog shows no breaking changes.
+- **When the truth source changes, audit every downstream render.** When one source of truth feeds multiple rendered artifacts (design tokens → CSS + Storybook + docs; OpenAPI → SDKs + mocks + docs), updating the source does not refresh the renders. Before declaring the fix shipped, list every artifact derived from the changed truth and verify each — build-time caches, hand-tweaked files, and provenance artifacts that intentionally show the pre-fix state each behave differently; call out which.
+
 ### Probe before acting on a hypothesis
 
 A bug ticket, a spike, or a prior-session note often arrives with a hypothesized mechanism, a proposed fix, or an inherited diagnosis. Treat it as a claim to disprove, not a foundation to build on. Before acting, run the cheapest probe — a throwaway script, a data dump, a single query — that would confirm or refute it. One run answers two questions: is the hypothesis correct, and where is the real signal? The frequent outcome is that the probe inverts the framing and the real cause sits in a different region than the text predicted.

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -225,6 +225,25 @@ below close those gaps.
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
 
+### Green CI does not prove environment independence
+
+CI runs on a clean checkout in one controlled environment. A passing
+gate is NOT "no bugs" when the check's input or behavior depends on the
+developer environment:
+
+- The test reads the working-tree filesystem (`readdirSync`, `glob`)
+  rather than tracked files (`git ls-tree`, explicit imports), so local
+  scratch or gitignored artifacts change its input — CI never sees them
+- The test depends on line endings, locale, timezone, filesystem case
+  sensitivity, or available binaries
+- The CI matrix omits the OS or runtime contributors use locally
+
+For such tests: prefer tracked-files enumeration over filesystem walks;
+gate a directory on an explicit anchor file so local-only artifacts are
+filtered out; document the dependency in a comment at the test; and run
+the gate locally on the dev OS at least once per session — local-first
+catches what a clean-room CI cannot.
+
 ---
 
 ## Generated-file staleness gate


### PR DESCRIPTION
Closes #485. Closes #484. Closes #486. Closes #526. Closes #494.

PR 1 of v2.14. Consolidates the "verify a claim against reality before relying on it" lesson family into its natural homes (not one forced location) — extends v2.12's *Probe before acting* / *Verify external state* family.

## Changes

**`templates/base/workflow/ai-workflow.md` — Lessons Learned** — new "Verify before relying on a claim" subsection:
- Handoff-note counts ("33 stale logs") decay fast → re-measure before scoping (#485)
- A dependency bump is verified by running the gate, not reading the changelog (#484)
- When a truth source changes, audit every downstream render (#494)

**`templates/base/core/quality.md` — Code style** (#526)
- A "safe because Y" comment is a load-bearing claim to re-verify when read, not documentation — reasoning comments rot faster than the code.

**`templates/base/workflow/quality-gates.md` — Gate scope agreement** (#486)
- New "Green CI does not prove environment independence" subsection — filesystem-walking / env-dependent tests pass on a clean-room runner; run gates on the dev OS.

**`generated/`** — regenerated chains embedding `base-quality` / `base-quality-gates` (`ai-workflow.md` is reference-only → no chain change).

## Placement note
Each issue went to its semantically-correct file rather than all into `ai-workflow.md`: #526 is about reading code comments (quality.md), #486 is about gate scope (quality-gates.md). One concern (verify-before-relying), multi-part across files per ADR-014.

## Validation
- `py tests/run_smoke.py` — 18/18 pass
- `py tools/sync.py --check` — all files in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)