### PR TITLE
docs(testing): verify shared-path fixes across every call site (#478 #472)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/stack/c-embedded.md -->
 # Stack -- Embedded C

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/security/security.md -->
 # Base — Application Security

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/stack/rust-lib.md -->
 # Stack — Rust Library / CLI

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/config.md -->
 # Base — Configuration

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/infra/cicd.md -->
 # Base — CI/CD and Delivery

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/frontend/static-site.md -->
 # Frontend — Static Site

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1293,6 +1293,29 @@ valid. A cohort-level assertion catches what per-record checks miss.
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
 
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value
+
 
 <!-- templates/base/core/oop.md -->
 # Base — Object-Oriented Design

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -252,3 +252,26 @@ valid. A cohort-level assertion catches what per-record checks miss.
   spot-checks
 - The pattern generalizes to any bulk migration where producer and
   consumer derive keys independently from a shared concept
+
+---
+
+## Shared-path fixes verify every call site
+[ID: testing-shared-path-breadth]
+
+A fix that changes a shared code path may surface latent bugs at other
+call sites that were silent before. Verification MUST exercise every
+call site sharing the changed code, not only the case from the bug
+report.
+
+- Run the project's ground-truth comparison (golden tests, reference
+  data, recorded fixtures, snapshot suite) on every entity exercising
+  the path — "expected unchanged" is the bug case, so verify it rather
+  than assume it
+- Enumerate every downstream consumer of the changed surface — each
+  tool or report that derives a committed artifact from it — and re-run
+  it, so a stale artifact does not misread as the fix not working.
+  Document the consumer list alongside the surface so the sweep stays
+  cheap to repeat
+- A silent prior bug at a sibling call site surfaces only in the
+  broader benchmark — the breadth of verification bounds the fix's
+  value


### PR DESCRIPTION
## What

New **Shared-path fixes verify every call site** section in
`base/testing.md` (`[ID: testing-shared-path-breadth]`):

- **#478** — when a fix changes a shared code path, verification MUST
  exercise every call site against ground truth, not just the targeted
  case; "expected unchanged" is the bug case
- **#472** — folded as the artifact angle: enumerate and re-run every
  downstream consumer that derives a committed artifact, and document
  the consumer list alongside the surface so the sweep is repeatable

## Genericity

Examples span golden tests / reference data / fixtures / snapshots and
any tool-or-report consumer — no ground-truth/EYE/MTF specifics.
#472's dispatch-surface framing generalized to "shared surface +
downstream consumers."

## Derived artifacts

base-testing is core tier → all 30 `generated/` chains regenerated.
Smoke 19/19 (new section ID validates unique).

Closes #478, closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)