### PR TITLE
docs(quality): maintainability — variants, ports, decomposition (#451 #436 #345 #332)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -121,6 +121,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -115,6 +115,36 @@
   abstraction
 - **High Cohesion**: modules that change together should live together;
   a module whose parts serve unrelated concerns should be split
+- **Per-config opt-in over global auto-detect**: when an algorithm
+  variant helps one input class and hurts another, prefer a per-config
+  flag with a safe default over a global threshold that auto-detects
+  which class an input belongs to. Auto-detect works only when the input
+  cleanly partitions on a measurable signal; when it does not, it
+  misclassifies silently — often for the worst input. Per-config opt-in
+  captures the human-known classification directly
+- **Cross-language function ports must be byte-equivalent**: when a
+  function exists in one language and is consumed by code in another,
+  port it exactly — same operation order, character classes, and edge
+  cases (empty input, leading/trailing separators). Reference the
+  original in the port's docstring so the invariant is discoverable.
+  Never re-implement from the name or description alone — that produces
+  close-but-diverging siblings that surface as silent data corruption
+- **Decompose a ported mega-script into a strategy-dispatched
+  pipeline**: when porting a procedural script (one file, branching
+  control flow per case) into a typed library, split it into small
+  single-responsibility modules with the orchestrator dispatching on a
+  declared type-axis (enum / Literal / tagged union). Adding a case
+  becomes "add a dispatch arm," not "sprinkle if-this-case throughout,"
+  and each stage becomes testable in isolation — this composes the
+  existing strategy and composition patterns, not a new one
+- **Build extraction-ready internal modules**: structure an internal
+  module today so it can become a standalone repo or submodule tomorrow
+  without a rewrite. Host-specific values (cache dirs, config) MUST be
+  injected as constructor parameters with portable defaults, never read
+  from host globals; the module MUST own its public API (`__init__`
+  re-exports), README, tests, and requirements; a thin CLI wraps the
+  library rather than being the product. Extraction stays deferred, but
+  the module is ready the moment it is wanted
 
 ## Testability
 


### PR DESCRIPTION
Four Maintainability bullets into `base/core/quality.md` (core-tier; all 30 chains regenerated).

- **#451** — per-config opt-in over a global auto-detect threshold when an algorithm variant helps one input class and hurts another.
- **#436** — cross-language function ports must be byte-equivalent; tag the port and never re-implement from the name alone.
- **#345** — decompose a ported procedural mega-script into a strategy-dispatched pipeline of single-responsibility modules.
- **#332** — build extraction-ready internal modules (injected host values, own API/README/tests, thin CLI) so submodule extraction needs no rewrite.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #451, closes #436, closes #345, closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)