### PR TITLE
docs(generated-files): bulk-emit scripts must expose --check (#560)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -861,6 +861,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -367,6 +367,16 @@ it as stale.
   — the banner's "do not edit" header is a contract, and the next
   `--check` run flags a hand-edited file as stale against freshly
   generated content
+- The `--check` rule applies whether the script renders one file or
+  rewrites many entries inside one source-of-truth file. A bulk-emit
+  script that mutates multiple slugs / entries / records in a single
+  file MUST support `--check` and be wired into CI as a required gate
+  — otherwise extractor drift accumulates silently and surfaces as a
+  multi-hundred-line diff during an unrelated, narrow PR
+- A bulk-emit `--check` failure MUST report the count of stale entries,
+  not just the file path. "19 of 19 entries stale" tells the maintainer
+  the extractor itself drifted; a bare filename reads like a one-line
+  edit and hides the scale
 
 ## Output file by agent
 


### PR DESCRIPTION
Closes #560.

Generalizes the per-file `--check` rule in `base-docs` to bulk-emit
scripts — those that rewrite many entries inside one source-of-truth
file (e.g. an extractor regenerating ~19 records into one `.ts` file).

## Changes

`templates/base/core/docs.md` "Generated files" — two bullets:
- A bulk-emit script that mutates multiple entries in a single file
  MUST support `--check` and a CI gate, or extractor drift accumulates
  silently and surfaces as a multi-hundred-line diff during an
  unrelated PR.
- The `--check` failure MUST report the **count** of stale entries, not
  just the path — the pass-condition detail that makes the gate
  actionable.

This applies `quality-gates-pair-check` (#479): name the check *and* its
pass condition. Self-contained in `base-docs` — no forward cross-file
reference (quality-gates depends on docs, not the reverse).

Regenerated 30 chains (base-docs is core tier). Smoke 18/18, sync clean,
new lines dogfood the <80 rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)