### PR TITLE
docs(360): headless-product perspectives + audit-storage choice (#519 #337)

### DIFF
--- a/templates/base/workflow/360.md
+++ b/templates/base/workflow/360.md
@@ -69,6 +69,27 @@ each category to force a perspective reset.
 
 [ID: 360-categories]
 
+### Adapting the perspective set to the product surface
+
+[ID: 360-headless]
+
+The four perspectives are the default for a product with a user-facing
+surface. The underlying principle is one isolated reviewer per
+independent slice of the product — and the slices should match where the
+product's surface area actually is.
+
+When the project has no user-facing surface (a headless service,
+library, or CLI), the Value perspective reduces to the README and the
+Discovery perspective largely does not apply — forcing the four-way split
+leaves two lenses empty and overloads Quality. Instead, keep the
+mechanics (parallel role-isolated subagents, clean context, adversarial
+per-finding verification, letter grades, a persisted report) and
+re-project the Quality perspective into N engineering dimensions — e.g.
+architecture, API contract, container/deployment, dependencies,
+correctness, code quality, security, tests, CI/CD, documentation —
+running one isolated reviewer per dimension. The overall grade is still
+the lowest dimension grade.
+
 ### 1. Value (user perspective)
 
 [ID: 360-value]
@@ -459,14 +480,19 @@ only as strong as its weakest perspective.
 Audit results MUST be persisted in the repository — agent memory is
 ephemeral and invisible to other contributors.
 
-- Projects MUST maintain a `docs/360-audit.md` file with a score
-  history table
-- Each row MUST include: date, grade per category, and issue
-  references spawned by that audit
-- A "Current bottleneck" section SHOULD identify the weakest
-  category and list its key gaps
-- The end-of-session checklist SHOULD include updating
-  `docs/360-audit.md` after running an audit
+- Audit history MUST live in one of two forms — pick one convention and
+  keep all history there, never split across both:
+  - **(a)** a single `docs/360-audit.md` history file: one score-table
+    row per audit (date, grade per category, issue references) plus a
+    "Current bottleneck" section naming the weakest category (structure
+    below)
+  - **(b)** verbose dated reports under `docs/audits/YYYY-MM-DD-360.md`,
+    each with per-dimension findings tables and the rationale for every
+    grade
+- Prefer (b) when preserving the reasoning behind each grade matters — a
+  bare score row ages poorly and loses how the grade was reached
+- The end-of-session checklist SHOULD update the chosen location after
+  running an audit
 
 ### Minimum file structure
 


### PR DESCRIPTION
Two 360.md refinements (base-360 is register-only — 0 chains, no `generated/` restale).

- **#519** — new §*Adapting the perspective set to the product surface*: for a headless service/library/CLI, Value reduces to the README and Discovery doesn't apply; keep the mechanics but re-project Quality into N engineering dimensions, one isolated reviewer each. Default stays four perspectives for user-facing products.
- **#337** — §Tracking now offers two storage forms: (a) a single `docs/360-audit.md` score-history file, or (b) verbose dated `docs/audits/YYYY-MM-DD-360.md` reports; pick one, never split. Resolves the single-source-of-truth conflict with an existing dated-reports convention.

Smoke: 19/19 pass (new `360-headless` ID unique). `sync.py --check`: in sync.

Closes #519, closes #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)