### PR TITLE
docs(playbook): align release section with ADR-006 (#604)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -255,8 +255,24 @@ shell access can use them directly.
 
 ## Release a new version
 
-1. Create a release branch: `git checkout -b chore/release-vA.B.C`
-2. Update `docs/dev-journal.md` with a release entry
-3. Commit: `git commit -m "chore: release vA.B.C"`
-4. Push, open PR, merge
-5. Tag on `main`: `git tag vA.B.C && git push origin vA.B.C`
+This repo has no version manifest (plain Markdown), so it follows the
+no-build release variant from ADR-006: tag `main` directly via a GitHub
+Release — there is no `chore: release` branch, commit, or PR.
+
+1. Confirm the milestone's issues are all closed and `main` is green
+   (`py tests/run_smoke.py` passes) and up to date (`git pull`)
+2. Cut the release from `main` with a bare-version title and
+   auto-generated notes:
+   ```bash
+   gh release create vA.B.C --title vA.B.C --generate-notes
+   ```
+   This tags `main` at HEAD and publishes notes built from the PRs
+   merged since the previous tag
+3. Close the `vA.B.C` milestone once the release is published
+4. Add the session's `docs/dev-journal.md` entry **separately** — its
+   own `docs(journal): ...` PR with **no milestone**, not part of the
+   release
+
+Projects with a version manifest (`package.json`, `pyproject.toml`,
+etc.) instead follow the branch → bump → PR → merge → tag flow; see
+ADR-006 and `base/core/git.md`.


### PR DESCRIPTION
## What

Rewrites the PLAYBOOK "Release a new version" section, which still
described the abandoned `chore/release` branch + commit + PR + tag flow.

The repo (plain Markdown, no version manifest) follows ADR-006's
no-build variant, used for every release v2.14–v2.21:

- Cut a **GitHub Release** from `main` with a **bare-version title**
  (`vA.B.C`) and `--generate-notes` — this tags main at HEAD.
- **Close the milestone** once published.
- Add the **dev-journal** entry via its own `docs(journal)` PR with
  **no milestone**, separate from the release.

The chore-PR flow now points to where it actually applies — projects
with a version manifest (`base/core/git.md`, "Projects with a version
manifest").

## Scope

- `docs/PLAYBOOK.md` only. Template content (`git.md`,
  `static-site-tutorial.md`) already scopes the chore-PR flow correctly
  under the manifest variant per ADR-006 — left untouched.

## Validation

- `py tests/run_smoke.py` — 19/19 pass
- `py tools/sync.py --check` — all files in sync

Closes #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)