### PR TITLE
docs(quality): ground thresholds, probes & generation in real data (#469 #464 #428)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -90,6 +90,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -295,11 +302,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -84,6 +84,13 @@
   element so existing callers and tests survive; remove it in a follow-up
 - Magic numbers and magic strings must be named constants — unnamed literals
   scattered across the codebase are a maintenance hazard
+- Size numeric thresholds (a filter, cutoff, bound, or tolerance) from the
+  actual distribution of the relevant quantity in the working data set
+  (p95, p99, max-legitimate) — not from first principles or intuition. A
+  threshold chosen by feel is too loose (masks bugs) or too tight (breaks
+  edge cases) with no record of why. Document the data source in the
+  constant's docstring so a future maintainer can rerun the analysis
+  against fresh data and re-validate
 - No substantial duplication across sibling modules — if the same code
   appears in two or more places, extract a shared module; the third
   copy is a bug
@@ -289,11 +296,25 @@ maintainer time on phantom fixes.
 - Probe scripts are the antidote to guessing: prefer writing one
   over inferring data shape or runtime behaviour from incomplete
   evidence
+- A throwaway probe also fits a uniform mechanical migration: when one
+  edit repeats across hundreds of identical call sites (e.g. inserting a
+  new required field at a fixed anchor in a large data file), a small
+  `probe_*` script that performs the insertion is faster and safer than
+  hand-editing or an opaque `sed` one-liner. The diff is the audit trail,
+  not the script — review the diff, then delete the probe before the
+  commit
 
 ## Automated enforcement
 
 - Quality conventions in this document are enforced automatically via
   quality gates (editor → pre-commit → CI)
+- A code or data generator MUST emit output that passes the project's
+  linters and formatters natively — never rely on `lint --fix` as a
+  post-process step. A fix pass at the consumer end hides the generator's
+  responsibility, makes every re-emit a noisy diff, and confuses
+  contributors who regenerate and see unexplained changes. Any time
+  `lint --fix` is needed to clean generated output, treat it as a
+  generator bug to fix at the source
 
 ## Testing
 


### PR DESCRIPTION
Three measurement/generation-discipline rules into `base/core/quality.md` (core-tier; all 30 chains regenerated).

- **#469** — §Maintainability: size numeric thresholds from the working data's actual distribution (p95/p99/max-legitimate), document the source in the constant's docstring — the other half of the named-constant rule.
- **#464** — §Probe scripts: a throwaway probe fits uniform mechanical migrations (insert a field at a fixed anchor across N call sites); the diff is the audit trail, delete the probe before commit.
- **#428** — §Automated enforcement: generators MUST emit lint-clean output natively; needing `lint --fix` is a generator bug to fix at the source.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #469, closes #464, closes #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)