### PR TITLE
docs(quality): honest absence beats a recovered wrong value (#617)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-flutter.md
+++ b/generated/stack-flutter.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-react-native.md
+++ b/generated/stack-react-native.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-react-spa.md
+++ b/generated/stack-react-spa.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-svelte.md
+++ b/generated/stack-svelte.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/generated/stack-vue.md
+++ b/generated/stack-vue.md
@@ -201,6 +201,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -195,6 +195,22 @@ that runs the tool. The rules below address each.
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
 
+### Honest absence beats a recovered wrong value
+
+- When a fix flips an extractor from a wrong value to an honest absence
+  (`None`, empty, no-reading) because the source genuinely has no data
+  at that point, the absence is the correct output — not a regression
+  to recover
+- Update the reference / ground-truth framing in the same change: any
+  prior expected value at that point MUST be re-marked as extrapolation
+  past the data, never carried forward as a hit-this target the
+  extractor "should" reach
+- Distinguish the two absences in logs and reference notes: `None`
+  because the extractor failed (a defect to fix) versus `None` because
+  the source carries no value there (the correct answer) — the two
+  demand opposite responses, and conflating them sends a maintainer to
+  "fix" a correct absence
+
 ### Thresholds move, not the measurement
 
 - When a measurement and a threshold disagree, the threshold is the


### PR DESCRIPTION
## What

Adds a subsection to `base/core/quality.md` `## Calibration discipline`: **honest absence beats a recovered wrong value**.

## Why

When a fix flips an extractor from a wrong value to an honest absence (`None`, empty) because the source genuinely has no data at that point, the absence is the **correct output — not a regression to recover**. Carrying forward the old expected value turns an extrapolation past the data into a phantom regression goal.

- Re-mark any prior expected value at that point as **extrapolation**, not a hit-this target.
- Distinguish `None` because the extractor **failed** (a defect) from `None` because the **source has no value there** (correct) — they demand opposite responses.

## Verification

- `py tests/run_smoke.py` — 19/19 pass
- `py tools/sync.py --check` — in sync (30 core-tier chains regenerated)

Closes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)