### PR TITLE
docs(quality): a comment citing an issue inherits its lifecycle (#616)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -325,6 +325,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -319,6 +319,15 @@ maintainer time on phantom fixes.
   next time the code is read, never rely on it as-is. Reasoning comments rot
   faster than the code they annotate: the code stays correct while the predicate
   the comment cites silently goes false
+- A comment or doc note that cites an issue, PR, or ADR by number inherits
+  that reference's lifecycle: when the cited item is closed without action,
+  superseded, or replaced by a different fix, the citation is a defect even
+  when the annotated code still works — a future reader tracing the stale
+  number lands on a dead thread and misses the live follow-up. Fix it in a
+  small change. When closing or superseding an item that comments may cite,
+  audit the references in the same change — `rg "#<number>"` (or the tracker
+  URL) over the repo lists them, and the audit is done when none point at the
+  stale item
 
 ## Debug code
 


### PR DESCRIPTION
## What

Extends the existing reasoning-comments-rot rule in `base/core/quality.md` (`## Code style`) with a sibling: a comment or doc note that **cites an issue, PR, or ADR by number inherits that reference's lifecycle**.

## Why

When the cited item is closed without action, superseded, or replaced by a different fix, the citation is a **defect even when the annotated code still works** — a future reader tracing the stale number lands on a dead thread and misses the live follow-up.

- Fix a stale citation in a small change.
- When closing/superseding an item that comments may cite, audit references in the same change — `rg "#<number>"` lists them; done when none point at the stale item.

## Verification

- `py tests/run_smoke.py` — 19/19 pass
- `py tools/sync.py --check` — in sync (30 core-tier chains regenerated)

Closes #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)