### PR TITLE
docs(api): add design-first OpenAPI source-of-truth pattern (#600)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3740,6 +3740,14 @@ Overridden by each framework stack. The common principle:
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1762,6 +1762,14 @@ DEBUG=false
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1762,6 +1762,14 @@ DEBUG=false
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-nextjs.md
+++ b/generated/stack-nextjs.md
@@ -2504,6 +2504,14 @@ DEBUG=false
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-spring-boot.md
+++ b/generated/stack-spring-boot.md
@@ -1710,6 +1710,14 @@ DEBUG=false
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/templates/backend/api.md
+++ b/templates/backend/api.md
@@ -34,6 +34,14 @@
 - Include: all resources, methods, parameters, response schemas, error responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
+- Prefer design-first: hand-author the spec as the single source of
+  truth and serve it verbatim — the published spec is the same file the
+  team edits, not one generated from code annotations
+- Pin the spec to code: assert that enums, routes, and error codes in
+  code match the spec so any drift fails a test, not a consumer
+- Contract-test the running API against the spec — generate cases from
+  the spec and run them against a live instance (e.g. Schemathesis) so
+  the implementation provably conforms to the published contract
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility


### PR DESCRIPTION
## What

Extends the **OpenAPI specification** section in `backend/api.md` with
the design-first pattern (proven downstream — randomgen, session 5):

- **Design-first** — hand-author the spec as the single source of truth
  and serve it verbatim; the published spec is the file the team edits,
  not one generated from code annotations.
- **Pin to code** — assert enums, routes, and error codes in code match
  the spec, so drift fails a test, not a consumer.
- **Contract-test** — generate cases from the spec and run them against
  a live instance (e.g. Schemathesis) so the implementation provably
  conforms to the published contract.

## Home decision (api.md vs http.md)

`api.md` — it already owns the OpenAPI specification + API-first
sections; co-locating keeps all OpenAPI guidance in one place (no
duplication / attention dilution). `http.md` is the lower transport
layer it depends on.

Reaches the 5 stacks that include `backend-api` (django, express,
nestjs, nextjs, spring-boot). **fastapi/flask are intentionally out of
scope** — fastapi has its own framework-native *code-first* OpenAPI
section (generated from Pydantic/route annotations) and does not depend
on the API-design layer; forcing design-first there would fight the
framework. That code-first vs design-first split is deliberate.

## Validation

- `py tests/run_smoke.py` — 19/19 pass
- `py tools/sync.py --check` — all files in sync

Closes #600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)