### PR TITLE
feat(backend): add inbound webhook handling template (#565)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -105,6 +105,7 @@ backend/
 ├── jobs.md         # Background jobs, idempotency, retry, DLQ, scheduling
 ├── concurrency.md  # Threads vs. processes vs. async, shared state, structured concurrency
 ├── messaging.md    # Brokers, producers, consumers, schema, DLQ, observability
+├── webhooks.md     # Inbound webhook intake, edge signature verification, fast-ack, retry amplification
 ├── grpc.md         # Proto design, status codes, interceptors, health check
 ├── microservices.md # Service boundaries, inter-service comms, saga, contract testing
 ├── errors.md       # Classification, propagation, recovery, external failures

--- a/templates/backend/webhooks.md
+++ b/templates/backend/webhooks.md
@@ -1,0 +1,54 @@
+# Backend — Inbound Webhook Handling
+[ID: backend-webhooks]
+[DEPENDS ON: templates/backend/http.md, templates/backend/messaging.md, templates/base/security/security.md, templates/backend/observability.md]
+
+Rules for receiving inbound webhooks (provider callbacks, integration
+events) under bursty load. Compose this template on demand for a service
+that receives webhooks — it is not part of any stack chain by default.
+
+The generic resilience substrate — idempotency, retry/backoff, DLQ,
+debounce/coalesce, backpressure, fairness — is inherited from
+messaging.md; this template adds only the HTTP-ingestion-specific surface.
+
+---
+
+## Intake
+
+- Expose a distinct intake URL per provider or connection — never
+  multiplex unrelated providers onto one endpoint; per-integration URLs
+  isolate failures, scope signature handling, and sharpen observability
+
+## Verify at the edge
+
+- Verify the provider signature before doing any work — reject forged or
+  malformed payloads before parsing, persisting, or enqueueing
+- Verify against the exact bytes received, not a re-serialised copy, and
+  treat the raw body as untrusted until the signature checks out
+
+## Respond fast
+
+- Return 2xx within the provider's timeout budget: acknowledge receipt,
+  then process asynchronously — never run heavy work inline on the
+  request path
+- Persist or enqueue the event before responding so an acknowledged
+  event is never lost
+
+## Survive provider retries
+
+- Account for retry amplification — a non-2xx response makes the provider
+  resend, so a slow or failing handler multiplies inbound load
+- Return 2xx even when intentionally skipping an event (duplicate,
+  irrelevant); reserve 5xx strictly for failures where redelivery is wanted
+- Deduplicate on the provider's event ID — at-least-once delivery means
+  the same event will arrive more than once
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- Test signature rejection: a tampered body or invalid signature MUST be
+  rejected before any side effect occurs
+- Test idempotency: deliver the same event twice and assert a single effect
+- Test the fast-ack path: the handler returns 2xx without waiting for
+  downstream processing to complete

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -159,6 +159,10 @@ backend:
   - id: backend-messaging
     file: templates/backend/messaging.md
     description: Brokers, producers, consumers, schema, DLQ, observability
+  - id: backend-webhooks
+    file: templates/backend/webhooks.md
+    description: Inbound webhook intake, edge signature verification, fast-ack, retry amplification
+    depends_on: [backend-http, backend-messaging, base-security, backend-observability]
   - id: backend-grpc
     file: templates/backend/grpc.md
     description: Proto design, status codes, interceptors, health check


### PR DESCRIPTION
## What

New `templates/backend/webhooks.md` — an on-demand, composable template
for services that receive inbound webhooks.

- **Composes** the generic resilience substrate (idempotency,
  retry/backoff, DLQ, debounce/coalesce, backpressure, fairness) from
  `messaging.md` via `[DEPENDS ON]` — no duplication.
- **Adds only the webhook-specific surface:** per-integration intake URL,
  edge signature verification before any work, fast 2xx ack + async
  processing, retry-amplification handling (2xx-on-skip / 5xx only when
  redelivery wanted), event-ID dedup. Plus an `[EXTEND: base-testing]`
  block.

## Wiring decision

**Register-only — not wired into any stack chain by default**
(composition over inheritance, ADR-004). A project composes it when it
actually receives webhooks. Confirmed: **0 generated chains change**;
only the manifest entry + SPEC directory listing are added.

## Why

Closes #565. Completes the v2.15 resilience arc (#564 decision → #568
generic rules → this composing template).

## Validation

- `py tests/run_smoke.py` → 18/18 pass (validates the new manifest entry,
  `depends_on`, and `[EXTEND]` reachability)
- `py tools/sync.py` → SPEC listing updated; no chain regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)