### PR TITLE
docs(playbook): genericity vetting step for downstream lessons

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -55,6 +55,28 @@ composition model.
 
 ---
 
+## Drain a downstream lesson into a template
+
+A lesson sourced from one downstream project (a bug write-up, a session
+retro) carries that project's domain in its framing. Vet it for
+genericity before it becomes template content:
+
+1. Extract the generic kernel — the rule that holds regardless of stack
+   or domain. Strip project-specific nouns (entity, tool, and metric
+   names)
+2. If the kernel is genuinely cross-cutting, add it to the relevant
+   `base/` or layer template per "Add a new base or layer template"
+3. If a fragment only applies to one stack or domain, fold it as an
+   *example* inside a generic rule — do not add it as standalone base
+   content. Standalone one-stack content in a core-tier template loads
+   into every chain and dilutes attention
+4. Prefer extending an existing related rule over adding a parallel
+   section — duplicate rules restated across templates are the same
+   attention-dilution failure
+5. Validate per "Validate a template change"
+
+---
+
 ## Rename a template file
 
 1. `git mv <old-path> <new-path>`


### PR DESCRIPTION
Adds a **Drain a downstream lesson into a template** section to
`docs/PLAYBOOK.md`: extract the generic kernel, fold one-stack
fragments as examples inside a generic rule rather than as standalone
base content, and prefer extending an existing rule over a parallel
section.

Codifies the load-bearing step from the v2.17 lessons-drain (where
#458 and #472 were demoted to folded examples). Recurs — ~49 Backlog
fragments remain, many downstream-sourced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)