### PR TITLE
docs(git): add bulk-operations skip-list-then-unblock pattern (#442)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -399,6 +399,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -87,6 +87,25 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Bulk operations
+
+When a bulk operation (cohort emit, codebase-wide migration, mass
+rename, dependency bump) hits a per-item bug mid-run, do not stall
+the whole batch on one broken item — split it into two stacked PRs.
+
+- PR A ships the bulk operation with the broken items in an explicit
+  skip-list and a tracking issue filed for the bug
+- PR B, stacked on A, fixes the bug, re-runs the operation on the
+  skipped items, and removes the skip-list
+- The skip-list MUST live in the operation's input filter, not in the
+  target data; each entry MUST reference the tracking issue
+- Merge A first, then refresh B onto updated main per "De-stacking a
+  dependent branch" before merging it
+
+Two surgical PRs beat one stalled PR: PR A ships the work that is
+done, PR B ships the work that was blocked, and each is reviewed on
+its own scope.
+
 ### Close-and-resubmit when framing drifts
 
 When a PR's framing turns out to be wrong mid-review — the rule it


### PR DESCRIPTION
## What

Adds a generic **Bulk operations** subsection to `base/git.md`: when a
bulk operation (cohort emit, codebase-wide migration, mass rename,
dependency bump) hits a per-item bug mid-run, split into two stacked
PRs instead of stalling the whole batch:

- PR A — bulk op with broken items in an explicit skip-list + a
  tracking issue
- PR B (stacked) — fixes the bug, re-runs on skipped items, removes
  the skip-list

Sits alongside the existing *De-stacking* and *Close-and-resubmit*
subsections (both "two PRs beat one bigger PR").

## Genericity

Phrased for any bulk op — no domain specifics. Verified against the
"generic, not one-stack" bar before landing.

## Derived artifacts

base-git is core tier, so all 30 `generated/` chains were regenerated
via `py tools/sync.py`. Smoke: 19/19.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)