### PR TITLE
feat(generation): gate end-of-session audit fidelity (#498)

### DIFF
--- a/examples/hybrid-astro/CLAUDE.md
+++ b/examples/hybrid-astro/CLAUDE.md
@@ -142,4 +142,18 @@ Verify MUSTs from `base/docs.md`, `base/readme.md`, `base/git.md`,
 
 ## 6. Session protocol
 
-Follow `base/scope.md` for scope guard and end-of-session audit.
+Follow `base/scope.md` for the scope guard and end-of-session audit.
+
+### 6.1 Start of session
+
+Read `base/scope.md` (Session startup) and the mandatory startup block.
+
+### 6.2 During the session
+
+Follow `base/scope.md` (During work) — stay within the agreed scope.
+
+### 6.3 End of session
+
+On "wrap up" / "close out", read `base/scope.md` (End of session audit)
+and execute each item sequentially; do not summarize or skip. Print the
+checklist and mark each item done before moving to the next.

--- a/templates/INTERVIEW.md
+++ b/templates/INTERVIEW.md
@@ -116,6 +116,9 @@ templates for the rest. Follow the hybrid model structure in
    safety rules, and content rules
 4. References quality framework, review process, testing, a11y,
    SEO, and CI/CD from the templates
+5. Renders §6.3 (end-of-session audit) by inlining `scope.md`'s
+   checklist verbatim or hard-delegating ("execute each item; do not
+   summarize") — never paraphrased into bullets (see `agents.md` §6.3)
 
 End the file with: `<!-- Generated with solid-ai-templates (github.com/braboj/solid-ai-templates) -->`
 

--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -103,7 +103,12 @@ Follow `templates/base/workflow/scope.md` for scope guard and end-of-session aud
 ### 6.2 During the session
 [templates/base/workflow/scope.md — During work]
 ### 6.3 End of session
-[templates/base/workflow/scope.md — End of session audit (full checklist)]
+[templates/base/workflow/scope.md — End of session audit. Render this
+ONE of two ways: inline the full checklist VERBATIM, or hard-delegate
+with an imperative — "Read scope.md (End of session audit) and execute
+each item sequentially; do not summarize or skip." NEVER paraphrase the
+checklist into a short bullet list: that silently drops steps and the
+"print and execute sequentially" enforcement, producing a thin wrap-up.]
 ```
 
 Omit sections that are not applicable to the project (e.g. omit section 4
@@ -172,7 +177,12 @@ Follow `templates/base/workflow/scope.md` for scope guard and end-of-session aud
 ### 6.2 During the session
 [templates/base/workflow/scope.md — During work]
 ### 6.3 End of session
-[templates/base/workflow/scope.md — End of session audit (full checklist)]
+[templates/base/workflow/scope.md — End of session audit. Render this
+ONE of two ways: inline the full checklist VERBATIM, or hard-delegate
+with an imperative — "Read scope.md (End of session audit) and execute
+each item sequentially; do not summarize or skip." NEVER paraphrase the
+checklist into a short bullet list: that silently drops steps and the
+"print and execute sequentially" enforcement, producing a thin wrap-up.]
 ```
 
 ---
@@ -193,6 +203,9 @@ than inline but safer than pure reference.
   no raw SQL — violations introduce security or correctness bugs
 - **Content rules** — formatting, writing style, and structure that
   define the project's voice (if applicable)
+- **Session protocol / end-of-session audit** — a procedural checklist
+  is skipped silently when condensed; it belongs in the active tier,
+  not "reference the rest" (see §6.3)
 
 ### What to reference
 
@@ -259,7 +272,12 @@ Follow `templates/base/workflow/scope.md` for scope guard and end-of-session aud
 ### 6.2 During the session
 [templates/base/workflow/scope.md — During work]
 ### 6.3 End of session
-[templates/base/workflow/scope.md — End of session audit (full checklist)]
+[templates/base/workflow/scope.md — End of session audit. Render this
+ONE of two ways: inline the full checklist VERBATIM, or hard-delegate
+with an imperative — "Read scope.md (End of session audit) and execute
+each item sequentially; do not summarize or skip." NEVER paraphrase the
+checklist into a short bullet list: that silently drops steps and the
+"print and execute sequentially" enforcement, producing a thin wrap-up.]
 ```
 
 ---

--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -69,6 +69,7 @@ reused for a different component within the same area.
 | `02` | ID uniqueness — section IDs across all templates |
 | `03` | Manifest coverage — every template file has a manifest entry |
 | `04` | Header–manifest sync — DEPENDS ON headers match manifest depends_on |
+| `05` | Generation fidelity — end-of-session audit inlined verbatim or hard-delegated, never paraphrased |
 
 ### TPL - Template
 

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -13,6 +13,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-SMK-SYS-02-001A` | SMK | P0 | All section IDs are unique across all templates |
 | `SAIT-SMK-SYS-03-001A` | SMK | P0 | Every template file has a corresponding manifest entry |
 | `SAIT-SMK-SYS-04-001A` | SMK | P0 | DEPENDS ON headers match manifest depends_on |
+| `SAIT-SMK-SYS-05-001A` | SMK | P1 | End-of-session audit is inlined verbatim or hard-delegated, never paraphrased |
 | `SAIT-SMK-TPL-04-001A` | SMK | P1 | All EXTEND and OVERRIDE directives reference existing IDs |
 | `SAIT-INT-TPL-01-001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
 | `SAIT-INT-TPL-02-001A` | INT | P1 | EXTEND adds rules without removing base rules |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -1002,6 +1002,83 @@ def check_e2e_01():
 
 
 # ---------------------------------------------------------------------------
+# SYS-05 — end-of-session audit rendered faithfully (inline or delegated)
+# ---------------------------------------------------------------------------
+# A procedural checklist (the scope.md End of session audit) loses steps and
+# its enforcement header when a generator condenses it into bullets. The two
+# compliant renderings — inline-verbatim and hard-delegation — both keep the
+# load-bearing phrase ("execute each item ... do not summarize"); a paraphrase
+# drops it. This check asserts that phrase survives in the output spec
+# (agents.md §6.3 directive, every output model) and in every example
+# CLAUDE.md that declares a session-protocol section. Examples with no such
+# section are out of scope (skipped), not failures.
+
+ENFORCE_RE = re.compile(
+    r"execute each item|do not summari[sz]e|do not paraphrase",
+    re.IGNORECASE,
+)
+
+
+def _section_block(lines, start_index, stop_pattern):
+    """Return text from start_index+1 until a line matching stop_pattern."""
+    body = []
+    for line in lines[start_index + 1:]:
+        if stop_pattern.match(line):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def check_sys_05():
+    failures = []
+
+    # 1) Output spec — every §6.3 directive in agents.md carries the rule.
+    agents_path = os.path.join(ROOT, "templates", "base", "core", "agents.md")
+    a_lines = read(agents_path).splitlines()
+    h63 = re.compile(r"^###\s+6\.3\b")
+    stop_spec = re.compile(r"^(#{1,3}\s|```)")
+    found = False
+    for i, line in enumerate(a_lines):
+        if h63.match(line):
+            found = True
+            block = _section_block(a_lines, i, stop_spec)
+            if not ENFORCE_RE.search(block):
+                failures.append(
+                    f"  agents.md:{i + 1}: §6.3 directive must require "
+                    f"inline-verbatim or hard-delegation (missing 'execute "
+                    f"each item' / 'do not summarize')"
+                )
+    if not found:
+        failures.append("  agents.md: no '### 6.3' directive found")
+
+    # 2) Examples — any CLAUDE.md with a session-protocol section must render
+    #    the audit faithfully; examples without one are out of scope.
+    examples_dir = os.path.join(ROOT, "examples")
+    head = re.compile(r"^#{2,3}\s.*([Ss]ession protocol|[Ee]nd of session)")
+    stop_top = re.compile(r"^##\s")
+    if os.path.isdir(examples_dir):
+        for name in sorted(os.listdir(examples_dir)):
+            cm = os.path.join(examples_dir, name, "CLAUDE.md")
+            if not os.path.isfile(cm):
+                continue
+            e_lines = read(cm).splitlines()
+            start = next((i for i, l in enumerate(e_lines) if head.match(l)),
+                         None)
+            if start is None:
+                continue
+            block = _section_block(e_lines, start, stop_top)
+            if not ENFORCE_RE.search(block):
+                failures.append(
+                    f"  examples/{name}/CLAUDE.md: session-protocol section "
+                    f"neither inlines the audit verbatim nor hard-delegates "
+                    f"(missing 'execute each item' / 'do not summarize') — a "
+                    f"soft reference or paraphrase drops the wrap-up steps"
+                )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Test registry
 # ---------------------------------------------------------------------------
 
@@ -1034,6 +1111,8 @@ CHECKS = [
      "title": "Every template file has a manifest entry", "fn": check_sys_03},
     {"id": "SYS-04", "spec": "SAIT-SMK-SYS-04-001A",
      "title": "DEPENDS ON headers match manifest depends_on", "fn": check_sys_04},
+    {"id": "SYS-05", "spec": "SAIT-SMK-SYS-05-001A",
+     "title": "End-of-session audit inlined verbatim or hard-delegated", "fn": check_sys_05},
     {"id": "TPL-08", "spec": "SAIT-SMK-TPL-08-001A",
      "title": "Every base template has at least one [ID:] tag", "fn": check_tpl_08},
     {"id": "TPL-09", "spec": "SAIT-SMK-TPL-09-001A",

--- a/tests/specs/SAIT-SMK-SYS-05-001A.md
+++ b/tests/specs/SAIT-SMK-SYS-05-001A.md
@@ -1,0 +1,71 @@
+---
+id: SAIT-SMK-SYS-05-001A
+title: End-of-session audit is inlined verbatim or hard-delegated, never paraphrased
+product: sait
+type: smoke
+area: SYS
+priority: p1
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-06-25
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [generation, fidelity, session-protocol, output-spec]
+---
+
+## Short description
+
+> **Given** the output spec (`agents.md`) and the example context files
+> **When** the §6.3 end-of-session audit directive and every example
+> session-protocol section are inspected
+> **Then** each one inlines the `scope.md` audit verbatim or
+> hard-delegates to it, keeping the enforcement phrase — none paraphrase
+> the checklist into bullets
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every §6.3 directive and example session-protocol section keeps "execute each item" / "do not summarize" |
+| FAILED | One or more paraphrase or soft-reference the audit, dropping the enforcement phrase |
+| SKIPPED | — |
+| BLOCKED | — |
+| ERROR | File system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+
+### Setup
+
+1. Change to the repository root
+2. Read `templates/base/core/agents.md`
+3. Read every `examples/*/CLAUDE.md`
+
+### Execution
+
+1. For each `### 6.3` directive in `agents.md`, capture the directive
+   block up to the next heading or code fence
+2. For each example with a `Session protocol` / `End of session`
+   heading, capture the section up to the next top-level heading
+3. Match each captured block against the enforcement signature
+   (`execute each item` / `do not summari[sz]e` / `do not paraphrase`)
+
+### Assertions
+
+1. Assert every `agents.md` §6.3 directive matches the signature
+2. Assert every example session-protocol section matches the signature
+3. Examples with no session-protocol section are out of scope (skipped)
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Issue #498 — generation drops/condenses the end-of-session audit
+- `quality-gates-pair-check` — the rule this check pairs with
+- `templates/base/workflow/scope.md` — canonical End of session audit


### PR DESCRIPTION
Closes #498 (v2.16 scope: generation rule + smoke gate; the wrap-up
skill is deferred to v3.0, overlapping #414/#415).

## Problem

In hybrid generation, the §6.3 end-of-session audit gets paraphrased
into a short bullet list — dropping most steps **and** the "execute
sequentially, do not summarize" enforcement. The generated §6.3 looks
complete but silently produces a thin wrap-up.

## Grounding

In this repo only `hybrid-astro` had a §6 section, and it **soft-
referenced** scope.md (the weak pointer the issue warns about); the
other 7 examples have no §6 at all. So the fix targets the **output
spec** + the one example that exercises §6.3; the stale §6-less examples
are tracked separately in #581.

## Changes

- **`agents.md`** — §6.3 directive (all three output models) now
  mandates: inline the audit VERBATIM **or** hard-delegate ("execute
  each item; do not summarize"), **never** paraphrase. Adds the audit to
  the hybrid "what to inline" tier (root cause: it was filed under
  "reference the rest").
- **`INTERVIEW.md`** — hybrid section mirrors the rule.
- **`examples/hybrid-astro`** — soft reference → hard-delegation.
- **`SYS-05`** (`SAIT-SMK-SYS-05-001A`) — smoke check asserting the
  enforcement phrase survives in the spec and every example session-
  protocol section. The signature (`execute each item` / `do not
  summarize`) is kept by both compliant renderings and dropped by a
  paraphrase — verified it fails on both bug forms and passes the fix.
  Spec file + INDEX + CODIFICATION (SYS-05) registered.

Dogfoods `quality-gates-pair-check` (#479): the rule ships with its
check. Smoke 19/19, sync clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)