### PR TITLE
docs(infra): add build-once/deploy-via-hook CD pattern (#601)

### DIFF
--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2292,6 +2292,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2578,6 +2578,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2813,6 +2813,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2578,6 +2578,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2578,6 +2578,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3269,6 +3269,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3269,6 +3269,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2922,6 +2922,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-grpc-java.md
+++ b/generated/stack-grpc-java.md
@@ -2400,6 +2400,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2950,6 +2950,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2813,6 +2813,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2882,6 +2882,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2578,6 +2578,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -2761,6 +2761,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-sveltekit.md
+++ b/generated/stack-sveltekit.md
@@ -2618,6 +2618,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1526,6 +1526,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 

--- a/templates/base/infra/cicd.md
+++ b/templates/base/infra/cicd.md
@@ -64,6 +64,12 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
 - Health check endpoint MUST return healthy before traffic is routed to a
   new instance
 - Deploy small and often — large infrequent deployments increase risk
+- Trigger deploys with a post-publish hook — after the artifact is
+  published, the pipeline SHOULD trigger the deploy by sending the
+  artifact's immutable reference (image digest or tag) to the deploy
+  target, never rebuilding in the deploy step. This guarantees the
+  deployed artifact is the exact one that passed the gates (see
+  "Promote the same artifact" under Environment separation)
 
 ## Release record
 


### PR DESCRIPTION
## What

Adds a Deployment strategy rule to `base/infra/cicd.md`: after the
artifact is published, the pipeline triggers the deploy by sending the
artifact's **immutable reference** (image digest or tag) to the deploy
target — never rebuilding at deploy time. This guarantees the deployed
artifact is the exact one that passed the gates.

Proven downstream (randomgen, session 5). `cicd.md` already covered the
"same artifact across environments" principle under Environment
separation but not the post-publish hook *mechanism* — the new rule
references that principle rather than restating it.

## Scope

- One bullet under **Deployment strategy** in `base/infra/cicd.md`.
- Regenerated the 16 `generated/` chains that include `base-cicd`
  (backend services, full-stack, terraform).

## Validation

- `py tests/run_smoke.py` — 19/19 pass
- `py tools/sync.py --check` — all files in sync

Closes #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)