### PR TITLE
docs(ux): add graded variant bake-off method (#514)

### DIFF
--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1587,6 +1587,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -1925,6 +1925,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -1925,6 +1925,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1587,6 +1587,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -1925,6 +1925,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]

--- a/templates/frontend/ux.md
+++ b/templates/frontend/ux.md
@@ -97,6 +97,17 @@ A feature is not complete until:
   self-contained components; avoid monolithic views
 - New components SHOULD be documented with usage examples before shipping
 
+## Graded variant bake-off
+[ID: frontend-ux-bakeoff]
+
+When several UX approaches are plausible, do not pick by fiat:
+
+1. Build N minimal variants (e.g. three editor designs).
+2. Grade each on weighted criteria — at least implementation effort and
+   UX quality — by exercising them on a dev server, not on paper.
+3. Pick the best score-per-effort; record the runners-up and why they
+   lost, so the discarded variants document the design space.
+
 ## Browser support
 
 [ID: frontend-ux-browsers]


### PR DESCRIPTION
New §*Graded variant bake-off* in `templates/frontend/ux.md` (5 frontend chains regenerated).

A reusable method for choosing among UX alternatives empirically: build N minimal variants, grade each on weighted criteria (at least implementation effort and UX quality) by exercising them on a dev server (not on paper), pick the best score-per-effort, and record the runners-up so the discarded variants document the design space.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)