### PR TITLE
docs(python-flask): versioned-API registry + factory over duplication (#512)

### DIFF
--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3758,6 +3758,14 @@ CLAUDE.md
 - Blueprint registered with a URL prefix (`/api/v1`, `/auth`, etc.)
 - No cross-blueprint imports — shared logic goes in a service module
 - Routes thin — business logic delegated to service functions, not in route handlers
+- For multiple API versions that share one contract (same params,
+  validation, and response — differing only in implementation), use a
+  version registry (`{"v1": ImplV1, "v2": ImplV2}`) plus a blueprint
+  factory (`make_api_blueprint(version, impl)` mounted at
+  `url_prefix=f"/api/{version}"`). Adding a version is then a one-line
+  registry edit with no per-version route duplication. Reserve a
+  dedicated per-version module for when a version's contract actually
+  diverges — let the divergence earn the split rather than starting there
 
 ---
 

--- a/templates/stack/python-flask.md
+++ b/templates/stack/python-flask.md
@@ -76,6 +76,14 @@ CLAUDE.md
 - Blueprint registered with a URL prefix (`/api/v1`, `/auth`, etc.)
 - No cross-blueprint imports — shared logic goes in a service module
 - Routes thin — business logic delegated to service functions, not in route handlers
+- For multiple API versions that share one contract (same params,
+  validation, and response — differing only in implementation), use a
+  version registry (`{"v1": ImplV1, "v2": ImplV2}`) plus a blueprint
+  factory (`make_api_blueprint(version, impl)` mounted at
+  `url_prefix=f"/api/{version}"`). Adding a version is then a one-line
+  registry edit with no per-version route duplication. Reserve a
+  dedicated per-version module for when a version's contract actually
+  diverges — let the divergence earn the split rather than starting there
 
 ---
 


### PR DESCRIPTION
Adds a versioned-API structure sub-point to §Blueprints in `templates/stack/python-flask.md` (regenerates the flask chain).

When API generations share one contract (same params/validation/response, different algorithm), a per-version directory tree duplicates byte-identical handlers and implies a contract divergence that doesn't exist. Default to a version registry + blueprint factory (`make_api_blueprint(version, impl)` at `/api/{version}`) — adding a version is a one-line registry edit. Reserve a per-version module for genuine contract divergence; let the divergence earn the split.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)