### PR TITLE
docs(quality): fail loud on hidden preconditions; retract dead code (#452 #476)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -22,6 +22,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -116,6 +124,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -16,6 +16,14 @@
   is extracted to its own repo," "when a second call site appears").
   A deferral without a trigger gets re-argued every time it comes up
   or quietly forgotten; a deferral with a trigger is a decision.
+- **Delete dead-code paths discovered during implementation**: when a
+  probe against real data invalidates a path you wrote earlier in the
+  same session, delete it in the same commit. "In case it's useful
+  later" is sunk-cost reasoning — what you already wrote feels valuable,
+  but code with no real test case to anchor it rots fast and confuses
+  the next maintainer about which path actually fires. If a future case
+  needs it, git history has it. Distinct from YAGNI: YAGNI says do not
+  build speculative code; this says retract what probing made speculative.
 
 ## Architecture
 
@@ -110,6 +118,15 @@
   wrong-but-plausible derived value (a 404 URL, a mismatched ID) emitted
   without warning is worse than a script that refuses to run until the
   data is correct
+- **A caller-side input filter is not a precondition**: when a runner
+  filters its inputs by a caller-side criterion (data availability,
+  ground-truth presence, a feature flag) that is tighter than the inner
+  function's actual preconditions, the function silently rots whenever an
+  unrelated change breaks it on the excluded inputs — no test exercises
+  them. Either widen the filter so the function runs over its full input
+  domain, or push the precondition into the function as an assertion so
+  it fails loud. A filter that "happens to" exclude broken inputs is a
+  buried defect waiting for someone to lift it
 - **Law of Demeter**: a module should only talk to its direct
   dependencies; chaining through objects (`a.b.c.d`) signals missing
   abstraction


### PR DESCRIPTION
Two defensive-hygiene rules into `base/core/quality.md` (core-tier; all 30 chains regenerated).

- **#476** — Core principles, near YAGNI: delete dead-code paths a probe against real data invalidates mid-session; "in case it's useful later" is sunk-cost. Distinct from YAGNI (don't build speculative) — this is retract-what-became-speculative.
- **#452** — Maintainability: a caller-side input filter tighter than the inner function's preconditions lets the function silently rot on excluded inputs; widen the filter or push the precondition into the function as a loud assertion.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #452, closes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)