### PR TITLE
docs(git): add regenerated-artifact verification steps (#465 #466 #470)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -365,6 +365,28 @@ maintainer time on phantom fixes.
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -53,6 +53,28 @@
   git checkout main && git pull
   ```
 
+### Verifying regenerated artifacts
+
+After regenerating derived artifacts and before staging them, verify
+the diff is real and the output is correct.
+
+- Filter line-ending and whitespace noise first: `git diff
+  --ignore-all-space <file>` with no output means the change is
+  CRLF/whitespace-only — `git checkout -- <file>` to drop it so the
+  PR stays scoped to genuine content (and the noise does not reappear
+  as a fake regression on another OS)
+- Binary artifacts (images, diagrams, screenshots, plots) diff as
+  "Binary files differ" — opaque to git and often uncovered by the
+  test suite. Open each in a viewer (or an image-read tool for agent
+  workflows) and confirm it tracks its source data with no corruption
+- When a fix regenerates many artifacts, pair a spot-check of 3-5
+  representative cases (the fix's primary target, the most complex
+  case, a clean baseline) with a global metric that aggregates across
+  the population (test pass rate, link check, accessibility score,
+  calibration result). The spot-check catches broken regeneration;
+  the metric catches population-wide drift — together they match full
+  per-artifact review at a fraction of the cost
+
 ### Squash-merge safety
 
 When using squash merge, the branch commits become orphaned after


### PR DESCRIPTION
## What

New **Verifying regenerated artifacts** subsection in `base/git.md`,
extending the existing *Regenerate derived artifacts in the same PR*
rule with how to verify before staging:

- **#465** — filter CRLF/whitespace noise (`git diff --ignore-all-space`
  → `git checkout --`) so the PR stays scoped and noise doesn't reappear
  as a fake regression on another OS
- **#466** — visually spot-check binary artifacts (opaque to git diff,
  often uncovered by tests); open in a viewer or image-read tool
- **#470** — at scale, pair a 3-5 representative spot-check with a global
  aggregate metric instead of inspecting all N

## Genericity

Examples span images/diagrams/screenshots and link/accessibility/test
metrics — no domain specifics. #470's "cohort/calibration" framing and
#466's overlay-PNG origin were generalized.

## Derived artifacts

base-git is core tier → all 30 `generated/` chains regenerated. Smoke 19/19.

Closes #465, closes #466, closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)