### PR TITLE
docs(git): repeat closing keyword before each issue number (#517)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -332,6 +332,10 @@ maintainer time on phantom fixes.
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -20,6 +20,10 @@
 ## Pull requests
 - PRs should be small and focused — one concern per PR
 - Always test locally before committing
+- **Repeat the closing keyword before each issue number** when a PR
+  closes more than one issue: `Closes #a, closes #b, closes #c` closes
+  all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
+  a plain reference, not a closing one, and stays open after merge.
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the


### PR DESCRIPTION
Adds the multi-issue closing-keyword rule to `base/core/git.md` Pull requests.

> Repeat the closing keyword before each issue number: `Closes #a, closes #b, closes #c` closes all three. `Closes #a, #b, #c` closes only `#a`.

GitHub treats a `#n` as a *closing* reference only when a keyword immediately precedes it; bare numbers stay open after merge (observed downstream: a 3-spike PR left two open).

git.md is core-tier, so all 30 `generated/` chains were regenerated in this PR.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)