### PR TITLE
docs(quality-gates): add convention-as-test pattern (#561)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1939,6 +1939,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2549,6 +2549,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3116,6 +3116,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3116,6 +3116,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3116,6 +3116,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1715,6 +1715,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1715,6 +1715,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1715,6 +1715,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1715,6 +1715,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2466,6 +2466,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1715,6 +1715,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3116,6 +3116,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1939,6 +1939,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -336,6 +336,29 @@ A rule states intent; its paired check is what makes the intent hold.
 
 ---
 
+## Convention-as-test
+
+[ID: quality-gates-convention-as-test]
+
+A specific shape of `quality-gates-pair-check`: when a convention takes
+the form "every record satisfying property X MUST share derived
+artifact Y", its check is a test that enumerates the X-satisfying
+records and asserts Y-equality across them.
+
+- A written-down "if X then Y" invariant MUST be encoded as a test when
+  Y is mechanically comparable. The test enumerates every record
+  satisfying X and asserts they share Y. Examples: entries sharing a
+  canonical product URL MUST share their generated chart file; build
+  outputs in one locale MUST share a glossary file
+- The test gates the invariant at commit time. A prose convention is
+  forgotten and the next divergent record lands undetected; the test
+  fails loud, naming the pair that broke it
+- This applies only to mechanically checkable invariants. Conventions
+  that genuinely cannot be tested (subjective code style, prose tone)
+  stay declarative (see `quality-gates-exclusions`)
+
+---
+
 ## What NOT to gate
 
 [ID: quality-gates-exclusions]


### PR DESCRIPTION
Closes #561.

A specific shape of `quality-gates-pair-check` (#479): when a convention
takes the form "every record satisfying property X MUST share derived
artifact Y", its check is a **test** that enumerates the X-satisfying
records and asserts Y-equality.

## Changes

`templates/base/workflow/quality-gates.md` — new section
`[ID: quality-gates-convention-as-test]`, placed right after
`quality-gates-pair-check` (its governing rule, same file → inline
reference is valid):
- A written "if X then Y" invariant MUST be encoded as a test when Y is
  mechanically comparable.
- The test gates the invariant at commit time and names the pair that
  broke it; a prose convention is forgotten and the next divergent
  record lands undetected.
- Applies only to mechanically checkable invariants — subjective ones
  stay declarative (`quality-gates-exclusions`).

Worked example behind the rule: me-fuji #1265/#1294 (entries sharing a
canonical URL must share their generated chart).

Regenerated 13 chains. Smoke 18/18, sync clean, new lines <80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)