### PR TITLE
docs(quality): import-cycle shared module + return-type shim rules (#446, #439)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -75,12 +75,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -69,12 +69,19 @@
 
 - No circular dependencies between modules or packages — dependency graphs
   must be acyclic; restructure or introduce an interface to break cycles
+- When an import cycle would block sharing logic between two modules, move
+  the shared logic to a third module — never code a divergent local copy
+  in one caller; a silent copy drifts from the canonical version (e.g.
+  skipping an upstream filter step) and breaks later, invisibly
 - Keep the dependency graph shallow — if changing module A requires reading
   modules B, C, and D to understand the impact, the coupling is too high
 - Changes to one module's internals must not require changes in unrelated
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When extending a function's return type (value → list, scalar → tuple),
+  keep a one-line shim under the old name returning the first/scalar
+  element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
 - No substantial duplication across sibling modules — if the same code


### PR DESCRIPTION
## What

Two Maintainability rules in `base/core/quality.md`:

- **#446** — when an import cycle would block sharing logic between two
  modules, move the shared logic to a third module; never code a
  divergent local copy in one caller (it drifts from canonical and
  breaks invisibly — e.g. skipping an upstream filter step). Placed as a
  corollary of the existing no-circular-dependencies rule.
- **#439** — when extending a function's return type (value→list,
  scalar→tuple), keep a one-line shim under the old name returning the
  first/scalar element so existing callers and tests survive; remove in
  a follow-up. Placed by the existing deprecation rule.

## Why

Closes #446, closes #439. Both surfaced in me-fuji sessions.

## Validation

- `py tests/run_smoke.py` → 18/18 pass
- `py tools/sync.py` → regenerated all core-tier chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)