### PR TITLE
docs(quality-gates): promote a resistant case to a gated tier (#491)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2067,6 +2067,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2677,6 +2677,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3244,6 +3244,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3244,6 +3244,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3244,6 +3244,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1843,6 +1843,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1843,6 +1843,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1843,6 +1843,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1843,6 +1843,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2594,6 +2594,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1843,6 +1843,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3244,6 +3244,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2067,6 +2067,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -282,6 +282,26 @@ catches what a clean-room CI cannot.
 
 ---
 
+## Promote a resistant case to a gated tier
+[ID: base-quality-gates-tier-promotion]
+
+Projects with a tiered test/fixture system separate gated cases (a
+golden-output or ground-truth regression that fails the build) from
+ungated ones (spot-checked CI runs, confidence priors, informally
+verified internal calls). When a bug surfaces in an ungated case and the
+quick-fix candidates all probe-falsify against the existing gated
+anchors, promote the affected case into the next-strictest tier before
+attempting the deep fix. Promotion converts a silent failure into a
+measurable metric, so the eventual fix lands against a regression target
+instead of working blind.
+
+The shape generalizes: promote a flaky integration test to a contract
+test with a stronger oracle; promote a tutorial example to a CI-verified
+example the first time doc-rot slips through; promote a manual smoke test
+to an automated regression the first time a regression escapes. When a
+fix does not fit one session, measure first by elevating the case a tier;
+the deep fix follows with the metric as the gating signal.
+
 ## Generated-file staleness gate
 
 [ID: quality-gates-staleness]


### PR DESCRIPTION
New §*Promote a resistant case to a gated tier* in `base/workflow/quality-gates.md` (base-quality-gates; 13 chains regenerated).

When a bug surfaces in an ungated case and quick fixes all probe-falsify against existing gated anchors, promote the case to the next-strictest tier to convert a silent failure into a measurable regression metric before the deep fix. Generalizes to flaky→contract tests, tutorial→CI-verified examples, manual→automated smoke.

Merges **#491** with **#493 part 4** (tiered-fixture promotion — the second observed use of the same pattern, which is what cleared the genericity bar).

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)