### PR TITLE
docs(workflow): plan & scope discipline (#501, #527, #516, #430)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2434,6 +2434,27 @@ always loaded into context automatically.
 - Build after every change — do not accumulate multiple changes without
   verifying the build still passes
 
+## Reconcile candidates against scope before planning
+
+A suggestion for what to do next — an audit's feature recommendation, a
+session-handoff or memory breadcrumb, a "showcase value" idea — is a
+candidate, not a decision. Reconcile it against the authoritative record
+before it becomes planned work:
+
+- An audit or feature recommendation MUST be checked against the
+  documented scope (the in/out-of-scope list — e.g. arc42 §3.3 — and the
+  requirements). A candidate that falls in "Out of scope" is dropped, or
+  promoted by a deliberate scope-changing ADR — never slipped in because
+  it sounds valuable. "Best practice" does not override a written
+  boundary; a planned item not traceable to an in-scope requirement or a
+  scope-changing ADR is scope creep.
+- A handoff breadcrumb names continuity, not priority. A
+  "next: continue on X" pointer marks the cheapest resumption of the last
+  thread, not the highest-priority move. Before acting, re-check X's
+  milestone and priority against the project's current milestone — if
+  they differ, ask first. The wrap-up writer SHOULD record each pointer's
+  milestone and priority inline so the next session sees the mismatch.
+
 ## Default scope boundaries
 
 - One logical unit of work per session (one feature, one chapter, one

--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -232,6 +232,28 @@ convention.
 If the prior format is genuinely problematic and worth changing,
 raise it explicitly — never silently deviate.
 
+### Read in-source audit comments at the edit site
+[ID: ai-workflow-read-edit-site]
+
+Before the first change to a file, read the code around the target
+lines and scan for in-source comments that record prior audits,
+experiments, or rejected approaches. Audited code carries comments
+stating WHAT WAS TESTED and WHAT THE OUTCOME WAS — written precisely
+so the next reader does not re-attempt a known-bad fix. Look for:
+
+- comments dated by session or PR (e.g. "Per-hue audit (S155): ...")
+- lists of tested-and-rejected approaches, or "known limitation"
+  callouts
+- a named regression metric (e.g. "p95 0.024 -> 0.146")
+
+When such a comment bears on the proposed change, the agent MUST
+either state its finding and ask whether the change overrides it, or
+re-scope from the finding. Reading the comment costs seconds; skipping
+it costs multi-session work on an approach the file already records as
+broken. This is distinct from matching document convention (that rule
+is about form; this is about substance) — a file can match convention
+perfectly and still carry a load-bearing audit comment.
+
 ### Verify working directory before concluding on a negative
 [ID: ai-workflow-pwd-on-negative]
 
@@ -370,6 +392,10 @@ A productive session can cover a lot of ground. But jumping between unrelated to
 - Context switching that reduces quality
 
 **Recommendation:** Commit to a theme per session. When an unrelated topic surfaces, create an issue and return to it in the next session. If you do switch topics mid-session, commit and push the current work first.
+
+### Constraints can invalidate a plan mid-execution
+
+When an architectural constraint surfaces mid-execution that makes the agreed plan unreachable as stated, pause, name the constraint, and re-surface the option set — each option with its blast radius — for the user to re-decide. Do NOT scope-creep the fix to absorb the constraint silently: rewriting a fixed parameter, re-deriving anchor data, or otherwise expanding the blast radius ships a half-done architectural change. Re-surfacing is cheap; recovering from a half-done architectural change is not. When the constraint hits, the move is always stop and re-decide, not plough on.
 
 ### Data quality is the real bottleneck
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -65,6 +65,27 @@ always loaded into context automatically.
 - Build after every change — do not accumulate multiple changes without
   verifying the build still passes
 
+## Reconcile candidates against scope before planning
+
+A suggestion for what to do next — an audit's feature recommendation, a
+session-handoff or memory breadcrumb, a "showcase value" idea — is a
+candidate, not a decision. Reconcile it against the authoritative record
+before it becomes planned work:
+
+- An audit or feature recommendation MUST be checked against the
+  documented scope (the in/out-of-scope list — e.g. arc42 §3.3 — and the
+  requirements). A candidate that falls in "Out of scope" is dropped, or
+  promoted by a deliberate scope-changing ADR — never slipped in because
+  it sounds valuable. "Best practice" does not override a written
+  boundary; a planned item not traceable to an in-scope requirement or a
+  scope-changing ADR is scope creep.
+- A handoff breadcrumb names continuity, not priority. A
+  "next: continue on X" pointer marks the cheapest resumption of the last
+  thread, not the highest-priority move. Before acting, re-check X's
+  milestone and priority against the project's current milestone — if
+  they differ, ask first. The wrap-up writer SHOULD record each pointer's
+  milestone and priority inline so the next session sees the mismatch.
+
 ## Default scope boundaries
 
 - One logical unit of work per session (one feature, one chapter, one


### PR DESCRIPTION
Closes #501. Closes #527. Closes #516. Closes #430.

PR 2 of v2.14. Four related rules — respect a higher-priority signal (an edit-site audit comment, a surfaced constraint, the documented scope, the current milestone) before ploughing ahead on an agreed direction. Routed to correct homes rather than all into one section.

## Changes

**`templates/base/workflow/ai-workflow.md` — Practices** (#501, P2)
- New "Read in-source audit comments at the edit site" `[ID: ai-workflow-read-edit-site]`: before the first edit, scan for prior-audit / rejected-approach / known-limitation comments; state the finding and ask, or re-scope from it — don't re-attempt a fix the file already records as broken. (Distinct from match-convention: substance vs form.)

**`templates/base/workflow/ai-workflow.md` — Lessons Learned** (#527)
- "Constraints can invalidate a plan mid-execution": when a constraint makes the agreed plan unreachable, pause, name it, re-surface the option set with blast radii — never scope-creep the fix to absorb it silently.

**`templates/base/workflow/scope.md`** (#516 + #430, consolidated)
- New "Reconcile candidates against scope before planning": an audit/feature recommendation is a candidate, not a decision — check against the documented in/out-of-scope list (arc42 §3.3) before planning (#516); a handoff breadcrumb names continuity, not priority — re-check the pointed-at issue's milestone before acting (#430).

**`generated/`** — regenerated chains embedding `base-scope` (`ai-workflow.md` is reference-only → no chain change).

## Validation
- `py tests/run_smoke.py` — 18/18 pass (new `[ID]` validated by TPL-08)
- `py tools/sync.py --check` — all files in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)