### PR TITLE
docs(issues): labels-at-creation + deferred-work-with-trigger (#575 #461)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2379,7 +2379,9 @@ a title convention, and a body template.
 ## Issue types
 [ID: base-issues-types]
 
-Every issue MUST have exactly one type and one priority.
+Every issue MUST have exactly one type and one priority, applied at
+creation — never create a ticket unlabeled. The label taxonomy is
+project-specific; the at-creation discipline is not.
 
 | Type | When to use |
 |------|-------------|
@@ -2399,6 +2401,29 @@ Every issue MUST have exactly one type and one priority.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
+
+---
+
+## Deferred work
+[ID: base-issues-defer]
+
+When work is genuinely valuable but intentionally deferred — not in the
+next milestone, perhaps not the next several — the right home is a
+Backlog-milestoned issue with explicitly named trigger conditions, not a
+TODO line in an ADR or a code comment. This is distinct from a P4
+"someday" issue: the deferral is deliberate, the trigger is named, and
+the work is sized.
+
+- Open the body with the deferral note: "Do not pick up before one of
+  the trigger conditions fires."
+- State trigger conditions as concrete, observable events ("a second
+  component exhibits pattern X", "badged data runs four weeks without
+  pushback") — natural language is fine; naming them is the discipline.
+- Carry acceptance criteria as usual, so the work is sized when picked up.
+- Reference the issue from the decision that deferred it (e.g. the ADR's
+  Decision section), so the decision stays discoverable from the tracker
+  rather than buried where it will be re-litigated or quietly done
+  unnecessarily.
 
 ---
 

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -9,7 +9,9 @@ a title convention, and a body template.
 ## Issue types
 [ID: base-issues-types]
 
-Every issue MUST have exactly one type and one priority.
+Every issue MUST have exactly one type and one priority, applied at
+creation — never create a ticket unlabeled. The label taxonomy is
+project-specific; the at-creation discipline is not.
 
 | Type | When to use |
 |------|-------------|
@@ -29,6 +31,29 @@ Every issue MUST have exactly one type and one priority.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
+
+---
+
+## Deferred work
+[ID: base-issues-defer]
+
+When work is genuinely valuable but intentionally deferred — not in the
+next milestone, perhaps not the next several — the right home is a
+Backlog-milestoned issue with explicitly named trigger conditions, not a
+TODO line in an ADR or a code comment. This is distinct from a P4
+"someday" issue: the deferral is deliberate, the trigger is named, and
+the work is sized.
+
+- Open the body with the deferral note: "Do not pick up before one of
+  the trigger conditions fires."
+- State trigger conditions as concrete, observable events ("a second
+  component exhibits pattern X", "badged data runs four weeks without
+  pushback") — natural language is fine; naming them is the discipline.
+- Carry acceptance criteria as usual, so the work is sized when picked up.
+- Reference the issue from the decision that deferred it (e.g. the ADR's
+  Decision section), so the decision stays discoverable from the tracker
+  rather than buried where it will be re-litigated or quietly done
+  unnecessarily.
 
 ---
 


### PR DESCRIPTION
Drains two issue-lifecycle lessons into `base/workflow/issues.md` (base-issues; restales 1 chain — `stack-tutorial` regenerated).

- **#575** — extend the issue-types rule with the at-creation labeling discipline: every issue ships with its type + priority at creation, never unlabeled. Taxonomy stays project-specific in CLAUDE.md; the discipline is the reusable part.
- **#461** — new *Deferred work* section: park intentionally-deferred work as a Backlog issue with explicitly named, observable trigger conditions, referenced from the deferring decision — not a TODO line in an ADR.

Honored the no-inline-cross-reference rule (the issue's suggested quality-gates.md cross-ref is carried by `depends_on`, not inline prose).

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #575, closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)