### PR TITLE
docs(backend): add pipeline diagnosability (DiagnosticSink) to observability.md (#447)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1525,6 +1525,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1601,6 +1601,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1745,6 +1745,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1601,6 +1601,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1601,6 +1601,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2047,6 +2047,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/backend/errors.md -->
 # Backend — Error Handling
 [ID: backend-errors]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2047,6 +2047,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/backend/errors.md -->
 # Backend — Error Handling
 [ID: backend-errors]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2337,6 +2337,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/backend/grpc.md -->
 # Backend — gRPC
 [ID: backend-grpc]

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1891,6 +1891,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/backend/grpc.md -->
 # Backend — gRPC
 [ID: backend-grpc]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1891,6 +1891,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/backend/grpc.md -->
 # Backend — gRPC
 [ID: backend-grpc]

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1745,6 +1745,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2549,6 +2549,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/infra/cicd.md -->
 # Base — CI/CD and Delivery
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1601,6 +1601,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1693,6 +1693,27 @@ Use the correct level — do not elevate debug information to INFO:
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
 
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 

--- a/templates/backend/observability.md
+++ b/templates/backend/observability.md
@@ -71,3 +71,24 @@ Use the correct level — do not elevate debug information to INFO:
 - Distinguish between client errors (4xx) and server errors (5xx) in logs
 - Include correlation/request IDs in error responses to enable log tracing
 - Never expose internal state, stack traces, or file paths in error responses
+
+## Pipeline diagnosability
+
+Multi-stage pipelines (ETL, data/image extraction, compiler passes, build
+tools) hide their failures: when a stage produces wrong output, the only
+visible artifacts are the input and the final result, so every "this
+looks wrong" becomes a probe session reconstructing intermediate state.
+
+- Accept an optional diagnostic sink (a `DiagnosticSink` Protocol or
+  interface) as a pipeline parameter; each stage calls
+  `sink.record_<stage>(artifact)` only when a sink is supplied
+- Provide a `FileDiagnosticSink` that writes one named artifact per stage
+  (image, mask, table, AST, JSON) to a known directory for inspection
+- Contract: pipeline output MUST be byte-identical with or without a sink
+  — the diagnostic concern lives outside the core path, never alters it
+- Diagnostic artifacts are gitignored — on-demand debugging output, not
+  committed state
+- Reach for this when stages have named, inspectable intermediate
+  artifacts, failure reports describe symptoms rather than stages, and a
+  change can break one stage silently while the final output still looks
+  plausible


### PR DESCRIPTION
## What

New `Pipeline diagnosability` section in `backend/observability.md`: an
opt-in **DiagnosticSink Protocol** for multi-stage pipelines (ETL,
data/image extraction, compiler passes, build tools).

- pipeline accepts an optional sink; each stage calls
  `sink.record_<stage>(artifact)` only when one is supplied
- a `FileDiagnosticSink` writes one named artifact per stage to a known dir
- **contract:** output byte-identical with or without a sink
- artifacts gitignored (on-demand debugging, not committed state)
- when-to-reach-for-it rule (named intermediate artifacts; symptom-not-stage
  failure reports; silent stage breakage)

## Why

Closes #447. **Placement note:** moved off the originally-planned
quality-gates.md — that file is about *gates* (verification), whereas a
DiagnosticSink *instruments for debugging*. observability.md is the
semantically-correct home and scopes it to backend stacks where
multi-stage pipelines exist. Grounded in me-fuji ADR-050.

## Validation

- `py tests/run_smoke.py` → 18/18 pass
- `py tools/sync.py` → regenerated affected backend chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)