### PR TITLE
docs(http): harden response output — NaN serialisation + nosniff MIME (#521, #522)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1720,6 +1720,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1791,6 +1796,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1463,6 +1463,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1865,6 +1870,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1791,6 +1796,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1791,6 +1796,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -1368,6 +1368,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1857,6 +1857,11 @@ staticcheck ./...     # additional static analysis
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -2323,6 +2328,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1857,6 +1857,11 @@ staticcheck ./...     # additional static analysis
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -2323,6 +2328,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1857,6 +1857,11 @@ staticcheck ./...     # additional static analysis
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -2023,6 +2028,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1577,6 +1582,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1577,6 +1582,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1463,6 +1463,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1865,6 +1870,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1706,6 +1706,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —
@@ -2172,6 +2176,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1791,6 +1796,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -1420,6 +1420,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1490,6 +1490,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1411,6 +1411,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 
@@ -1813,6 +1818,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1490,6 +1490,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1706,6 +1706,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —
@@ -2165,6 +2169,11 @@ DEBUG=false
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1490,6 +1490,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/templates/backend/http.md
+++ b/templates/backend/http.md
@@ -49,6 +49,11 @@
   - Currency codes: ISO 4217
 - Any integer that exceeds 2^53 − 1 (9007199254740991) MUST be serialised
   as a string — JavaScript cannot represent larger integers precisely
+- Endpoints that serialise computed floats MUST reject non-finite values:
+  `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
+  fail loud (a 500 at the serialisation boundary) instead of emitting a
+  bare `NaN` token that strict parsers reject; represent an undefined
+  value as `null` and document the field as nullable in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/templates/base/security/security.md
+++ b/templates/base/security/security.md
@@ -129,6 +129,10 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
+- When enabling `nosniff`, pin static asset MIME types in code — the
+  OS registry resolves `.js` to `text/plain` on some platforms, so the
+  browser refuses to run the script and CI on Linux will not catch it;
+  verify script/style execution in a real browser, not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —


### PR DESCRIPTION
## What

Two small HTTP response-hardening rules, both grounded in
`braboj/randomgen` v0.20.0:

- **#521** `backend/http.md` (Resource representation): endpoints
  serialising computed floats MUST reject non-finite values — `NaN`/
  `Infinity` are invalid RFC 8259 JSON. Fail loud at the boundary;
  represent undefined as `null`; document the field nullable.
- **#522** `base/security/security.md` (Security headers): enabling
  `nosniff` requires pinning static asset MIME types in code (the OS
  registry resolves `.js` to `text/plain` on some platforms; CI on
  Linux misses it) and verifying execution in a real browser.

Placed in the existing semantically-correct sections (#522 in
security.md's Security headers, where `nosniff` already lives — not
devsecops.md).

## Why

Closes #521, closes #522.

## Validation

- `py tests/run_smoke.py` → 18/18 pass
- `py tools/sync.py` → regenerated affected chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)