### PR TITLE
docs(frontend): answer-engine optimization + social/heading/favicon SEO (#490 #311)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1594,6 +1594,11 @@ to change.
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)
+- `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
+  ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
+- Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
+  Control — new domains block AI bots by default (since 2025-07-01),
+  which overrides `robots.txt`
 
 ### SEO strategy (structure audit)
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -1594,6 +1594,11 @@ to change.
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)
+- `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
+  ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
+- Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
+  Control — new domains block AI bots by default (since 2025-07-01),
+  which overrides `robots.txt`
 
 ### SEO strategy (structure audit)
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -1703,6 +1703,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -1712,6 +1727,9 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines
 
 
 <!-- templates/base/core/oop.md -->

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -2041,6 +2041,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -2050,6 +2065,9 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines
 
 
 <!-- templates/stack/spa-react.md -->

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -2041,6 +2041,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -2050,6 +2065,9 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines
 
 
 <!-- templates/stack/spa-svelte.md -->

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -1703,6 +1703,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -1712,6 +1727,9 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines
 
 
 <!-- templates/base/core/oop.md -->

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1594,6 +1594,11 @@ to change.
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)
+- `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
+  ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
+- Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
+  Control — new domains block AI bots by default (since 2025-07-01),
+  which overrides `robots.txt`
 
 ### SEO strategy (structure audit)
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -2041,6 +2041,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -2050,6 +2065,9 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines
 
 
 <!-- templates/stack/spa-vue.md -->

--- a/templates/frontend/quality.md
+++ b/templates/frontend/quality.md
@@ -94,6 +94,21 @@ Rules:
 - Verify the chosen convention matches the hosting platform's behavior
 - Privacy-friendly analytics only — no consent banner required
 - No third-party tracking scripts without explicit user consent
+- If `og:image` is present, `twitter:image` MUST also be present —
+  Twitter/X does not reliably fall back to `og:image`. Include
+  `og:image:width`/`og:image:height` (recommended 1200×630) to avoid
+  render delays on social platforms
+- H1 keywords SHOULD appear in the page body — search and answer engines
+  use heading/body coherence as a relevance signal; H1 SHOULD be unique
+  per page and reflect its content
+- Provide a complete favicon set: an SVG favicon
+  (`<link rel="icon" type="image/svg+xml">`) and a 180×180
+  `apple-touch-icon` for iOS home-screen bookmarks
+- Answer engines retrieve passages, not whole pages — lead each section
+  with a direct answer and keep paragraphs self-contained
+- Measure answer-engine (AEO) visibility as citation frequency across a
+  fixed prompt set over time, not as a single rank — generative output is
+  non-deterministic
 
 ## Structured data (if applicable)
 
@@ -103,3 +118,6 @@ Rules:
   implies commerce, `priceValidUntil` implies a store)
 - Review schema choice when site role differs from template examples —
   e-commerce examples applied to editorial sites produce misleading markup
+- `FAQPage` markup SHOULD NOT be expected to render a Google rich result
+  (gov/health only since 2023) — it still aids machine parsing for answer
+  engines

--- a/templates/frontend/static-site.md
+++ b/templates/frontend/static-site.md
@@ -156,6 +156,11 @@ to change.
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
 - Privacy-friendly analytics only (no consent banner required)
+- `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
+  ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
+- Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
+  Control — new domains block AI bots by default (since 2025-07-01),
+  which overrides `robots.txt`
 
 ### SEO strategy (structure audit)
 


### PR DESCRIPTION
SEO rules into the existing frontend SEO sections (already wired to frontend stacks — regenerates frontend chains).

- **#490** — AEO: `frontend/quality.md` gains passage-first content + citation-frequency measurement and a `FAQPage`-aids-machine-parsing note; `frontend/static-site.md` gains the answer-engine crawler allowlist (OAI-SearchBot, ChatGPT-User, PerplexityBot, Claude-SearchBot/User, Applebot) + Cloudflare AI Crawl Control caveat.
- **#311 (rules)** — `frontend/quality.md` gains the general web-SEO rules: `twitter:image` paired with `og:image` (+ dimensions), H1/body heading coherence, and a complete favicon set (SVG + apple-touch-icon). Placed in `quality.md` so all frontend stacks inherit them, not just static sites.

**#311's dedicated `frontend/seo.md` template** (file creation + migrating existing SEO into it) is deferred to the v3.0 frontend restructure (#492) and filed separately — creating a new frontend file days before that restructure would only be moved again. #311 closed with that disposition.

Smoke: 19/19 pass. `sync.py --check`: in sync.

Closes #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)