### PR TITLE
docs(workflow): require labels at ticket creation (#566)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,9 @@ py tools/resolve.py --generate               # regenerate all cached files
 
 ### 2.2 Issue labels
 
-Every issue MUST have exactly one type label and one priority label.
-Triage labels are terminal — applied when closing without action.
+Every issue MUST have exactly one type label and one priority label,
+applied at creation — never create a ticket unlabeled. Triage labels
+are terminal — applied when closing without action.
 
 #### Type labels (pick one)
 


### PR DESCRIPTION
## What

Tighten CLAUDE.md §2.2 so the type + priority label requirement is
applied **at creation** — never create a ticket unlabeled. The rule
existed as a property of issues; this makes it a creation-time action.

## Why

Closes #566. Fast-tracked via the Expedite lane. Separate concern from
spike #479 (kept untouched, per §2.1 one-concern-per-PR).

## Validation

- `py tests/run_smoke.py` → 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)