### PR TITLE
docs(python-lib): editable-install staleness gotcha + build gate (#518 #511)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2895,6 +2895,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -2914,6 +2918,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -2930,6 +2935,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3498,6 +3498,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -3517,6 +3521,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -3533,6 +3538,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3498,6 +3498,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -3517,6 +3521,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -3533,6 +3538,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3498,6 +3498,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -3517,6 +3521,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -3533,6 +3538,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2812,6 +2812,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -2831,6 +2835,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -2847,6 +2852,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2061,6 +2061,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -2080,6 +2084,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -2096,6 +2101,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3498,6 +3498,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -3517,6 +3521,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -3533,6 +3538,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -91,6 +91,10 @@ CLAUDE.md
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
 - Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
+- If `__version__` derives from `importlib.metadata.version(...)`, an
+  editable install reports a stale version after a `[project].version`
+  bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
+  install fresh and are unaffected
 
 ---
 
@@ -110,6 +114,7 @@ mypy src/ --strict        # type check
 ruff check src/ tests/    # lint
 ruff format src/ tests/   # format
 python -m build           # build distribution
+twine check dist/*        # validate wheel/sdist metadata
 ```
 ---
 
@@ -126,6 +131,7 @@ python -m build           # build distribution
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
 | Coverage | — | — | pytest-cov ≥ 80% | `pyproject.toml` |
+| Build | — | — | `python -m build` + `twine check dist/*` | `pyproject.toml` |
 
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with


### PR DESCRIPTION
Two python-lib packaging items into `templates/stack/python-lib.md` (base for the Python stacks — regenerates 7 Python chains).

- **#518** — §Packaging gotcha: an `importlib.metadata.version(...)`-derived `__version__` reports a stale value on an editable install after a `[project].version` bump until `pip install -e .` is rerun; built artifacts are unaffected.
- **#511** — quality-gates §Build row: `python -m build` + `twine check dist/*` (validates wheel/sdist metadata — README rendering, license, classifiers — a cheap linter even for non-PyPI packages), plus the `twine check` command.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #518, closes #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)