### PR TITLE
chore(repo): gitignore .claude/ (local harness state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.claude/
 tests/reports/
 temp/
 __pycache__/


### PR DESCRIPTION
## What

Add `.claude/` to `.gitignore`. It holds machine-local Claude Code
state — `scheduled_tasks.lock` (the lock file) and
`settings.local.json` — which must never be committed.

## Why

Part of repo hygiene cleanup. Also removed (local, untracked — not in
this diff): `docs/drafts/` (obsolete v2.6 README draft) and
`docs/spikes/` (findings for open spikes #350/#479 archived to those
issues first).

## Validation

- `git status` clean — no untracked entries remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)