### PR TITLE
docs(communication): register-only base communication template (#467)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,8 @@ base/
 │   ├── scope.md        # Scope guard, session protocol, drift prevention
 │   ├── quality-gates.md # Three-layer gate model (editor, pre-commit, CI), thresholds
 │   ├── ai-workflow.md  # AI-assisted development lifecycle, work item hierarchy
-│   └── 360.md          # 360-degree project analysis — four stakeholder perspectives, grading
+│   ├── 360.md          # 360-degree project analysis — four stakeholder perspectives, grading
+│   └── communication.md # Communication preferences — concise output, shorthand verbs, scope-asking
 ├── infra/
 │   ├── cicd.md         # Pipeline stages, triggers, environments, IaC, deployment
 │   ├── containers.md   # Dockerfile, runtime security, resource limits, Kubernetes

--- a/templates/base/workflow/communication.md
+++ b/templates/base/workflow/communication.md
@@ -1,0 +1,22 @@
+# Communication Preferences
+[ID: base-communication]
+
+How the agent communicates with the user during a session. These are
+override-friendly defaults — a downstream project MAY add its own
+shorthand verbs and MUST preserve these if it references this template.
+
+## Defaults
+
+- Concise, direct answers — no filler, no preamble, no restating the
+  request before answering
+- State your preferred option after presenting suggestions — do not make
+  the user choose when you have a view
+- Ask before assuming scope on an ambiguous instruction — do not silently
+  expand it
+
+## Shorthand verbs
+
+- **"next"** — move to the next item without asking for confirmation
+- **"stop"** — stop working; this does NOT mean save or commit
+- **"yes"** — proceed; do not summarise what you are about to do, just
+  do it

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -93,6 +93,9 @@ base:
   - id: base-360
     file: templates/base/workflow/360.md
     description: 360-degree project analysis — four stakeholder perspectives, grading
+  - id: base-communication
+    file: templates/base/workflow/communication.md
+    description: Communication preferences — concise output, shorthand verbs, scope-asking
 
 platform:
   - id: platform-github


### PR DESCRIPTION
Adds a new `templates/base/workflow/communication.md` [ID: base-communication] — a single upstream home for communication-preference defaults that downstream projects currently keep privately in their own CLAUDE.md.

**Contents:** the six defaults (concise/no-preamble, state-preferred-option, ask-before-scope) plus shorthand verbs (`next`=no-confirm, `stop`=stop-only-don't-commit, `yes`=proceed-no-summary), framed as override-friendly defaults a project MAY extend and MUST preserve if referencing.

**Wiring:** register-only — 0 chains, matching `webhooks.md` and `ai-workflow.md` (composition over inheritance, ADR-004). Downstream references it explicitly; not auto-inherited. No `generated/` restale; `sync.py` refreshed the SPEC.md template listing only.

Genericity: verbs are partly user-specific, so they ship as documented defaults under an explicit override clause rather than mandates.

Smoke: 19/19 pass (validates the new manifest entry + unique ID). `sync.py --check`: in sync.

Closes #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)