### PR TITLE
docs(quality-gates): pair checkable output constraints with their check (#479)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,9 @@ base/ ──┬── frontend/ ──┐
 - Optional sections are marked `(if applicable)` in the heading
 - Keep line length under 80 characters
 - No HTML — Markdown only
+- A mechanically-checkable output constraint MUST name its
+  agent-runnable check (command + pass condition); subjective
+  constraints stay declarative (see `quality-gates-pair-check`)
 
 ### 2.8 manifest.yaml
 

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1896,6 +1896,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2506,6 +2506,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3073,6 +3073,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3073,6 +3073,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3073,6 +3073,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1672,6 +1672,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1672,6 +1672,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1672,6 +1672,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1672,6 +1672,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2423,6 +2423,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1672,6 +1672,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3073,6 +3073,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1896,6 +1896,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -303,6 +303,39 @@ paths.
 
 ---
 
+## Pair a checkable constraint with its check
+
+[ID: quality-gates-pair-check]
+
+`quality-gates-staleness` is one case of a general rule: a stated
+constraint without its check is decorative. It looks enforced and
+decays silently, because a violating artifact looks identical to a
+clean one. A constraint that travels into a generated project (a
+template output constraint inherited by a generated `CLAUDE.md`) carries
+this risk furthest — the project inherits the rule with no protocol to
+self-check it.
+
+- An output constraint that is mechanically checkable MUST name its
+  agent-runnable check — the command to run and the pass condition.
+  Examples: "line length < 80" -> `awk 'length > 80' FILE`, output MUST
+  be empty; "no raw HTML" -> `grep -nE '<[a-z]+>' FILE`, output MUST be
+  empty
+- State the check next to the rule it verifies — not in a separate
+  tooling file the generated project never receives. The rule and its
+  check MUST travel together, so every artifact generated from the
+  template inherits both
+- A constraint that is inherently subjective (imperative tone, "no
+  explanatory prose", heading-case judgment) stays declarative and
+  relies on review. Do NOT invent a brittle check to satisfy this rule
+  (see `quality-gates-exclusions`)
+- When the constraint guards a committed generated artifact, wire its
+  check into CI as a required status check (see
+  `quality-gates-staleness`)
+
+A rule states intent; its paired check is what makes the intent hold.
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]


### PR DESCRIPTION
Closes #479.

Resolves the #479 spike. **Decision: option (a), scoped.**

## Decision

A template output constraint that is **mechanically checkable** MUST
ship paired with its agent-runnable check (command + pass condition).
A constraint that is **inherently subjective** (imperative tone, "no
explanatory prose") stays declarative and relies on review.

This generalizes `quality-gates-staleness` ("a banner without its gate
is decorative") from generated-file staleness to all output
constraints, and respects `quality-gates-exclusions` ("what NOT to
gate") by not forcing brittle checks onto subjective rules.

- Pure (b) rejected — it is why the §2.7 constraints (line < 80, no
  HTML) are unenforced today; the smoke suite proves the value, as
  every *structural* rule already pairs with a check.
- Blanket-MUST (a) rejected — contradicts the exclusions list.

## Changes

- `templates/base/workflow/quality-gates.md` — new section
  `[ID: quality-gates-pair-check]` (chain reach → propagates to
  generated projects).
- `CLAUDE.md` §2.7 — one-line authoring rule.

No ADR — extends an existing rule rather than introducing a new
structural concept (matching the #564 precedent). Implementation of the
actual smoke checks follows in #560 / #561; the generation-fidelity
application follows in #498.

Smoke: 18/18 green. New content dogfoods the line-length rule (<80).
Full decision record: #479 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)