### PR TITLE
docs(quality): gate & test honesty (#460, #480, #525, #502)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1736,6 +1760,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2321,6 +2345,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2862,6 +2886,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2862,6 +2886,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2862,6 +2886,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1512,6 +1536,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1512,6 +1536,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1512,6 +1536,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1512,6 +1536,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2233,6 +2257,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1512,6 +1536,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -2862,6 +2886,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 
@@ -1736,6 +1760,42 @@ Document the skip rule in an ADR alongside the workflow change —
 the reasoning ("this gate cannot produce signal on these PRs")
 should be discoverable later when someone wonders why the gate
 sometimes doesn't run.
+
+---
+
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
 
 ---
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1194,6 +1194,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -74,6 +74,11 @@ Practical guidance:
 - [ ] Third-party dependencies are necessary, understood, and well-maintained
 - [ ] Code is simple — no new abstraction without two or more call sites,
       no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
 
 ## Structure audit
 

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -212,6 +212,30 @@ fixing the design fixes the testability.
 
 ---
 
+## Tests should name what they pin
+[ID: testing-name-what-pinned]
+
+A test that asserts a numeric threshold (precision ≥ 0.85, latency
+< 100ms, IoU ≥ 0.20) MUST document what about the system the threshold
+pins — otherwise an intended improvement that legitimately moves the
+number produces a failure indistinguishable from a real regression, and
+nobody can tell whether to lower the bar, update the test, or revert.
+
+State, in the docstring or assertion message:
+
+- the relationship under test (the property the threshold gates)
+- the conditions it was calibrated under (pipeline state, reference data)
+- the expected response if a future improvement legitimately moves it
+
+Flag in review a single-number assertion whose failure message names
+only the observed value ("Expected ≥ 0.85, got 0.81") — make it
+actionable ("Expected ≥ 0.85 polyline-on-skeleton precision, a
+self-consistency check calibrated post-#953; got 0.81 — verify the
+skeleton is still the dense per-curve trace the threshold assumed").
+This applies to threshold-asserting tests specifically, not every test.
+
+---
+
 ## Data validation tests
 [ID: base-testing-data-validation]
 

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -177,6 +177,42 @@ sometimes doesn't run.
 
 ---
 
+## Reading a gate verdict honestly
+
+[ID: quality-gates-verdict-reading]
+
+A gate verdict is a signal to interpret, not a conclusion to act on
+blindly. Two failure modes sit on either side of the pass/fail line.
+
+### Disaggregate verdict, plausibility, and accuracy
+
+When a gate fires, its single verdict often conflates three judgments:
+
+- **Verdict** — what the gate says (pass / fail / LOW)
+- **Plausibility** — is the output *shape* consistent with priors,
+  sanity checks, and schema invariants?
+- **Accuracy** — does the output match ground truth where it exists?
+
+A "LOW" can mean the output is inaccurate, the plausibility check is
+unsound for this input class, or both — and each implies a different
+fix (fix the producer / tune the check per-class / both). Separate them
+before acting. Worked example: a digitization gate fired
+`prior_failed` on a chart whose output was within ±0.05 of ground
+truth on 41 of 43 points — the ground truth itself violated the prior,
+so the fix was a per-family prior whitelist, not a producer change. The
+verdict alone pointed the wrong way.
+
+### Lenient gates need a human residual check
+
+The complement to a noisy gate is a lenient one: it passes, but a human
+glance catches a defect the gate cannot. A single-sample dip in a curve
+can pass a tolerance averaged across samples. Tightening the threshold
+to catch it would mis-flag legitimate runs; instead keep the gate AND
+document that the artifact type requires a maintainer-eye review before
+commit. A passing gate is necessary, not sufficient.
+
+---
+
 ## Gate scope agreement
 
 [ID: quality-gates-scope-agreement]


### PR DESCRIPTION
Closes #460. Closes #480. Closes #525. Closes #502.

PR 3 of v2.14 (final). One theme — a gate/test signal is **necessary but not sufficient**; interpret it rather than acting on it blindly.

## Changes

**`templates/base/workflow/quality-gates.md`** — new "Reading a gate verdict honestly" `[ID: quality-gates-verdict-reading]`:
- Disaggregate **verdict / plausibility / accuracy** when a gate fires — each implies a different fix; worked example where the ground truth, not the output, violated the prior (#460).
- Lenient gates need a **human residual check** — keep the gate and add maintainer-eye review rather than over-tightening and mis-flagging legit runs (#480).

**`templates/base/core/review.md` — SHOULD checklist** (#525)
- Numerical comparison gates lock sampled magnitudes, not contour shape — pair with manual visual review on render-producing pipelines.

**`templates/base/core/testing.md`** — new "Tests should name what they pin" `[ID: testing-name-what-pinned]` (#502)
- A threshold-asserting test MUST document the property it pins, its calibration conditions, and the expected response if an improvement legitimately moves the number — so an intended fix isn't indistinguishable from a regression.

**`generated/`** — regenerated chains embedding the changed core templates.

## Validation
- `py tests/run_smoke.py` — 18/18 pass (both new `[ID]`s validated)
- `py tools/sync.py --check` — all files in sync

Final PR of the v2.14 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)