### PR TITLE
docs(backend): add load & backpressure rules to messaging.md (#568)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2200,6 +2200,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2435,6 +2435,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2200,6 +2200,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2200,6 +2200,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2815,6 +2815,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2815,6 +2815,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2435,6 +2435,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2200,6 +2200,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -2383,6 +2383,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf

--- a/templates/backend/messaging.md
+++ b/templates/backend/messaging.md
@@ -59,6 +59,27 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ---
 
+## Load and backpressure
+
+- Decouple receive from process under load: acknowledge or enqueue the
+  message fast, then do the work in a worker you pace — never run heavy
+  processing inline on the receive path
+- Coalesce bursts: debounce repeated events for the same resource into a
+  single unit of work after a short quiet period, instead of processing
+  every duplicate
+- Apply backpressure when the queue saturates: bound the queue and slow
+  or shed intake so the system degrades gracefully — an unbounded intake
+  amplifies a downstream slowdown into an outage
+- Enforce per-key or per-tenant fairness: cap in-flight work per source
+  so one noisy producer cannot starve the rest (head-of-line blocking)
+- Load-test the consumer at volume: watch queue depth and consumer lag,
+  not the receive endpoint's latency, to find the real saturation point
+- For bounded worker concurrency see `templates/backend/concurrency.md`;
+  idempotency, retry/backoff, and the DLQ are covered in Consumer rules
+  above
+
+---
+
 ## Schema and contracts
 
 - Define message schemas explicitly — JSON Schema, Avro, or Protobuf


### PR DESCRIPTION
## What

Adds a `Load and backpressure` section to the consumer side of
`templates/backend/messaging.md` — the genuinely net-new generic async
event-processing resilience rules:

- decouple receive from process under load (ack/enqueue fast, pace the worker)
- debounce/coalesce bursts
- backpressure / graceful degradation on queue saturation
- per-key/per-tenant fairness (head-of-line blocking)
- load-test the consumer at volume

No duplication of the existing idempotency / retry-backoff-jitter / DLQ
rules (already in Consumer rules + jobs.md); bounded concurrency points
to concurrency.md.

## Why

Closes #568. Implements the placement decision from spike #564 (generic
home = existing messaging.md, no new file/layer). Unblocks #565 (webhook
template composes these via `[DEPENDS ON]`).

## Validation

- `py tests/run_smoke.py` → 18/18 pass
- `py tools/sync.py` → regenerated 9 affected service-stack chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)