### PR TITLE
docs(examples): regenerate all examples to six-section format (#581)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,8 @@ base/ ──┬── frontend/ ──┐
    `depends_on`, `description`, `label`, and `layer` fields
 5. Run `py tools/sync.py` — updates SPEC.md, README.md, INTERVIEW.md
 6. Add an example in `examples/<name>/CLAUDE.md` if the stack is
-   concrete
+   concrete — generate it via the pipeline per ADR-016 (see PLAYBOOK
+   "Regenerate an example"); never hand-write it
 
 ### 2.6 Adding a new base or layer template
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -238,6 +238,31 @@ shell access can use them directly.
 
 ---
 
+## Regenerate an example
+
+Per ADR-016, the files in `examples/*/CLAUDE.md` are agent-generated
+outputs, not hand-maintained. When a template in an example's chain
+changes the output shape, regenerate the example — do not patch it by
+hand.
+
+1. Attach three inputs to a local agent:
+   - the existing `examples/<name>/CLAUDE.md` — for the project brief
+     (name, owner, repo, deployment, stack choices, architecture) to
+     preserve
+   - `generated/<stack>.md` — the resolved chain (the rules to apply);
+     read any addon templates the example's stack source names but the
+     chain does not include
+   - `templates/base/core/agents.md` — the output models (inline,
+     reference, or hybrid — keep the example's existing model)
+2. Ask the agent to regenerate `examples/<name>/CLAUDE.md` in the
+   six-section structure, keeping the concrete project identity and
+   recording the generation inputs in a note near the top.
+3. Verify: `py tests/run_smoke.py` (SYS-05 gates the §6.3 audit) and
+   review the diff for coherence. Byte-for-byte reproduction is not
+   expected — generation is non-deterministic.
+
+---
+
 ## Submit a pull request
 
 1. Ensure you are on a feature branch — never commit to `main` directly

--- a/examples/astro-portfolio/CLAUDE.md
+++ b/examples/astro-portfolio/CLAUDE.md
@@ -1,34 +1,44 @@
 # Maria Chen — Portfolio
 
-Personal portfolio and blog for a product designer. Showcases selected work,
-writing, and contact information.
+Personal portfolio and blog for a product designer — showcases
+selected work, writing, and contact information.
 
----
+- Owner: Maria Chen
+- Repo: github.com/mariachen/portfolio
+- Live URL: mariachen.design
+- Deployment: GitHub Pages via GitHub Actions on push to `main`
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/static-site-astro.md`
+> - Resolved chain: `generated/stack-astro.md` (base + frontend +
+>   static-site-astro)
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: Maria Chen — Portfolio — Maria Chen — Astro 4
+>   (output: static) / zero client-side JS / plain CSS with custom
+>   properties / JSON content in `src/data/` — npm, Prettier with
+>   `prettier-plugin-astro` — GitHub Pages via GitHub Actions
 
-- **Name**: maria-chen-portfolio
-- **Owner**: Maria Chen
-- **URL**: mariachen.design
-- **Deployment**: GitHub Pages via GitHub Actions on push to `main`
-- **Stack source**: `stack/static-site-astro.md`
-- **Output format**: `base/core/agents.md`
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Framework: Astro 4 (output: static)
-- Interactive components: none — zero client-side JS
+- Interactive components: none — zero client-side JS, no islands
 - CSS: plain CSS with custom properties — no framework
 - Content: JSON files in `src/data/`
+- Language: TypeScript (`.astro` frontmatter, build config)
 - Package manager: npm
 - Formatter: Prettier with `prettier-plugin-astro`
-- Deployment: GitHub Actions → GitHub Pages
+- Hosting: GitHub Pages, deployed via GitHub Actions on push to `main`
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 src/
@@ -50,115 +60,370 @@ src/
       index.astro           # All posts list
       [slug].astro          # Individual blog post
     contact.astro
+    404.astro               # Custom error page
   data/
     site.json               # Nav, hero text, social links, footer copy
-    projects.json           # Work items — title, slug, tags, image, description
-    posts.json              # Blog posts — title, slug, date, body (Markdown string)
+    projects.json           # Work items — title, slug, tags, image, body
+    posts.json              # Blog posts — title, slug, date, body
   styles/
-    global.css              # CSS custom properties, resets, typography scale
+    global.css              # CSS custom properties, resets, type scale
     tokens.css              # Colour, spacing, and font tokens
 public/
   images/
-    work/                   # Case study images — WebP, named by project slug
-    og/                     # Open Graph images — 1200×630 WebP
-  fonts/                    # Self-hosted variable fonts
+    work/                   # Case study images — WebP, named by slug
+    og/                     # Open Graph images — 1200x630 WebP
+  fonts/                    # Self-hosted variable fonts (woff2)
+  robots.txt
 astro.config.mjs
 prettier.config.mjs
+eslint.config.js
 package.json
 README.md
 CLAUDE.md
 ```
 
----
+- Separation of content and code — all editable content lives in
+  `src/data/` as JSON, never hardcoded in `.astro` files
+- One stylesheet pair — tokens in `tokens.css`, everything else in
+  `global.css`; no inline styles except dynamic/computed values
+- `src/content/` is intentionally avoided — Astro reserves that path
+  for Content Collections; migrate only when data outgrows JSON (see
+  2.4)
+- See `README.md` for the full project structure
 
-## Commands
+### 1.3 Commands
 
 ```bash
-npm run dev      # develop — hot reload at localhost:4321
-npm run build    # compile — production build to dist/
-npm run preview  # verify — preview the production build locally
+npm run dev      # astro dev — hot reload at localhost:4321
+npm run build    # astro build — production build to dist/
+npm run preview  # astro preview — serve production build locally
+npm run lint     # eslint .
+npm run format   # prettier --check .
+npm run check    # astro check — validate .astro files and types
+npm run validate # lint + format + check + build — full quality gate
 ```
 
----
+- `validate` composes the named scripts — each step is callable on
+  its own and as part of the full gate
+- Run `npm run build` (or `npm run validate`) locally before pushing —
+  a failing build MUST NOT reach `main`
 
-## Git conventions
+## 2. Code conventions
 
-- Branch: `main` (source of truth), deploys automatically on push
-- Commits: `<type>: <summary>` — types: content, style, fix, chore
-- Do not commit `dist/`, `node_modules/`, `.DS_Store`
-- Always run `npm run build` locally to verify no build errors before pushing
-- Do not commit unoptimised images — compress to WebP before adding to `public/`
+### 2.1 Git
 
----
+- Branch: `main` (source of truth) — deploys automatically on push;
+  never commit directly, always work on a branch
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `content/<scope>`,
+  `chore/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: content, feat, fix,
+  style, chore; subject under 80 characters, imperative mood
+- PRs are small and focused — one concern per PR
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new
+  work
+- Always run `npm run dev` (and `npm run build` for a release) before
+  committing
+- Do not commit `dist/`, `node_modules/`, or `.DS_Store`
+- Do not commit unoptimised images — compress to WebP before adding to
+  `public/`
+- Every repository MUST have a `.gitignore` and a committed lockfile
 
-## Code conventions
+### 2.2 Astro and TypeScript
 
-### Component rules
+- Default to `.astro` components — they are static by default, ship
+  zero JS
+- This site has no interactive components — never use a `client:*`
+  directive; all pages are fully static
+- One concern per component — layout, UI primitives, and page sections
+  are separate files
+- TypeScript `strict: true` — no exceptions; follow
+  `@typescript-eslint/recommended`
+- No `any` — use `unknown` and narrow, or define a proper type
+- Use `interface` for object shapes; `type` for unions and aliases;
+  no enums — use `as const` objects or string literal unions
+- Import types with `import type { ... }`; explicit return types on
+  non-trivial functions
+- MUST NOT use `set:html` — it bypasses Astro's escaping (the
+  `innerHTML` equivalent); use `{expression}` for text content. The
+  only acceptable exception is JSON-LD via `JSON.stringify()`, where
+  the input is fully server-controlled (see 3.4)
+- ESLint with `@typescript-eslint/recommended` and
+  `eslint-plugin-sonarjs` for any `.ts` files — configured in
+  `eslint.config.js`, run on save
+- Prettier owns all formatting — `.astro` files use the official
+  `prettier-plugin-astro`; no style debates in code review
+- Source files UTF-8, ASCII content only, LF line endings
 
-- Default to `.astro` components — zero JS shipped unless explicitly opted in
-- No client-side JavaScript — this site has no interactive components
-- Never use `client:*` directives — all pages are fully static
-- One concern per component — layout, UI primitives, and page sections are
-  separate files
+### 2.3 Content editing
 
-### Content editing
-
-- All editable text lives in `src/data/` JSON files — never hardcoded in `.astro`
+- All editable text lives in `src/data/` JSON files — never hardcoded
+  in `.astro`
 - To add a project: add an entry to `projects.json` and its images to
   `public/images/work/`
-- To add a post: add an entry to `posts.json` with the full Markdown body in
-  the `body` field
+- To add a post: add an entry to `posts.json` with the full Markdown
+  body in the `body` field
+- Never hardcode derived counts (project totals, post counts) — compute
+  them from the data source
 
 | File | Controls |
 |------|----------|
-| `src/data/site.json` | Nav links, hero text, footer copy, social links |
-| `src/data/projects.json` | Work items — title, slug, tags, thumbnail, body |
+| `src/data/site.json` | Nav links, hero text, footer copy, socials |
+| `src/data/projects.json` | Work items — title, slug, tags, image, body |
 | `src/data/posts.json` | Blog posts — title, slug, date, excerpt, body |
 
-### Styling
+### 2.4 Content Collections (when data outgrows JSON)
 
-- All design tokens in `src/styles/tokens.css` as CSS custom properties —
-  never use raw colour or spacing values in component styles
-- Mobile-first: base styles for mobile, `@media (min-width: 768px)` for tablet,
-  `@media (min-width: 1200px)` for desktop
-- No Tailwind, no CSS-in-JS, no utility frameworks — plain CSS only
-- Typography scale: use `--text-sm`, `--text-base`, `--text-lg`, etc. from tokens
-- Animation: a single `IntersectionObserver` in `BaseLayout.astro` handles
-  `.reveal` → `.reveal.visible` transitions — do not add per-component scripts
+- Migrate from `src/data/` JSON to Astro Content Collections when a
+  single file exceeds ~200 entries / ~500 lines, entries need rich
+  Markdown bodies, per-entry git diffs get hard to review, or a
+  non-developer needs to author content
+- Define collection schemas in `src/content.config.ts` using Zod;
+  every field that affects rendering or sorting MUST be in the schema
+- Use `z.enum()` for constrained values; mark optional fields with
+  `.optional()`
+- Query with `getCollection()` / `getEntry()` — never read files
+  directly; sort and filter in the page component, not the data files
+- The Zod schema MUST include a `description` field — layouts render
+  it as the meta, OG, and Twitter Card description (see 3.3)
 
-### Assets
+### 2.5 Styling
 
-- Images in `public/images/` — reference as `/images/filename.webp`
-- All images must be WebP format, compressed before committing
-- Provide `width` and `height` attributes on every `<img>` to prevent layout
-  shift
-- OG images in `public/og/` at 1200×630 — one per page
+- All design tokens in `src/styles/tokens.css` as CSS custom
+  properties — never use raw colour or spacing values in component
+  styles
+- All CSS in the global stylesheet pair — no inline styles except
+  dynamic/computed values, no CSS-in-JS, no utility frameworks
+- BEM-like naming: `.component-element` (e.g. `.hero-grid`,
+  `.nav-link`)
+- Mobile-first: base styles for mobile, `@media (min-width: 768px)`
+  for tablet, `@media (min-width: 1200px)` for desktop
+- Typography scale: use `--text-sm`, `--text-base`, `--text-lg`, etc.
+  from tokens
+- Self-host fonts as woff2 in `public/fonts/` with `@font-face` in CSS
+  and `font-display: block` — never depend on an external font CDN at
+  runtime
+- Animation: a single `IntersectionObserver` in `BaseLayout.astro`
+  handles `.reveal` -> `.reveal.visible` transitions — do not add
+  per-component scripts
+- Maximum line length 80 characters (exempt: prose strings,
+  third-party URLs)
 
----
+### 2.6 Assets
 
-## Design
+- Images in `public/images/` — reference as `/images/filename.webp`;
+  no assets outside `public/` — Astro only serves static files from
+  there
+- All images MUST be WebP, compressed before committing
+- Provide `width` and `height` attributes on every `<img>` to prevent
+  layout shift
+- OG images in `public/og/` at 1200x630 — one per page
+
+## 3. Quality
+
+### 3.1 Testing and quality gates
+
+- This is a content site with no business logic — the build is the
+  primary test: `npm run validate` (lint + format + check + build)
+  MUST pass before every PR
+- `astro check` validates `.astro` files, types, and any content
+  schemas — zero errors before merge
+- Quality gate map (editor -> pre-commit -> CI):
+
+| Category | Tool | Config |
+| --- | --- | --- |
+| Lint | ESLint | `eslint.config.js` |
+| Format | Prettier | `.prettierrc` |
+| Type check | `astro check` / `tsc --noEmit` | `tsconfig.json` |
+| Secrets | gitleaks (pre-commit + CI) | — |
+| Build | `astro build` | — |
+| Links | lychee (`--root-dir dist`) | `lychee.toml` |
+| Site quality | Lighthouse CI | `lighthouserc.json` |
+
+- Hook framework: `husky` + `lint-staged` — config in `package.json`
+- Lighthouse thresholds: accessibility >= 90 (error); performance,
+  SEO, best practices >= 90 (warn)
+- lychee MUST use `--root-dir dist` to resolve root-relative paths
+  (e.g. `/work`); without it every root-relative link reports a false
+  error
+
+### 3.2 Accessibility — WCAG 2.1 AA
+
+- Target standard: WCAG 2.1 AA; minimum text contrast 4.5:1 (normal),
+  3:1 (large)
+- Semantic HTML: correct landmark elements and a single, ordered
+  heading hierarchy per page
+- Every `<img>` has descriptive `alt`; decorative images use `alt=""`
+- Icon-only or ambiguous links MUST have a descriptive `aria-label`
+- All `<a>` and nav links MUST have a visible `:focus-visible` outline
+  — use `:focus-visible`, not `:focus`
+- No content relies on colour alone to convey meaning
+- Lighthouse accessibility score >= 90 on every page (CI error)
+
+### 3.3 SEO
+
+- `robots.txt` required, and it MUST allow answer-engine crawlers
+  (OAI-SearchBot, ChatGPT-User, PerplexityBot, Claude-SearchBot /
+  Claude-User, Applebot)
+- `@astrojs/sitemap` MUST be installed as an Astro integration —
+  generates the sitemap at build time, referenced in `robots.txt`
+- Open Graph and Twitter Card meta tags required; canonical URL
+  required on every page
+- Every page MUST have a unique `description` — used for
+  `<meta name="description">`, OG description, and Twitter Card; write
+  it as a pitch ("why should I click?"), not a summary
+- If `og:image` is present, `twitter:image` MUST also be present;
+  include `og:image:width` / `og:image:height` (1200x630)
+- H1 is unique per page and reflects its content; H1 keywords appear
+  in the page body
+- Privacy-friendly analytics only — no consent banner, no third-party
+  tracking scripts without explicit consent
+
+### 3.4 Structured data
+
+- JSON-LD SHOULD be present on content pages in a
+  `<script type="application/ld+json">` tag in the layout — render via
+  `JSON.stringify()` with `set:html` (the acceptable exception to the
+  `set:html` ban, since the input is server-controlled)
+- Schema `@type` MUST match the page's actual role — use `Person` for
+  the about/home, `CreativeWork` or `Article` for case studies and
+  posts; do not use commerce types (`Product`, `Offer`) on an
+  editorial portfolio
+
+### 3.5 Performance and deployment
+
+- Static generation by default — no client-side rendering
+- Preload critical above-the-fold assets (hero image, primary font);
+  defer any non-critical scripts
+- Keep shipped JS at zero — the only script is the shared
+  `IntersectionObserver` reveal handler
+- Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
+- Trailing slash: GitHub Pages forces trailing slashes — set
+  `trailingSlash: "always"` in `astro.config.mjs` and enforce it across
+  internal links, canonical URLs, and sitemap entries
+
+## 4. Identity
+
+### 4.1 Design
 
 - Palette: off-white `#F9F8F6` background, near-black `#1A1A18` text,
-  sage green `#6B8F71` accent
-- Typography: "DM Sans" (variable, self-hosted) for body; "DM Serif Display"
-  for headings
+  sage green `#6B8F71` accent — all defined as tokens in `tokens.css`
+- Typography: "DM Sans" (variable, self-hosted) for body; "DM Serif
+  Display" for headings
 - Spacing scale: 4px base unit — spacing tokens in `tokens.css`
-- Aesthetic: editorial, airy, generous whitespace — no heavy borders or shadows
+- Aesthetic: editorial, airy, generous whitespace — no heavy borders
+  or shadows
+- Never hardcode visual values — colour, spacing, and type always come
+  from the tokens
 
----
-
-## Brand voice
+### 4.2 Brand voice
 
 - Tone: warm, direct, thoughtful — never corporate or salesy
 - Write in first person — "I designed", "I led", not "The designer"
-- Project descriptions: lead with the problem, then the approach, then the
-  outcome — no jargon
-- Blog posts: conversational but substantive — aim for clarity over cleverness
+- Project descriptions lead with the problem, then the approach, then
+  the outcome — no jargon
+- Blog posts: conversational but substantive — aim for clarity over
+  cleverness
+- Lead each page section with a direct answer and keep paragraphs
+  self-contained — answer engines retrieve passages, not whole pages
 
----
+## 5. Review process
 
-## Documentation
+### 5.1 Code review
 
-- Single source of truth: this file + inline comments in complex `.astro` files
-- `README.md`: local setup steps and content editing guide only
-- No external wiki or docs site
+Before merging, review the diff against the base branch in priority
+order (highest first):
+
+1. Correctness — content lives in `src/data/`, no hardcoded copy or
+   counts; no `client:*` directives; `width`/`height` on every image
+2. Accessibility — semantic HTML, alt text, `:focus-visible` outlines,
+   contrast holds; Lighthouse a11y >= 90
+3. Clarity — names self-documenting, one concern per component
+4. Conventions — ESLint and Prettier clean, no `set:html` (except
+   server-controlled JSON-LD), tokens used for all visual values,
+   lines under 80 characters
+
+Confirm CI is green. Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `npm run validate` before every PR (lint + format + check +
+  build)
+- Verify `robots.txt`, the generated sitemap, canonical URLs, and a
+  unique `description` exist for every page
+- Verify every internal link uses a trailing slash and resolves under
+  `dist/` (lychee with `--root-dir dist`)
+- Verify `README.md` documents the commands and the content-editing
+  guide
+- Run the audit after: new project, a new page type, a Content
+  Collections migration, or before a release
+
+## 6. Session protocol
+
+Follow `templates/base/workflow/scope.md` for scope guard and
+end-of-session audit.
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first
+   change
+2. Check the current branch — if not `main`, ask why before proceeding
+3. Check `git status` — if uncommitted changes exist, ship the
+   previous session's wrap (branch, commit, push, merge) before any
+   new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check deploy health — verify the latest GitHub Pages deploy on
+   `main` completed successfully; flag if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable
+   for this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over
+  starting something new
+- Run `npm run dev` (and `npm run build` for build-affecting changes)
+  after every change — do not accumulate unverified changes
+- When a tool (formatter, codemod, image optimiser) touches unrelated
+  files, revert the drift before committing and file it separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result)
+before moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a
+   new directory or content move between documents each needs an ADR
+6. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep
+   each rule to one line
+7. README.md — for each new command, dependency, or structural change,
+   confirm it is reflected; name the section
+8. docs/ONBOARDING.md — for each new tool, prerequisite, or setup step,
+   confirm it is documented; name the section
+9. docs/PLAYBOOK.md — for each new command, script, or workflow,
+   confirm it is documented; name the section
+10. Content and assets — confirm new images are WebP and compressed,
+    and any new page has a unique `description`, canonical URL, and OG
+    image
+11. Build and quality gate — run `npm run validate` and confirm it
+    passes
+12. Flag gaps — if any item cannot be completed this session, report it
+    as pending (never as done) before closing
+13. Summary — summarize what was done and what is next

--- a/examples/fastapi-service/CLAUDE.md
+++ b/examples/fastapi-service/CLAUDE.md
@@ -2,21 +2,32 @@
 
 REST API for managing tasks, projects, and team assignments.
 
----
+- Owner: Platform team
+- Repo: github.com/acme/taskflow-api
+- Deployment: Docker image (GHCR) -> Railway (production), Docker
+  Compose (local)
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/python-fastapi.md` + `backend/auth.md` +
+>   `backend/caching.md`
+> - Resolved chain: `generated/stack-fastapi.md` (base + backend +
+>   python-fastapi)
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: TaskFlow API — Platform team — Python 3.12 /
+>   FastAPI / Pydantic v2 / SQLAlchemy 2 async + Alembic / Redis —
+>   uv, ruff, mypy strict, pytest — Docker on Railway
 
-- **Name**: TaskFlow API
-- **Owner**: Platform team
-- **Repo**: github.com/acme/taskflow-api
-- **Deployment**: Docker → Railway (production), Docker Compose (local)
-- **Stack source**: `stack/python-fastapi.md` + `backend/auth.md` + `backend/caching.md`
-- **Output format**: `base/core/agents.md`
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: Python 3.12
 - Framework: FastAPI
 - Runtime: asyncio (async/await throughout)
@@ -25,22 +36,21 @@ REST API for managing tasks, projects, and team assignments.
 - Linter / formatter: ruff + ruff format
 - Type checker: mypy (strict mode)
 - Test runner: pytest + httpx (AsyncClient)
-- Database: PostgreSQL 16 via SQLAlchemy 2 async + Alembic
+- ORM: SQLAlchemy 2.x async + Alembic migrations
+- Database: PostgreSQL 16 via `asyncpg`
 - Cache: Redis 7 via `redis-py` async client
 - ASGI server (production): uvicorn + gunicorn
-- Deployment: Docker image pushed to GHCR, deployed on Railway
+- Distribution: Docker image pushed to GHCR, deployed on Railway
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 src/
   taskflow/
     __init__.py
     main.py              # FastAPI app, lifespan, router includes
-    config.py            # pydantic-settings BaseSettings
-    dependencies.py      # Shared Depends() — db session, current user, cache
+    config.py            # Settings via pydantic-settings
+    dependencies.py      # Shared Depends() — db session, user, cache
     routers/
       tasks.py           # /tasks endpoints
       projects.py        # /projects endpoints
@@ -76,129 +86,313 @@ README.md
 CLAUDE.md
 ```
 
----
+- One directory per feature domain — not one directory per layer
+- `services/<feature>.py` holds business logic with no framework imports
+- All editable config in `config.py` — never hardcoded in source modules
 
-## Commands
+### 1.3 Commands
 
 ```bash
-uv run uvicorn taskflow.main:app --reload   # develop — hot reload at :8000
+uv run uvicorn taskflow.main:app --reload   # develop — hot reload :8000
 uv run alembic upgrade head                 # apply migrations
 uv run alembic revision --autogenerate -m "describe change"
 uv run pytest                               # run tests
 uv run mypy src/ --strict                   # type check
-uv run gunicorn taskflow.main:app -w 4 -k uvicorn.workers.UvicornWorker
+uv run ruff check src/ tests/               # lint
+uv run ruff format src/ tests/              # format
+uv run gunicorn taskflow.main:app -w 4 \
+  -k uvicorn.workers.UvicornWorker          # production server
 docker compose up                           # start full stack locally
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Branch: `main` (protected), feature branches as `feat/<scope>`, fixes as `fix/<scope>`
-- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, docs, test, refactor
-- PRs require one approval and passing CI before merge
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`,
+  `docs/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
+  docs, refactor, test; subject under 80 characters, imperative mood
+- PRs are small and focused — one concern per PR; require one approval
+  and passing CI before merge
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new work
 - Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`, `dist/`
-- Alembic migrations are committed — never regenerate a migration already merged
+- Alembic migrations are committed — never regenerate a migration
+  already merged
+- Every repository MUST have a `.gitignore` and a committed lockfile
 
----
+### 2.2 Python
 
-## Code conventions
+- Follow PEP 8 (enforced by ruff) — fix the code, never disable a rule
+  to work around style
+- Follow PEP 257 Google-style docstrings — every public symbol has one
+- Follow PEP 484 / PEP 526 type annotations — all public functions and
+  class members annotated; run `mypy src/ --strict`
+- No bare `Any` — use specific types, `TypeVar`, or `TypeAlias`
+- Use `from __future__ import annotations` for forward references
+- Keep functions small and single-purpose; cognitive complexity <= 15
+- Raise specific exceptions — never bare `except:` or `except Exception:`
+- No mutable default arguments
+- No debug statements (`print()`, `pdb.set_trace()`) in committed code
+- Source files UTF-8, ASCII content only, LF line endings
 
-### Application setup
+### 2.3 Application setup
 
 - One `FastAPI` instance in `main.py` — no global state elsewhere
-- Use `lifespan` context manager for startup/shutdown hooks
-- `title`, `version`, and `description` set on the app instance
-- All routers registered via `app.include_router()` in `main.py`
+- Use the `lifespan` context manager for startup/shutdown — not
+  deprecated event handlers
+- Initialise the database engine and Redis client in `lifespan`, not at
+  module level
+- Set `title`, `version`, and `description` on the app instance
+- Register all routers via `app.include_router()` in `main.py`
 
-### Configuration
+### 2.4 Configuration
 
-- `pydantic-settings` `BaseSettings` in `config.py`
-- `Settings` instantiated once, injected as `Depends(get_settings)` — never imported globally
-- `.env.example` committed; `.env` in `.gitignore`
-- Required vars: `DATABASE_URL`, `SECRET_KEY`, `REDIS_URL`, `ALLOWED_ORIGINS`
-- Fail fast on startup if any required var is missing
+- `pydantic-settings` `BaseSettings` in `config.py` — reads from the
+  environment automatically
+- One `Settings` class, instantiated once at startup, injected via
+  `Depends(get_settings)` — never imported as a global in service code
+- `.env.example` committed with placeholders; `.env` in `.gitignore`
+- Required vars: `TASKFLOW_DATABASE_URL`, `TASKFLOW_SECRET_KEY`,
+  `TASKFLOW_REDIS_URL`, `TASKFLOW_ALLOWED_ORIGINS`
+- Prefix every env var with `TASKFLOW_` to avoid collisions
+- Fail fast: a missing required setting raises `ValidationError` on
+  startup
+- The port MUST be configurable via environment variable — never
+  hardcoded
 
-### Routing
+### 2.5 Routing and HTTP
 
-- One `APIRouter` per feature domain, prefixed and tagged
-- Routes thin — delegate all business logic to service functions
-- Auth, DB session, current user via `Depends()` with `Annotated` syntax
-- Return type annotations on all route handlers
+- One `APIRouter` per feature domain, with a prefix and tags
+- Handlers are thin: decode request -> call service -> encode response;
+  no business logic in handlers
+- Inject auth, DB session, and current user via `Depends()` using
+  `Annotated` syntax — avoid bare `= Depends()` in signatures
+- Return type annotations on all route handlers — FastAPI uses them for
+  OpenAPI
+- Path segments MUST be lowercase plural nouns with hyphens:
+  `/tasks`, `/projects/{projectId}/tasks` — no verbs, no trailing slash
+- Query parameter names use camelCase; reserve `limit`, `skip`,
+  `offset`, `expand`, `sortedBy` for framework use
+- No unbounded list endpoints — always paginate with an explicit limit
+- JSON is the default format; date/time values use ISO 8601
+- All traffic served over HTTPS — plain HTTP is not acceptable
 
-### Schemas
+### 2.6 Schemas
 
-- Separate request and response schemas — ORM models never returned directly
-- `model_config = ConfigDict(from_attributes=True)` on ORM-backed response schemas
-- `Field(...)` for all validation constraints (min/max, regex, ge/le)
-- No bare `Any` — all fields explicitly typed
+- Separate request and response schemas — ORM models are never returned
+  directly
+- `model_config = ConfigDict(from_attributes=True)` on ORM-backed
+  response schemas
+- All fields explicitly typed — no bare `Any`
+- `Field(...)` for all validation constraints (min/max length, regex,
+  ge/le)
+- Validators via `@field_validator` — no custom `__init__`
+- Responses contain only the fields the caller needs — no padding
 
-### Error handling
+### 2.7 Error handling
 
 - Raise `HTTPException` with explicit `status_code` and `detail`
-- Domain exceptions mapped to HTTP errors via custom exception handlers in `main.py`
-- Errors logged with request ID for traceability
+- Map domain exceptions to HTTP errors via custom exception handlers
+  registered in `main.py`
+- Follow RFC 9457 (`application/problem+json`) for the error body shape;
+  use 4xx for client errors, 5xx for server errors — never 200 for an error
+- Never return stack traces, internal paths, or implementation details
+  to the client
+- Log every error once with the request ID for traceability
 
-### Authentication
+### 2.8 Authentication and authorization
 
-- JWT bearer tokens — issued at `/users/login`, validated via `Depends(get_current_user)`
-- Tokens stored in `Authorization: Bearer <token>` header only — never in cookies or query params
-- Role checked in service layer, not in route handlers
-- Token expiry: 15 min access, 7 day refresh
+- JWT bearer tokens — issued at `/users/login`, validated via
+  `Depends(get_current_user)`
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens
+  missing any required claim
+- Token lifetime: access <= 15 min, refresh <= 7 days (rotated on use)
+- Access tokens MUST arrive in `Authorization: Bearer <token>` only —
+  never in cookies or query parameters
+- Refresh tokens stored server-side (Redis) so they can be revoked, and
+  in `httpOnly`, `Secure`, `SameSite=Strict` cookies on the client
+- Fail closed: deny by default, grant explicitly
+- Authorise at the service layer, not only in route handlers — a route
+  that passes auth may call a service that touches another user's data
+- Never trust client-supplied IDs for ownership checks — verify the
+  authenticated user owns the requested resource
+- Never log tokens, passwords, or secrets — even at DEBUG level
 
-### Caching
+### 2.9 Caching
 
-- Cache-aside pattern for read-heavy endpoints (project lists, user profiles)
-- Cache keys: `taskflow:<resource>:<id>` — namespaced, never bare IDs
-- TTL: 5 min for lists, 15 min for single resources
-- Invalidate on write — delete affected keys after a successful mutation
-- Never cache responses that contain user-specific data without scoping the key
+- Cache-aside (lazy loading) pattern for read-heavy endpoints (project
+  lists, user profiles)
+- Cache keys namespaced: `taskflow:<entity>:<id>` — e.g.
+  `taskflow:projects:42` — never bare IDs, never from unvalidated input
+- Every entry has a TTL: 5 min for list responses, 15 min for single
+  resources
+- Invalidate on write — `DEL` affected keys after a successful mutation;
+  prefer targeted deletes over `FLUSHDB`
+- Never cache secrets, tokens, PII, or real-time data; never cache
+  user-specific data without scoping the key
+- Cache failures MUST NOT crash the app — on miss or error, fall through
+  to PostgreSQL
 
-### Database
+### 2.10 Database
 
-- SQLAlchemy 2.x with async engine (`create_async_engine`)
-- Session injected per request via `Depends(get_db)` — never a global session
-- Migrations managed by Alembic — one migration per logical change
-- `select()` style queries only — no legacy `Query` API
+- SQLAlchemy 2.x with async engine (`create_async_engine`) and `asyncpg`
+- Session injected per request via `Depends(get_db)` — never a global
+  session; use the connection pool, never a connection per request
+- `select()` style queries only — no legacy `Query` API; avoid
+  `SELECT *`
 - No N+1 queries — use `selectinload` or `joinedload` for related data
-- Foreign key indexes added explicitly in migrations
+- Add an index for every foreign key explicitly in migrations
+- Wrap multi-step writes in a transaction; keep transactions short and
+  never hold one across an HTTP request boundary
+- All schema changes via Alembic — one migration per logical change,
+  each reversible with a `down`
 
-### Async conventions
+### 2.11 Async conventions
 
-- All route handlers and service functions `async def`
-- Blocking I/O runs in `asyncio.to_thread()`
-- `asyncio.gather()` for concurrent independent awaits — not sequential awaits in a loop
+- All route handlers and service functions are `async def`
+- Blocking I/O runs in `asyncio.to_thread()` — never block the event loop
+- Use `asyncio.gather()` for concurrent independent awaits — never
+  `await` inside a list comprehension or a sequential loop
+- Use structured concurrency (`asyncio.TaskGroup`) over fire-and-forget;
+  background tasks started in `lifespan` get a clean shutdown path
+- Pass request context (request ID, user identity) explicitly — never
+  via thread-locals
 
----
+## 3. Quality
 
-## Testing
+### 3.1 Testing
 
-- `httpx.AsyncClient` with `ASGITransport` for all route tests
-- Test DB: isolated PostgreSQL schema, truncated between test runs
-- No database mocking — integration tests use a real test database
-- `app.dependency_overrides` for injecting test fixtures
-- Name tests: `test_<function>_<state>_<expected>`
-  - e.g. `test_create_task_missing_title_returns_422`
-- Each route tested for: 2xx success, 422 validation error, 401/403 auth error
+- `httpx.AsyncClient` with `ASGITransport` for all route tests — no sync
+  `TestClient`
+- One async `client` fixture in `conftest.py`; override dependencies via
+  `app.dependency_overrides`
+- Test DB is a real PostgreSQL schema, truncated between runs — no
+  database mocking, no SQLite substitution
+- Test each endpoint for: success (2xx), validation error (422), auth
+  error (401/403), not found (404)
+- Test naming: `test_<route_or_function>_<state>_<expected>` —
+  e.g. `test_create_task_missing_title_returns_422`
 - Unit tests in `tests/unit/`, integration tests in `tests/integration/`
+- New code MUST reach 90% coverage; total coverage MUST NOT regress and
+  SHOULD stay at or above 80%
 - Run before every commit: `pytest && mypy src/ --strict`
 
----
+### 3.2 Observability
 
-## Observability
+- Structured JSON logs (`structlog`) with the request ID injected per
+  request; default level INFO — DEBUG/TRACE off in production
+- Log errors once, at the top of the call stack; 4xx at INFO, 5xx at
+  ERROR
+- Never log passwords, tokens, API keys, or PII
+- `/health` — shallow liveness check, returns 200 if the process is
+  alive; requires no authentication
+- `/ready` — deep readiness check, verifies PostgreSQL and Redis
+  connectivity, returns 503 when a critical dependency is down
+- Assign a trace ID at the service boundary, propagate it via the W3C
+  `traceparent` header, and return it on errors (`X-Trace-Id`)
+- Instrument with OpenTelemetry; expose Prometheus metrics at `/metrics`
+  (request count, latency, error rate); span names use route templates,
+  not URLs with IDs
 
-- Structured JSON logs — `structlog` with request ID injected per request
-- Log levels: DEBUG (dev only), INFO (normal ops), WARNING (degraded), ERROR (failures)
-- Never log passwords, tokens, or PII
-- `/health` — shallow liveness check (returns 200 if process is alive)
-- `/ready` — deep readiness check (verifies DB + Redis connectivity)
-- Prometheus metrics exposed at `/metrics` (request count, latency, error rate)
+## 4. Identity
 
----
+Not applicable — TaskFlow API is a backend service with no design system
+or brand voice. Its public contract is the OpenAPI schema served at
+`/docs` (disabled in production via `openapi_url=None`).
 
-## Documentation
+## 5. Review process
 
-- Single source of truth: this file + OpenAPI at `/docs` (disabled in production)
-- All routes have `summary`, `tags`, and explicit `response_model`
-- Architecture decisions recorded in `docs/adr/` as numbered Markdown files
-- `README.md`: setup steps, env var reference, and common commands only
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority order
+(highest first):
+
+1. Security — auth enforced at the service layer, no secrets or PII in
+   logs, HTTPS-only, no client-trusted ownership checks
+2. Correctness — routes thin, services pure-async, no N+1 queries,
+   transactions scoped correctly, cache invalidation on write
+3. Clarity — names are self-documenting, functions single-purpose,
+   cognitive complexity <= 15
+4. Conventions — PEP 8 / mypy strict clean, schema separation, RFC 9457
+   error shape, URI and query-parameter casing rules
+
+Confirm CI is green. Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `pytest && mypy src/ --strict` before every PR
+- Verify `.env.example` lists every required variable and `README.md`
+  documents the env reference and commands
+- Verify every route has `summary`, `tags`, and an explicit
+  `response_model`, and that new endpoints have success / 422 / auth /
+  404 tests
+- Run the audit after: new project, migration, a new feature domain, or
+  before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first change
+2. Check the current branch — if not `main`, ask why before proceeding
+3. Check `git status` — if uncommitted changes exist, ship the previous
+   session's wrap (branch, commit, push, merge) before any new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest CI/CD deploy on `main` completed successfully — flag
+   if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable for
+   this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over starting
+  something new
+- Run `pytest && mypy src/ --strict` after every change — do not
+  accumulate unverified changes
+- When a tool (formatter, codemod, migration autogenerate) touches
+  unrelated files, revert the drift before committing and file it
+  separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result) before
+moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a new
+   directory or content move between documents each needs an ADR
+6. Migrations — confirm every schema change has a reversible Alembic
+   migration committed and applied (`alembic upgrade head`)
+7. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep each
+   rule to one line
+8. README.md — for each new command, dependency, or env var, confirm it
+   is reflected; name the section
+9. docs/ONBOARDING.md — for each new tool, prerequisite, or setup step,
+   confirm it is documented; name the section
+10. docs/PLAYBOOK.md — for each new command, script, or workflow,
+    confirm it is documented; name the section
+11. Tests and types — run `pytest && mypy src/ --strict` and confirm
+    both pass
+12. Flag gaps — if any item cannot be completed this session, report it
+    as pending (never as done) before closing
+13. Summary — summarize what was done and what is next

--- a/examples/flask-api/CLAUDE.md
+++ b/examples/flask-api/CLAUDE.md
@@ -3,35 +3,47 @@
 REST API for warehouse inventory management — stock levels, locations,
 suppliers, and purchase orders.
 
----
+- Owner: Warehouse platform team
+- Repo: github.com/acme/inventory-api
+- Deployment: Docker image -> Fly.io (production), Docker Compose (local)
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/python-flask.md` + `backend/auth.md` +
+>   `backend/jobs.md`
+> - Resolved chain: `generated/stack-flask.md` (base + backend +
+>   python-flask). The auth and jobs addons are register-only in the
+>   chain, so their rules are inlined here directly from
+>   `templates/backend/auth.md` and `templates/backend/jobs.md`,
+>   specialized to InventoryAPI.
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: InventoryAPI — Warehouse platform team — Python 3.12
+>   / Flask 3.x / SQLAlchemy 2 + Flask-Migrate (Alembic) / PostgreSQL /
+>   Celery + Redis — uv, ruff, mypy strict, pytest — Docker on Fly.io
 
-- **Name**: InventoryAPI
-- **Owner**: Warehouse platform team
-- **Repo**: github.com/acme/inventory-api
-- **Deployment**: Docker → Fly.io (production), Docker Compose (local)
-- **Stack source**: `stack/python-flask.md` + `backend/auth.md` + `backend/jobs.md`
-- **Output format**: `base/core/agents.md`
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: Python 3.12
 - Framework: Flask 3.x
 - Package manager: uv
 - Linter / formatter: ruff + ruff format
 - Type checker: mypy (strict mode)
 - Test runner: pytest + pytest-flask
-- Database: PostgreSQL 16 via SQLAlchemy 2 + Flask-Migrate (Alembic)
-- Task queue: Celery 5 with Redis broker
+- ORM: SQLAlchemy 2.x + Flask-Migrate (Alembic) migrations
+- Database: PostgreSQL 16
+- Task queue: Celery 5 with a Redis broker
 - WSGI server (production): gunicorn
-- Deployment: Docker image, deployed on Fly.io
+- Distribution: Docker image, deployed on Fly.io
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 src/
@@ -44,7 +56,7 @@ src/
         __init__.py
         routes.py        # /api/v1/stock
         models.py        # StockItem, Location
-        schemas.py       # marshmallow or dataclass schemas
+        schemas.py       # marshmallow / dataclass schemas
         services.py      # business logic
       suppliers/
         routes.py        # /api/v1/suppliers
@@ -69,114 +81,273 @@ tests/
   integration/
     test_order_workflow.py
 pyproject.toml
-.env.example
+.env.example             # committed — never .env
 Dockerfile
 docker-compose.yml
 README.md
 CLAUDE.md
 ```
 
----
-
-## Commands
+### 1.3 Commands
 
 ```bash
 flask run                           # develop — hot reload
 flask db upgrade                    # apply migrations
-flask db migrate -m "description"   # generate migration
-celery -A inventory.celery worker   # start Celery worker (local)
+flask db migrate -m "description"   # generate a migration
+celery -A inventory.celery worker   # start a Celery worker (local)
 pytest                              # run tests
 mypy src/ --strict                  # type check
 gunicorn "inventory:create_app()"   # production server
 docker compose up                   # full local stack (Flask + Postgres + Redis)
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Branch: `main` (protected), feature branches as `feat/<scope>`, fixes as `fix/<scope>`
-- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, docs, test, refactor
-- PRs require one approval and passing CI before merge
-- Do not commit `.env`, `instance/`, `*.db`, `__pycache__/`, `.mypy_cache/`
+- Branch: `main` is protected — never commit directly; feature branches
+  as `feat/<scope>`, fixes as `fix/<scope>`, also `chore/`, `docs/`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, docs,
+  refactor, test; imperative mood, subject under 80 characters
+- PRs are small and focused — one concern per PR; require one approval
+  and green CI before merge
+- Repeat the closing keyword per issue: `Closes #a, closes #b` — a bare
+  `#b` does not close
+- Never force-push, including `--force-with-lease`; when a branch is
+  behind, merge `main` in or use `gh pr update-branch`
+- After merge, delete the remote and local branch, then pull `main`
+- Do not commit `.env`, `instance/`, `*.db`, `__pycache__/`,
+  `.mypy_cache/`
 - Migrations are committed — never regenerate a migration already merged
 
----
+### 2.2 Python
 
-## Code conventions
+- Target Python 3.12; type hints on every function signature, `mypy
+  --strict` clean with no `# type: ignore` without a reason comment
+- Format and lint with ruff + ruff format — generated and hand-written
+  code MUST pass natively, never rely on `--fix` as a post-step
+- Names are the primary documentation: verbs for functions, nouns for
+  classes, `is`/`has`/`can` for booleans; no single-letter names except
+  loop counters and `e` in `except`
+- Cognitive complexity <= 15 per function; max nesting depth three —
+  use early returns and guard clauses over `else` branches
+- No boolean flag parameters — use an enum or two named functions
+- Magic numbers and strings MUST be named constants
+- No debug statements (`print`, `pdb.set_trace`), no commented-out code,
+  no dead code paths in committed code
+- Source files are UTF-8, ASCII-only content, LF line endings
 
-### Application factory
+### 2.3 Application factory
 
-- `create_app(config=None)` in `inventory/__init__.py`
-- All blueprints and extensions registered inside `create_app`
-- Extensions instantiated in `extensions.py`, initialised with `ext.init_app(app)`
-- No global `app` object used outside of `create_app`
+- `create_app(config=None)` lives in `inventory/__init__.py`
+- Register all blueprints and extensions inside `create_app`
+- Extensions instantiated in `extensions.py`, initialised with
+  `ext.init_app(app)`
+- Never use a global `app` object outside `create_app`
 
-### Configuration
+### 2.4 Configuration
 
-- Three config classes in `config.py`: `DevelopmentConfig`, `TestingConfig`,
-  `ProductionConfig`
-- All env-specific values from environment variables — no hardcoded secrets
-- `DEBUG=False` enforced in `ProductionConfig`
-- Required vars: `DATABASE_URL`, `SECRET_KEY`, `REDIS_URL`, `CELERY_BROKER_URL`
+- Three config classes in `config.py`: `DevelopmentConfig`,
+  `TestingConfig`, `ProductionConfig`
+- All env-specific values come from environment variables — no hardcoded
+  secrets, no real values as defaults
+- `FLASK_DEBUG` / `DEBUG` MUST be `False` in `ProductionConfig`
+- Required vars: `DATABASE_URL`, `SECRET_KEY`, `REDIS_URL`,
+  `CELERY_BROKER_URL` — all documented in `.env.example`
 
-### Blueprints
+### 2.5 Blueprints
 
 - One blueprint per domain (`stock`, `suppliers`, `orders`, `auth`)
-- All registered with a URL prefix: `/api/v1/stock`, `/api/v1/suppliers`, etc.
+- Each registered with a URL prefix: `/api/v1/stock`,
+  `/api/v1/suppliers`, `/api/v1/orders`, `/auth`
 - No cross-blueprint imports — shared logic goes in a service module
-- Routes are thin: decode input, call service, return response
+- Routes are thin: decode and validate input, call a service, encode the
+  response; no business logic in handlers
+- Use `abort()` with explicit HTTP status codes rather than raising raw
+  exceptions
+- Path segments lowercase with hyphens, plural collection nouns, no
+  trailing slash; query-parameter names camelCase, used only for
+  filtering, sorting, and pagination
 
-### Authentication
+### 2.6 Authentication
 
 - JWT bearer tokens — issued at `/auth/token`, verified via a decorator
-- Token expiry: 15 min access, 7 day refresh
-- Role stored in JWT claims — checked in service functions, not route handlers
+  in `auth/middleware.py`
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject a token
+  missing any required claim
+- Token lifetime: access <= 15 min, refresh <= 7 days (rotated on use)
+- Access tokens MUST arrive in `Authorization: Bearer <token>` only —
+  never in query parameters
+- Refresh tokens stored server-side (Redis) so they can be revoked, and
+  in `httpOnly`, `Secure`, `SameSite=Strict` cookies on the client
+- HTTPS required for every authenticated endpoint — no exceptions
+- Fail closed: deny by default, grant explicitly
+- Roles stored in JWT claims; authorise at the service layer, not only
+  in route handlers — a route that passes auth may call a service that
+  touches another user's data
+- Never trust client-supplied IDs for ownership checks — verify the
+  authenticated user owns the requested resource
+- Log auth failures at WARN with IP, user agent, and username; never log
+  tokens, passwords, or secrets even at DEBUG
 
-### Database
+### 2.7 Database
 
-- SQLAlchemy 2 ORM — no raw SQL strings
-- Migrations via Flask-Migrate (Alembic) — one migration per logical change
-- `select()` style queries — no legacy `Query` API
+- SQLAlchemy 2.x ORM — no raw SQL strings; `select()` style queries
+  only, no legacy `Query` API, avoid `SELECT *`
+- Migrations via Flask-Migrate (Alembic) — one migration per logical
+  change, each reversible with a `down`
 - No N+1 queries — use `selectinload` or `joinedload` for relations
-- Foreign key indexes added explicitly in migrations
+- Add an index for every foreign key explicitly in migrations
+- Wrap multi-step writes in a transaction; keep transactions short and
+  never hold one across an HTTP request boundary
+- Use the connection pool with explicit limits — never a connection per
+  request, never a global session handle
 
-### Background tasks (Celery)
+### 2.8 Background tasks
 
-- Tasks defined in `tasks.py` per blueprint — keep task functions thin,
-  delegate to service functions
-- All tasks are idempotent — safe to re-run on retry
-- Retry with exponential backoff — max 3 retries then route to DLQ
-- Log task start, completion, and failure with task ID and correlation ID
+- Celery tasks defined in `tasks.py` per blueprint — handlers are thin,
+  delegating to the same service functions the HTTP layer uses; no
+  parallel logic paths and no direct DB access in a handler
+- Every task MUST be idempotent — safe to re-run; use a dedup key
+  (`job_id`, `event_id`) and design for at-least-once delivery
+- Retry with exponential backoff and jitter; cap retries at 3, then
+  route to a dead-letter queue — never silently drop a failed job
+- Log task start and completion at INFO and failures at ERROR with the
+  task ID, attempt number, and correlation ID
+- Scheduled jobs are defined in code (schedule-as-code), run as a single
+  instance via a distributed lock, with documented frequency and latency
+- Track task duration, queue depth, and DLQ depth as metrics; alert when
+  queue or DLQ depth indicates worker starvation
 
----
+## 3. Quality
 
-## Testing
+### 3.1 Testing
 
 - `pytest-flask` for the test client and app fixture
-- One `app` fixture in `conftest.py` — uses `TestingConfig` and a test database
-- Test each route for: success (2xx), validation error (400), auth error (401/403)
-- No mocking of the database — integration tests use a real PostgreSQL test DB
-- Celery tasks tested with `task.apply()` (synchronous, no broker needed for unit tests)
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
+- One `app` fixture in `conftest.py` — uses `TestingConfig` and a real
+  PostgreSQL test database, reset (truncated) between runs
+- No database mocking and no SQLite substitution — integration tests run
+  against real PostgreSQL
+- Test each route for: success (2xx), validation error (400), auth error
+  (401/403), not found (404)
+- Celery tasks tested with `task.apply()` (synchronous, no broker for
+  unit tests); test the service the task delegates to, plus the retry and
+  DLQ paths
+- Component test naming: `test_<route_or_function>_<state>_<expected>` —
   e.g. `test_create_stock_item_missing_sku_returns_400`
+- Unit/component tests in `tests/component/`, cross-component flows in
+  `tests/integration/`
+- New code MUST reach 90% coverage; total coverage MUST NOT regress and
+  SHOULD stay at or above 80%
 - Run before every commit: `pytest && mypy src/ --strict`
 
----
+### 3.2 Observability
 
-## Observability
+- Structured JSON logs via `structlog` with a request ID injected per
+  request; default level INFO — DEBUG/TRACE off in production
+- Log errors once, at the top of the call stack; 4xx at INFO, 5xx at
+  ERROR; never log passwords, tokens, API keys, or PII
+- `/health` — shallow liveness check, returns 200 if the process is
+  alive; requires no authentication
+- `/ready` — deep readiness check, verifies PostgreSQL and Redis
+  connectivity, returns 503 when a critical dependency is down
+- Assign a trace ID at the service boundary, propagate it via the W3C
+  `traceparent` header, return it on errors (`X-Trace-Id`)
+- Instrument with OpenTelemetry; span names use route templates, not
+  URLs with IDs; Celery queue and DLQ depth tracked via Flower or custom
+  metrics
 
-- Structured JSON logs via `structlog` — request ID injected per request
-- Log levels: DEBUG (dev only), INFO (normal ops), WARNING (degraded), ERROR (failures)
-- Never log passwords, tokens, or PII
-- `/health` — liveness check (200 if process alive)
-- `/ready` — readiness check (verifies DB + Redis connectivity)
-- Celery task metrics: queue depth and DLQ depth tracked via Flower or custom metrics
+## 4. Identity
 
----
+Not applicable — this project has no design system or brand voice.
 
-## Documentation
+## 5. Review process
 
-- Single source of truth: this file
-- All API endpoints documented in `README.md` with request/response examples
-- Architecture decisions recorded in `docs/adr/` as numbered Markdown files
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority order
+(highest first):
+
+1. Security — auth enforced at the service layer, JWT fully validated, no
+   secrets or PII in logs, HTTPS-only, no client-trusted ownership checks
+2. Correctness — routes thin, services own business logic, no N+1
+   queries, transactions scoped correctly, every Celery task idempotent
+3. Clarity — names are self-documenting, functions single-purpose,
+   cognitive complexity <= 15
+4. Conventions — ruff and mypy strict clean, blueprint and schema
+   separation, RFC 9457 error shape, URI and query-parameter casing rules
+
+Confirm CI is green. Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `pytest && mypy src/ --strict` before every PR
+- Verify `.env.example` lists every required variable and `README.md`
+  documents the env reference and commands
+- Verify each new route has success / 400 / auth / 404 tests and each new
+  Celery task has retry and DLQ tests
+- Verify every schema change ships a reversible Alembic migration
+- Run the audit after: new project, migration, a new blueprint domain, or
+  before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first change
+2. Check the current branch — if not `main`, ask why before proceeding
+3. Check `git status` — if uncommitted changes exist, ship the previous
+   session's wrap (branch, commit, push, merge) before any new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest CI/CD deploy on `main` completed successfully — flag
+   if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable for
+   this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over starting
+  something new
+- Run `pytest && mypy src/ --strict` after every change — do not
+  accumulate unverified changes
+- When a tool (formatter, codemod, migration autogenerate) touches
+  unrelated files, revert the drift before committing and file it
+  separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result) before
+moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a new
+   directory or content move between documents each needs an ADR
+6. Migrations — confirm every schema change has a reversible Alembic
+   migration committed and applied (`flask db upgrade`)
+7. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep each
+   rule to one line
+8. README.md — for each new command, dependency, or env var, confirm it
+   is reflected; name the section
+9. docs/ONBOARDING.md — for each new tool, prerequisite, or setup step,
+   confirm it is documented; name the section
+10. docs/PLAYBOOK.md — for each new command, script, or workflow,
+    confirm it is documented; name the section
+11. Tests and types — run `pytest && mypy src/ --strict` and confirm
+    both pass
+12. Flag gaps — if any item cannot be completed this session, report it
+    as pending (never as done) before closing
+13. Summary — summarize what was done and what is next

--- a/examples/go-service/CLAUDE.md
+++ b/examples/go-service/CLAUDE.md
@@ -1,45 +1,60 @@
-# MetricsHub
+# MetricStream
 
-Lightweight metrics ingestion and aggregation service. Receives time-series
-data points from client SDKs over HTTP, aggregates them in memory, and
-flushes to a PostgreSQL time-series table on a configurable interval.
+Metrics ingestion service. Receives time-series data points from client
+SDKs over HTTP, aggregates them in memory, and flushes to a PostgreSQL
+time-series table on a configurable interval.
 
----
+- Owner: Observability platform team
+- Repo: github.com/acme/metricstream
+- Deployment: Docker image (GHCR) -> Kubernetes (production), Docker
+  Compose (local)
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/go-service.md` + `backend/caching.md` +
+>   `backend/jobs.md`
+> - Resolved chain: `generated/stack-go-service.md` (base + backend +
+>   go-service); `backend/caching.md` and `backend/jobs.md` are not in
+>   the go-service chain, so their rules are inlined directly into
+>   sections 2.9 and 2.10
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: MetricStream — Observability platform team — Go 1.22
+>   / chi router / PostgreSQL via pgx / Redis via go-redis / env config
+>   — go test, golangci-lint, govulncheck — Docker on Kubernetes
 
-- **Name**: MetricsHub
-- **Owner**: Observability platform team
-- **Repo**: github.com/acme/metricshub
-- **Deployment**: Docker → Kubernetes (production), Docker Compose (local)
-- **Stack source**: `stack/go-service.md` + `backend/caching.md` + `backend/jobs.md`
-- **Output format**: `base/core/agents.md`
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: Go 1.22+
 - HTTP router: chi
 - Database: PostgreSQL 16 via `pgx/v5` (direct, no ORM)
 - Cache: Redis 7 via `go-redis/v9`
 - Config: `github.com/caarlos0/env` (struct tags, no Viper)
 - Test runner: go test (stdlib)
+- Static analysis: go vet, staticcheck, golangci-lint, govulncheck
+- Migrations: goose (SQL files in `migrations/`)
 - Containerisation: Docker (multi-stage)
 - Distribution: Docker image pushed to GHCR, deployed on Kubernetes
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 cmd/
-  metricshub/
-    main.go              # wires dependencies, starts HTTP server + flush worker
+  metricstream/
+    main.go              # wires dependencies, starts HTTP server +
+                         #   flush worker under one errgroup
 internal/
   ingest/
     handler.go           # POST /v1/metrics — thin, decodes and validates
     service.go           # aggregation logic
+    repository.go        # idempotency lookups (Redis)
     model.go             # DataPoint, AggregatedMetric types
   flush/
     worker.go            # periodic flush goroutine
@@ -50,7 +65,10 @@ internal/
     config.go            # Config struct, loaded from env at startup
   server/
     server.go            # chi router setup, middleware, graceful shutdown
+pkg/                     # code safe to import externally (if any)
 migrations/              # SQL migration files (goose)
+tests/
+  performance/           # k6 load scripts
 Makefile
 Dockerfile
 docker-compose.yml
@@ -60,112 +78,355 @@ README.md
 CLAUDE.md
 ```
 
----
+- `internal/` enforces encapsulation — external packages cannot import it
+- `cmd/metricstream/main.go` is thin: load config, construct
+  dependencies, start server — no business logic
+- One package per feature domain — name packages by domain, never
+  `utils/` or `helpers/`
 
-## Commands
+### 1.3 Commands
 
 ```bash
-go run ./cmd/metricshub           # develop
-go build -o bin/metricshub ./cmd/metricshub  # build binary
-go test ./...                     # run all tests
-go test -tags integration ./...   # run integration tests (requires Docker)
-go vet ./...                      # static analysis
-goimports -w .                    # format imports
-make migrate-up                   # apply DB migrations (goose up)
-make migrate-down                 # roll back last migration
-docker compose up                 # full local stack
+go run ./cmd/metricstream                 # develop
+go build -o bin/metricstream ./cmd/metricstream   # build binary
+go test ./...                             # run all tests
+go test -race ./...                       # run tests with race detector
+go test -tags integration ./...           # integration tests (needs Docker)
+go vet ./...                              # static analysis
+staticcheck ./...                        # additional static analysis
+goimports -w .                           # format imports
+govulncheck ./...                        # vulnerability scan
+make migrate-up                          # apply DB migrations (goose up)
+make migrate-down                        # roll back last migration
+docker compose up                        # full local stack
+docker build -t metricstream .           # build container image
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Branch: `main` (protected), feature branches as `feat/<scope>`, fixes as `fix/<scope>`
-- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, docs, test, refactor
-- PRs require one approval and passing CI before merge
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`,
+  `docs/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
+  docs, refactor, test; subject under 80 characters, imperative mood
+- PRs are small and focused — one concern per PR; require one approval
+  and passing CI before merge
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new work
 - Do not commit compiled binaries, `*.test` files, or `.env`
 - `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
+- goose migrations are committed — never edit a migration already merged
+- Tag releases with `vX.Y.Z` — the Go module proxy uses these
+- Every repository MUST have a `.gitignore` and the committed `go.sum`
 
----
+### 2.2 Go
 
-## Code conventions
+- Follow Effective Go and Go Code Review Comments — the canonical style
+  references; fix the code, never suppress a linter to dodge style
+- `gofmt` / `goimports` clean — CI rejects unformatted code
+- Run `go vet ./...` and `staticcheck ./...` — fix every warning before
+  committing
+- No unused imports or variables — the compiler rejects these
+- Exported symbols MUST have a doc comment
+- Names are the primary documentation; cognitive complexity <= 15 per
+  function, maximum nesting depth of three — use early returns and
+  guard clauses
+- No debug statements (`fmt.Println`, `log.Print` for debugging) in
+  committed code; no commented-out code blocks
+- Source files UTF-8, ASCII content only, LF line endings
 
-### Package and interface design
+### 2.3 Package and interface design
 
-- `internal/` for all application code — external packages cannot import it
-- `cmd/metricshub/main.go` is thin: load config, construct dependencies, start server
-- Interfaces defined in the calling package — `ingest.Repository` is defined in
-  `internal/ingest/`, not in `internal/flush/`
-- Interfaces have 1–3 methods — large interfaces indicate a design problem
+- `internal/` for all application code — external packages cannot
+  import it
+- Interfaces are owned by the caller, not the implementer:
+  `ingest.Repository` is defined in `internal/ingest/`, not in the
+  package that implements it
+- Keep interfaces small — 1-3 methods; a large interface signals a
+  design problem
 - Accept interfaces, return concrete types
+- Avoid package-level `init()` — use explicit initialisation in `main`
+- Apply SOLID at the package and type level; prefer composition over
+  inheritance and depend on abstractions, inject dependencies
 
-### Error handling
+### 2.4 Error handling
 
-- Never discard errors — no `_` on error returns
+- Never discard errors — no `_` on an error return
 - Wrap errors with context: `fmt.Errorf("flushing metrics: %w", err)`
-- Use `errors.Is()` and `errors.As()` for inspection
-- Sentinel errors (`var ErrNoData = errors.New(...)`) defined in the owning package
-- Log errors once at the top of the call stack — not at every level
+- Use `errors.Is()` and `errors.As()` for inspection — never string
+  matching
+- Sentinel errors (`var ErrNoData = errors.New(...)`) defined in the
+  package that owns the concept
+- Log each error once, at the top of the call stack — not at every level
+- Classify before handling — the class sets the response and log level:
 
-### HTTP handlers
+| Class | Cause | HTTP | Log level |
+| ------ | ------ | ------ | ------ |
+| Validation | Invalid input from the caller | 400, 422 | INFO |
+| Not found | Resource does not exist | 404 | INFO |
+| Conflict | Duplicate or stale write | 409 | INFO |
+| Infrastructure | DB, cache, or queue down | 503 | ERROR |
+| Unexpected | Unhandled error, programming bug | 500 | ERROR |
 
-- Decode request body explicitly with `json.NewDecoder` — validate before use
-- All error responses in JSON: `{"error": "description"}`
-- Use chi middleware for: request ID injection, structured logging, recovery
+- Never map an infrastructure or unexpected error to a 4xx, and never
+  map a validation error to a 5xx
+- Repository layer raises typed, domain-agnostic errors; service layer
+  re-raises as domain errors with context; handler layer maps domain
+  errors to HTTP via a central mapper — no ad-hoc `try`-style handling
+  per route
+- Wrap every outbound call (DB, cache) in a timeout — never wait
+  indefinitely; treat every unexpected error as a bug and file a ticket
 
-### Configuration
+### 2.5 HTTP handlers
 
-- One `Config` struct in `internal/config/config.go` — loaded from env vars at startup
-- Passed explicitly through the dependency graph — no global config
-- Fail fast if required vars are missing: `env.Parse` returns an error on startup
+- Handlers are thin: decode request -> call service -> encode response;
+  no business logic in handlers
+- Decode the request body explicitly with `json.NewDecoder` and validate
+  before use — never trust unvalidated input
+- All error responses in JSON with an explicit
+  `Content-Type: application/json`; follow a consistent shape and never
+  return stack traces, internal paths, or driver errors to the client
+- Path segments are lowercase plural nouns with hyphens
+  (`/v1/metrics`) — no verbs, no trailing slash; query parameter names
+  use camelCase, and `limit`, `skip`, `offset`, `expand`, `sortedBy`
+  are reserved
+- Date/time fields use ISO 8601; an integer above 2^53-1 is serialised
+  as a string; reject non-finite floats (`NaN`/`Infinity`) at the
+  encoder rather than emitting an invalid JSON token
+- Use chi middleware for request ID injection, structured logging, and
+  panic recovery — applied once at the router, not per route
+- All traffic is served over HTTPS; write endpoints require an
+  authenticated identity
 
-### Concurrency
+### 2.6 Configuration
 
-- Flush worker runs as a goroutine started in `main.go` under `errgroup`
-- `context.Context` is the first argument to all functions that may block
-- Shared aggregation map protected by `sync.RWMutex` — documented on the struct
-- Clean shutdown: HTTP server drains in-flight requests, flush worker drains
-  remaining data before exit
+- One `Config` struct in `internal/config/config.go` — loaded from env
+  vars at startup and passed explicitly through the dependency graph;
+  no global config object
+- Never read `os.Getenv` directly in application code outside the config
+  loader
+- Validate all required config at load time — `env.Parse` returns an
+  error and the process fails fast if a required var is missing
+- Env vars use `SCREAMING_SNAKE_CASE`, prefixed `METRICSTREAM_` to avoid
+  collisions (e.g. `METRICSTREAM_DATABASE_URL`,
+  `METRICSTREAM_REDIS_URL`, `METRICSTREAM_FLUSH_INTERVAL`)
+- The port MUST be configurable via environment variable — never
+  hardcoded
+- `.env.example` committed with placeholders; `.env` in `.gitignore`;
+  mark every secret as required with no default
 
-### Caching
+### 2.7 Concurrency
 
-- Redis used for deduplication of ingest requests (idempotency key TTL: 5 min)
-- Cache key: `metricshub:ingest:<client_id>:<metric_name>:<timestamp_bucket>`
-- Cache failure does not block ingestion — log at WARN and continue
+- The flush worker runs as a goroutine started in `main.go` under an
+  `errgroup` — never start a goroutine without a clear owner and a clear
+  way to stop it
+- `context.Context` is the first argument to every function that may
+  block; propagate cancellation explicitly — never via package globals
+- Protect the shared aggregation map with `sync.RWMutex` — document
+  which fields the lock guards on the struct; never hold a lock across
+  I/O
+- Graceful shutdown: listen for `SIGTERM`, call HTTP server shutdown to
+  drain in-flight requests, flush remaining buffered data, then cancel
+  the root context
+- Run tests with the race detector (`go test -race`) in CI — code review
+  alone does not catch data races
 
----
+### 2.8 Caching (Redis idempotency)
 
-## Testing
+- Redis deduplicates ingest requests — store an idempotency key with a
+  5-minute TTL; cache-aside on the receive path
+- Key schema: `metricstream:ingest:<clientId>:<metricName>:<bucket>` —
+  namespaced and documented; never built from unvalidated user input
+- Every cache entry MUST have a TTL — no indefinite caching; size the
+  TTL by acceptable staleness, not convenience
+- Cache failures MUST NOT block ingestion — on miss or error, fall
+  through to processing the request; log cache errors at WARN
+- Never cache secrets, tokens, or PII; never cache at more than one layer
+  for the same data
+- Instrument cache hit rate, miss rate, and eviction rate; alert when
+  hit rate drops well below baseline
+
+### 2.9 Background jobs (flush worker)
+
+- The periodic flush is a scheduled job defined in code (the worker
+  interval is config-driven) — schedule-as-code, never configured
+  manually in infrastructure
+- The flush job MUST be idempotent — a re-run with the same buffered
+  batch produces the same PostgreSQL state; design for at-least-once
+- The job handler is thin — it delegates the aggregation-to-rows
+  transform and the write to `flush.Repository`, reusing the same
+  service path, with no parallel logic
+- No direct ad-hoc database access outside the repository; no HTTP calls
+  inside the flush job
+- Retry a failed flush with exponential backoff and a bounded retry
+  limit; on exhaustion, route the batch to a dead-letter store rather
+  than dropping it, and alert on dead-letter depth
+- Ensure only one flush instance runs per replica set — use a
+  distributed lock or leader election so concurrent pods do not
+  double-write
+- Emit a structured INFO log at flush start and completion; log failures
+  at ERROR with batch ID, attempt number, and error; track flush
+  duration, buffer size, and failure rate as metrics
+
+### 2.10 Database
+
+- PostgreSQL via `pgx/v5` — use the connection pool, never a connection
+  per request; inject the pool as a dependency, no global DB handle
+- Parameterised queries only — never interpolate values into SQL strings
+- No unbounded queries; avoid `SELECT *` — select only the columns
+  needed
+- Add an index for every foreign key and for the common
+  filter-plus-sort combinations on the time-series table; use a partial
+  index where a column is usually filtered the same way
+- Wrap multi-step writes in a transaction and keep it short — never hold
+  a transaction across the HTTP request boundary or call an external
+  service inside one
+- All schema changes via goose migrations — one migration per logical
+  change, each reversible with a `down`; never edit a merged migration
+- Tests reset state between runs and use real PostgreSQL — never
+  substitute a different engine
+
+## 3. Quality
+
+### 3.1 Testing
 
 - Stdlib `testing` package — no third-party assertion libraries
 - Table-driven tests with `t.Run()` for parameterised cases
 - Test the public API of each package — not unexported functions
-- Use interfaces to inject dependencies — no monkey-patching
-- Integration tests in `*_integration_test.go` behind `//go:build integration`
-- Integration tests require Docker Compose (`make test-integration`)
-- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
+- Inject dependencies via interfaces — no monkey-patching
+- Component test naming: `Test<UnitOfWork>_<State>_<Expected>` —
   e.g. `TestIngestHandler_MalformedJSON_Returns400`
-- Run before every commit: `go test ./... && go vet ./...`
+- Integration tests in `internal/<feature>/*_integration_test.go`
+  behind `//go:build integration`; they use real PostgreSQL and Redis
+  via Docker Compose (`make test-integration`)
+- Test the cache fallback path: a cache miss or error still ingests
+  correctly; test the flush retry and dead-letter paths
+- New code MUST reach 90% coverage; total coverage MUST NOT regress and
+  SHOULD stay at or above 80%
+- Performance tests with k6 in `tests/performance/` — watch queue depth
+  and flush lag at volume, not just receive latency
+- Run before every commit: `go test -race ./... && go vet ./...`
 
----
+### 3.2 Observability
 
-## Observability
+- Structured JSON logs via `log/slog` (stdlib) — request ID in every log
+  line; default level INFO, DEBUG/TRACE off in production
+- Log each error once at the top of the call stack; 4xx at INFO, 5xx at
+  ERROR; never log secrets, tokens, or PII
+- `/health` — liveness, returns 200 if the process is alive; requires no
+  authentication
+- `/ready` — readiness, verifies PostgreSQL and Redis connectivity,
+  returns 503 when a critical dependency is down
+- Assign a trace ID at the service boundary, propagate it via the W3C
+  `traceparent` header, and return it on errors (`Api-Trace-Id`)
+- Instrument with OpenTelemetry; expose Prometheus metrics at `/metrics`
+  with low-cardinality span names (route templates, not URLs with IDs):
+  - `metricstream_ingest_requests_total` (by status)
+  - `metricstream_flush_duration_seconds` (histogram)
+  - `metricstream_aggregation_buffer_size` (gauge)
 
-- Structured JSON logs via `log/slog` (stdlib) — request ID in every log line
-- Log levels: DEBUG (dev only), INFO (normal ops), WARN (degraded), ERROR (failures)
-- `/health` — liveness: returns 200 if process is alive
-- `/ready` — readiness: verifies DB and Redis connectivity
-- Prometheus metrics at `/metrics`:
-  - `metricshub_ingest_requests_total` (by status)
-  - `metricshub_flush_duration_seconds` (histogram)
-  - `metricshub_aggregation_buffer_size` (gauge)
+## 4. Identity
 
----
+Not applicable — this project has no design system or brand voice. Its
+public contract is the OpenAPI schema for `/v1/metrics`, maintained by
+hand in `docs/openapi.yaml` and validated in CI.
 
-## Documentation
+## 5. Review process
 
-- Single source of truth: this file
-- `README.md`: local setup, env var reference, Makefile targets
-- Architecture decisions in `docs/adr/` as numbered Markdown files
-- API contract in `docs/openapi.yaml` — maintained by hand, validated in CI
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority
+order (highest first):
+
+1. Security — no secrets or PII in logs, HTTPS-only, parameterised
+   queries, write endpoints authenticated, container runs as non-root
+2. Correctness — handlers thin, services framework-agnostic,
+   aggregation map locked correctly, flush idempotent, cache failures
+   non-fatal, transactions scoped and short, no N+1 queries
+3. Clarity — names are self-documenting, functions single-purpose,
+   cognitive complexity <= 15, exported symbols documented
+4. Conventions — gofmt / go vet / staticcheck clean, interfaces owned by
+   the caller, error wrapping and classification correct, URI and
+   query-parameter casing rules
+
+Confirm CI is green (build, lint, `go test -race`, govulncheck,
+gitleaks). Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `go test -race ./... && go vet ./... && staticcheck ./...` before
+  every PR
+- Verify `.env.example` lists every required variable and `README.md`
+  documents the env reference and Makefile targets
+- Verify every new endpoint has success / 4xx / auth tests and that the
+  flush and cache paths have integration coverage
+- Confirm each schema change has a reversible goose migration committed
+- Run the audit after: new project, migration, a new feature package, or
+  before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first change
+2. Check the current branch — if not `main`, ask why before proceeding
+3. Check `git status` — if uncommitted changes exist, ship the previous
+   session's wrap (branch, commit, push, merge) before any new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest CI/CD deploy on `main` completed successfully — flag
+   if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable for
+   this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over starting
+  something new
+- Run `go test -race ./... && go vet ./...` after every change — do not
+  accumulate unverified changes
+- When a tool (goimports, golangci-lint, goose autogenerate) touches
+  unrelated files, revert the drift before committing and file it
+  separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result) before
+moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a new
+   directory or content move between documents each needs an ADR
+6. Migrations — confirm every schema change has a reversible goose
+   migration committed and applied (`make migrate-up`)
+7. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep each
+   rule to one line
+8. README.md — for each new command, dependency, or env var, confirm it
+   is reflected; name the section
+9. docs/ONBOARDING.md — for each new tool, prerequisite, or setup step,
+   confirm it is documented; name the section
+10. docs/PLAYBOOK.md — for each new command, script, or workflow,
+    confirm it is documented; name the section
+11. Tests and analysis — run `go test -race ./... && go vet ./... &&
+    staticcheck ./...` and confirm all pass
+12. Flag gaps — if any item cannot be completed this session, report it
+    as pending (never as done) before closing
+13. Summary — summarize what was done and what is next

--- a/examples/hybrid-astro/CLAUDE.md
+++ b/examples/hybrid-astro/CLAUDE.md
@@ -1,11 +1,31 @@
 # Starfield Blog
 
+Personal blog about astronomy and astrophotography. Static site with
+content collections and zero client-side JS.
+
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/static-site-astro.md`
+> - Resolved chain: `generated/stack-astro.md` (base + frontend +
+>   static-site-astro)
+> - Output format: `base/core/agents.md` (hybrid model)
+> - Project brief: Starfield Blog — Alex Rivera — astronomy /
+>   astrophotography blog — TypeScript strict / Astro 4 (static) /
+>   Content Collections / plain CSS — npm, Prettier, ESLint, astro
+>   check — GitHub Pages via GitHub Actions
+
+Quality conventions defined in `docs/solid-ai-templates/` (submodule).
+Project-specific overrides and additions follow below.
+
 > **MANDATORY STARTUP — DO THIS BEFORE YOUR FIRST RESPONSE**
 >
-> You MUST read every file listed below IN FULL using the Read tool before
-> you respond to the user's first message. No exceptions. Do not summarize,
-> skip, or defer. These files contain binding conventions that this CLAUDE.md
-> inherits. If you respond without reading them, you are violating project rules.
+> This file is hybrid: the damage-prone rules (git, TypeScript safety,
+> content, session protocol) are inlined below, but the full quality
+> framework lives in the referenced templates. You MUST read every file
+> listed below IN FULL using the Read tool before you respond to the
+> user's first message. No exceptions. Do not summarize, skip, or defer.
+> If you respond without reading them, you are violating project rules.
 >
 > 1. `docs/solid-ai-templates/base/quality.md`
 > 2. `docs/solid-ai-templates/base/typescript.md`
@@ -20,35 +40,25 @@
 > 11. `docs/solid-ai-templates/frontend/static-site.md`
 > 12. `docs/solid-ai-templates/stack/static-site-astro.md`
 
-Personal blog about astronomy and astrophotography. Static site with
-content collections and zero client-side JS.
-
-- Model: hybrid
-
-Quality conventions defined in `docs/solid-ai-templates/` (submodule).
-Project-specific overrides and additions follow below.
-
 
 ## 1. Project
 
 ### 1.1 Identity
 
+- **Model**: hybrid
 - **Name**: starfield-blog
 - **Owner**: Alex Rivera
 - **Repo**: github.com/arivera/starfield-blog
 - **URL**: starfield.blog
 - **Deployment**: GitHub Pages via GitHub Actions
+- **Language**: TypeScript (strict mode)
+- **Framework**: Astro 4 (output: static)
+- **Content**: Astro Content Collections (Markdown + frontmatter)
+- **CSS**: plain CSS with custom properties
+- **Package manager**: npm
+- **Formatter**: Prettier with `prettier-plugin-astro`
 
-### 1.2 Stack
-
-- Language: TypeScript (strict mode)
-- Framework: Astro 4 (output: static)
-- Content: Astro Content Collections (Markdown + frontmatter)
-- CSS: plain CSS with custom properties
-- Package manager: npm
-- Formatter: Prettier with `prettier-plugin-astro`
-
-### 1.3 Project structure
+### 1.2 Project structure
 
 ```
 src/
@@ -71,7 +81,7 @@ public/
 
 ### 1.3 Commands
 
-```
+```bash
 npm run dev       # develop at localhost:4321
 npm run build     # production build to dist/
 npm run preview   # preview production build
@@ -87,22 +97,31 @@ npm run check     # astro check
 - Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`
 - Always branch — never commit directly to `main`
 - Branch naming: `feat/description`, `fix/description`
+- PRs are small and focused — one concern per PR
+- Never force-push a branch, including with `--force-with-lease`
+- After a PR is merged, delete the branch and pull `main` before new work
+- Do not commit `dist/`, `node_modules/`, or `.env`
 
 ### 2.2 TypeScript
 
 - `strict: true` — no exceptions
 - No `any` — use `unknown` and narrow
 - No enums — use `as const` objects or string literal unions
+- Type all content-collection schemas in `src/content/config.ts`
 
 ### 2.3 Content rules
 
 - One Markdown file per post in `src/content/posts/`
 - Frontmatter must include: title, date, tags, description
 - Image alt text is required — no decorative images without `alt=""`
-- No inline HTML in Markdown posts
+- No inline HTML in Markdown posts — no `set:html` on untrusted input
 
 
 ## 3. Quality
+
+Reference `frontend/quality.md`, `frontend/ux.md`, and
+`frontend/static-site.md` for accessibility, performance, and the
+static-site quality framework. Inline only the SEO targets below.
 
 ### 3.1 SEO
 
@@ -116,27 +135,25 @@ npm run check     # astro check
 
 ### 4.1 Design
 
-- Dark background with deep blue accent
-- Minimal layout — content-first
+- Dark background with deep blue accent — evokes the night sky
+- Minimal, content-first layout — the photograph is the focal point
 - No stock photography — only original astrophotos
+- Generous whitespace; typographic hierarchy over decoration
+- Respect `prefers-reduced-motion` — no autoplay or parallax
 
 ### 4.2 Brand voice
 
-- Educational and enthusiastic
-- Technical but accessible to hobbyists
+- Educational and enthusiastic — share the wonder, explain the science
+- Technical but accessible to hobbyists — define jargon on first use
 - First person, conversational tone
+- Cite gear, settings, and capture conditions for each astrophoto
 
 
 ## 5. Review process
 
-### 5.1 Code review
-
-Follow `base/review.md` priority order. Apply `base/quality.md` and
-`base/typescript.md` as the standard.
-
-### 5.2 Structure audit
-
-Verify MUSTs from `base/docs.md`, `base/readme.md`, `base/git.md`,
+Follow `base/review.md` priority order. Apply `base/quality.md`,
+`base/typescript.md`, and `frontend/quality.md` as the standard. Verify
+MUSTs from `base/docs.md`, `base/readme.md`, `base/git.md`,
 `frontend/static-site.md`, and `stack/static-site-astro.md`.
 
 
@@ -146,14 +163,34 @@ Follow `base/scope.md` for the scope guard and end-of-session audit.
 
 ### 6.1 Start of session
 
-Read `base/scope.md` (Session startup) and the mandatory startup block.
+Read `base/scope.md` (Session startup) and the mandatory startup block
+above. Confirm the scope with the user before making changes.
 
 ### 6.2 During the session
 
 Follow `base/scope.md` (During work) — stay within the agreed scope.
+Run `npm run check` and `npm run lint` after any change; do not
+accumulate unverified changes.
 
 ### 6.3 End of session
 
 On "wrap up" / "close out", read `base/scope.md` (End of session audit)
 and execute each item sequentially; do not summarize or skip. Print the
-checklist and mark each item done before moving to the next.
+checklist and mark each item done (with result) before moving to the
+next. At minimum, confirm in order:
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues; verify auto-close worked
+3. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+4. ADRs — record any architectural decisions in `docs/decisions/`
+5. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc
+6. README.md / docs — for each new command, dependency, or content
+   rule, confirm it is reflected; name the section
+7. Build and checks — run `npm run check` and `npm run build` and
+   confirm both pass
+8. Flag gaps — report any item that cannot be completed as pending,
+   never as done, before closing
+9. Summary — summarize what was done and what is next

--- a/examples/metricshub/CLAUDE.md
+++ b/examples/metricshub/CLAUDE.md
@@ -1,50 +1,59 @@
 # MetricsHub
 
-Infrastructure metrics collection and aggregation service. Owned by the
-Infrastructure team.
+Infrastructure metrics collection and aggregation service.
 
----
+- Owner: Infrastructure team
+- Repo: github.com/acme/metricshub
+- Deployment: Docker image -> Kubernetes (cloud)
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/go-echo.md` (-> go-service -> go-lib) +
+>   `backend/auth.md` (JWT depth not in the resolved chain — inlined)
+> - Resolved chain: `generated/stack-go-echo.md` (base + backend +
+>   go-echo)
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: MetricsHub — Infrastructure team — Go 1.22 / Echo
+>   v4 / PostgreSQL via sqlc + pgx / JWT bearer auth / OpenFeature
+>   feature flags — go test, golangci-lint, Docker on Kubernetes
 
-- **Name**: MetricsHub
-- **Owner**: Infrastructure team
-- **Repo**: github.com/acme/metricshub
-- **Deployment**: Docker → Kubernetes (cloud)
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: Go 1.22+
 - HTTP framework: Echo v4
 - Database: PostgreSQL via sqlc + pgx
 - Config: github.com/caarlos0/env
 - Test runner: go test (stdlib)
-- Containerisation: Docker
-- Distribution: Docker image → Kubernetes
 - Auth: JWT bearer tokens
 - Feature flags: OpenFeature Go SDK
+- Containerisation: Docker
+- Distribution: Docker image -> Kubernetes
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 cmd/
   metricshub/
-    main.go              # entry point — wires dependencies, starts server
+    main.go              # entry point — wires deps, starts server
 internal/
   metrics/
     handler.go           # HTTP handlers (thin)
     service.go           # business logic
-    repository.go        # data access
+    repository.go        # data access (sqlc-generated + pgx)
     model.go             # domain types
   config/
-    config.go
+    config.go            # Config struct, loaded from env at startup
   server/
     server.go            # Echo instance, middleware, routing
-pkg/                     # code safe to import by external packages (if any)
+pkg/                     # code safe to import externally (if any)
 migrations/              # SQL migration files
 Dockerfile
 Makefile
@@ -54,187 +63,413 @@ README.md
 CLAUDE.md
 ```
 
-- `internal/` enforces encapsulation — external packages cannot import it
+- `internal/` enforces encapsulation — external packages cannot
+  import it
 - `cmd/` is thin — no business logic, only wiring
+- One domain concern per package — no `utils/` or `helpers/` packages
 
----
-
-## Commands
+### 1.3 Commands
 
 ```bash
 go run ./cmd/metricshub           # develop
 go build ./cmd/metricshub         # build binary
 go test ./...                     # run all tests
+go test -race ./...               # run with the race detector
 go test -tags integration ./...   # run integration tests
 go vet ./...                      # static analysis
 goimports -w .                    # format imports
+staticcheck ./...                 # additional static analysis
 make migrate-up                   # apply DB migrations
 docker build -t metricshub .      # build container image
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`,
-  `refactor:`, `style:`, `test:`
-- Keep the subject line under 80 characters
-- Use the imperative mood: "add feature" not "added feature"
-- Always work on a branch — never commit directly to `main`
-- Branch naming: `feat/description`, `fix/description`, `chore/description`,
-  `docs/description`
-- PRs should be small and focused — one concern per PR
-- After a PR is merged: delete branch, pull main before starting new work
-- Do not commit compiled binaries, `*.test` files, or `vendor/` (unless
-  vendoring is an explicit project decision — document it in README if so)
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`,
+  `docs/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
+  docs, refactor, style, test; subject under 80 characters,
+  imperative mood
+- PRs are small and focused — one concern per PR; review the diff and
+  confirm CI is green before merge
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new
+  work
+- Do not commit compiled binaries, `*.test` files, build output,
+  secrets, or `vendor/` (unless vendoring is an explicit decision —
+  document it in README)
 - `go.sum` is committed — do not delete or regenerate without cause
-- Tag releases with `vX.Y.Z` — Go module proxy uses these
-- Do not commit build output, secrets, or dependency directories
+- Tag releases with `vX.Y.Z` — the Go module proxy uses these
+- Migrations are committed — never edit or regenerate a migration
+  already merged
+- Every repository MUST have a `.gitignore` and a committed lockfile
 
----
+### 2.2 Go
 
-## Code conventions
+- Follow Effective Go and Go Code Review Comments — the canonical
+  style references
+- `gofmt` / `goimports` — code MUST be formatted; CI rejects
+  unformatted code
+- Run `go vet ./...` — fix all warnings before committing
+- Run `staticcheck ./...` for additional static analysis
+- No unused imports or variables — the compiler rejects these
+- Exported symbols MUST have a doc comment
+- Small, focused packages — one domain concern per package
+- Define interfaces where the caller owns them; keep them 1–3 methods
+- Accept interfaces, return concrete types
+- Avoid package-level `init()` — initialise explicitly in `main`
+- Always handle errors — never `_` discard an error return
+- Wrap errors with context: `fmt.Errorf("creating metric: %w", err)`
+- Use `errors.Is()` and `errors.As()` for inspection — never string
+  matching
+- Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the
+  package that owns the concept
+- Cognitive complexity <= 15 per function; maximum nesting depth of
+  three — use early returns and guard clauses
+- No debug statements (`fmt.Println`) in committed code
+- Source files UTF-8, ASCII content only, LF line endings
 
-### Application setup
+### 2.3 Application setup
 
 - One `Echo` instance created in `internal/server/server.go`
 - Register all routes and middleware in `server.go` — no scattered
   `e.GET(...)` calls across packages
-- Use `lifespan` / `main.go` for startup and shutdown orchestration
+- `main.go` owns startup and shutdown orchestration — wire
+  dependencies, start the server, handle signals
+- Processes MUST start fast and shut down gracefully on `SIGTERM`
+- Do not store state in-process — use PostgreSQL so processes are
+  disposable
 
-### Configuration
+### 2.4 Configuration
 
-- One `Config` struct in `internal/config/config.go` — loaded from env
-  vars at startup; passed explicitly through the dependency graph
-- Never read `os.Getenv` directly in application code outside of
-  the config loader
+- One `Config` struct in `internal/config/config.go` — loaded from
+  env vars at startup; passed explicitly through the dependency graph
+- Never read `os.Getenv` directly in application code outside the
+  config loader
+- Validate all required config at load time — fail fast if anything
+  is missing or invalid
+- `SCREAMING_SNAKE_CASE` env vars, prefixed `METRICSHUB_` to avoid
+  collisions (e.g. `METRICSHUB_DATABASE_URL`, `METRICSHUB_PORT`)
+- The port MUST be configurable via environment variable — never
+  hardcoded
+- `.env.example` committed with placeholders; `.env` in `.gitignore`
+- Mark all secrets as required — no defaults for passwords, tokens,
+  or keys; never log config values
 
-### Routing
+### 2.5 Routing
 
 - Define all routes in `internal/server/server.go` — one place, no
   scattered `e.GET(...)` calls across packages
 - Group routes by resource: `e.Group("/api/v1/metrics")` — apply
   middleware at group level, not per-route
-- Use named path parameters: `e.GET("/metrics/:id", handler)` — access
-  via `c.Param("id")`
+- Use named path parameters: `e.GET("/metrics/:id", handler)` —
+  access via `c.Param("id")`
 - Version all API routes under a prefix: `/api/v1/`, `/api/v2/`
+- Path segments MUST be lowercase plural nouns with hyphens, no
+  verbs, no trailing slash; query parameter names use camelCase
+- JSON is the default format; date/time values use ISO 8601
+- All traffic served over HTTPS — plain HTTP is not acceptable
 
-### Handlers
+### 2.6 Handlers
 
 - Handler signature: `func (h *Handler) Create(c echo.Context) error`
-- Bind and validate in one step: `c.Bind(&req)` then call a validator —
-  never trust unbound input
+- Handlers are thin — decode request, call service, encode response;
+  all business logic belongs in the service layer
+- Bind and validate in one step: `c.Bind(&req)` then call a validator
+  — never trust unbound input
 - Return errors with `c.JSON(code, resp)` or by returning an
   `*echo.HTTPError` — never write directly to `c.Response()`
-- Handlers are thin — all business logic belongs in the service layer
-- Decode request body explicitly — never trust unvalidated input
+- Enforce a strict handler -> service -> repository separation; no
+  database access in handlers
+- No unbounded list endpoints — always paginate with an explicit
+  limit
 
-### Request binding and validation
+### 2.7 Request binding and validation
 
-- Use `echo.Validator` interface — register a single validator at startup
-  (e.g. `go-playground/validator`)
+- Use the `echo.Validator` interface — register a single validator at
+  startup (e.g. `go-playground/validator`)
 - Call `c.Validate(req)` after `c.Bind(req)` in every handler that
   receives a body
 - Treat binding errors and validation errors as `400 Bad Request` —
   return a structured JSON body, not a plain string
 - Never use `json.Decoder` directly in handlers — let Echo's binder
   handle it
+- Validate all external input at the system boundary; allowlist, not
+  blocklist — reject everything not explicitly valid
+- Internal code trusts validated data — do not re-validate in the
+  service or repository layers
 
-### Middleware
+### 2.8 Middleware
 
-- Use `echo/middleware` for: `RequestID`, `Logger`, `Recover`, `CORS`,
-  `RateLimiter` — configure globally on the root `Echo` instance
-- Write custom middleware as `echo.MiddlewareFunc` — keep it stateless;
-  inject dependencies via closure
-- Order matters: `Recover` → `RequestID` → `Logger` → auth → business
-  middleware
+- Use `echo/middleware` for `RequestID`, `Logger`, `Recover`, `CORS`,
+  and `RateLimiter` — configure globally on the root `Echo` instance
+- Write custom middleware as `echo.MiddlewareFunc` — keep it
+  stateless; inject dependencies via closure
+- Order matters: `Recover` -> `RequestID` -> `Logger` -> auth ->
+  business middleware
 - Never put business logic in middleware
+- Set security headers at the middleware level, not per route; rate-
+  limit public endpoints
 
-### Error handling
+### 2.9 Error handling
 
 - Register a custom `Echo.HTTPErrorHandler` — all errors flow through
   one place
-- Map sentinel errors (e.g. `ErrNotFound`) to HTTP status codes in the
-  error handler, not in individual handlers
+- Map sentinel errors (e.g. `ErrNotFound`) to HTTP status codes in
+  the error handler, not in individual handlers
 - Return `*echo.HTTPError` for expected errors; let the error handler
   convert unexpected errors to `500`
 - Include `request_id` in every error response body for traceability
-- Always handle errors — never `_` discard an error return
-- Wrap errors with context: `fmt.Errorf("creating metric: %w", err)`
-- Use `errors.Is()` and `errors.As()` for inspection — never string
-  matching
+- Classify every error before handling it — the class sets the HTTP
+  status and log level:
+  - Validation -> 400/422, log INFO
+  - Authentication -> 401, log INFO
+  - Authorization -> 403, log INFO
+  - Not found -> 404, log INFO
+  - Conflict -> 409, log INFO
+  - Infrastructure (DB/cache down) -> 503, log ERROR
+  - External service failure -> 502/504, log ERROR
+  - Unexpected -> 500, log ERROR
+- Repository layer raises typed, domain-agnostic errors; service
+  layer adds business context; handler layer maps to HTTP — log once,
+  at the handler or middleware boundary
+- Follow RFC 9457 (`application/problem+json`) for the error body
+  shape; never use 200 for an error
+- Never return stack traces, internal paths, or implementation
+  details to the client
+- Wrap all outbound calls (HTTP, DB) in a timeout; use a circuit
+  breaker for repeated calls to external services
 
-### Concurrency and graceful shutdown
+### 2.10 Concurrency and graceful shutdown
 
 - Protect shared state with `sync.Mutex` or `sync.RWMutex` — document
-  which fields are guarded and by which lock
-- Always use `context.Context` as the first argument in functions that
-  may block
-- Use `errgroup` for structured concurrency — all goroutines started in
-  `main.go` under one group, stopped cleanly on context cancellation
-- Never start a goroutine without a clear owner and a clear way to stop
-  it
-- Graceful shutdown: listen for `SIGTERM`, call server shutdown, drain
-  in-flight requests, then cancel the root context
+  which fields are guarded by which lock
 - Never hold a lock while performing I/O — risk of deadlock and
   contention
+- Always use `context.Context` as the first argument in functions
+  that may block; propagate cancellation explicitly
+- Use `errgroup` for structured concurrency — all goroutines started
+  in `main.go` under one group, stopped cleanly on context
+  cancellation
+- Never start a goroutine without a clear owner and a clear way to
+  stop it
+- Graceful shutdown: listen for `SIGTERM`, call server shutdown,
+  drain in-flight requests, then cancel the root context
+- Run tests with `go test -race` in CI — do not rely on review alone
+  to catch data races
 
-### Authentication
+### 2.11 Authentication and authorization
 
 - JWT bearer tokens validated in a shared Echo middleware dependency
-- Never log or expose token payloads in error responses
+  — centralise auth logic, no scattered permission checks
+- Authentication (who) and authorization (what) are separate
+  concerns — keep them in separate layers
+- Never implement cryptographic primitives — use well-audited
+  libraries; fail closed (deny by default, grant explicitly)
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens
+  missing any required claim
+- Token lifetime: access <= 15 min, refresh <= 7 days (rotated on
+  use); store refresh tokens server-side so they can be revoked
+- Access tokens MUST arrive in `Authorization: Bearer <token>` —
+  never in query parameters; refresh tokens in `httpOnly`, `Secure`,
+  `SameSite=Strict` cookies
+- Use RBAC as the baseline; layer ABAC on top for fine-grained needs
+- Authorise at the service layer, not only at the route layer — a
+  route that passes auth may call a service touching another user's
+  data
+- Never trust client-supplied IDs for ownership checks — verify the
+  authenticated user owns the requested resource
+- Never log or expose token payloads, passwords, or secrets in error
+  responses or logs — even at DEBUG level
+- Log auth failures at WARN with IP and user agent (never the
+  attempted password); alert on a spike
 
-### Feature flags
+### 2.12 Feature flags
 
-- Use the OpenFeature Go SDK — wrap the provider behind an interface so
-  the provider can be swapped in tests
-- Pass the flag client through the dependency graph — constructor
+- Use the OpenFeature Go SDK — wrap the provider behind an interface
+  so it can be swapped in tests
+- Pass the flag client through the dependency graph — a constructor
   argument, not a package-level singleton
 - In tests, use the in-memory OpenFeature provider
 - Every flag has an owner and a removal date set at creation time —
   flags without a removal date are not allowed to merge
-- Remove the flag and its dead branch as soon as the rollout is complete
-- Never nest feature flags
+- Remove the flag and its dead branch as soon as the rollout is
+  complete — stale flags are technical debt
+- Never nest feature flags — a flag that activates only when another
+  is active creates untestable combinations
+- Keep the flagged code path as small as possible — wrap the decision
+  point, not the whole function
 - Flags are evaluated at runtime, not at startup — never cache a flag
-  value for longer than one request lifecycle unless justified
-- Evaluate flags at the entry point of the feature — handler or service
-  layer, never deep inside domain logic
+  value for longer than one request lifecycle unless the cost is
+  measured and justified
+- Evaluate flags at the entry point of the feature — handler or
+  service layer, never deep inside domain logic
+- Return the same response shape for both flag states; treat the
+  flag-off path as the production default until the flag is removed
+- Log which variant was evaluated per flagged request; fail to the
+  safe default and alert if flag evaluation fails
 
-### Code quality
+## 3. Quality
 
-- Follow **Effective Go** for idioms and design decisions
-- `gofmt` / `goimports` — code must be formatted; CI rejects unformatted
-  code
-- Run `go vet ./...` — fix all warnings before committing
-- Run `staticcheck ./...` for additional static analysis
-- No unused imports or variables — the compiler rejects these
-- Exported symbols must have a doc comment
+### 3.1 Testing
 
----
-
-## Testing
-
-- Use stdlib `testing` package — no third-party assertion libraries
+- Use the stdlib `testing` package — no third-party assertion
+  libraries
 - Table-driven tests with `t.Run()` for parameterised cases
 - Test the public API of each package — not unexported functions
 - Use interfaces to inject dependencies in tests — no monkey-patching
-- Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
-  e.g. `TestGetMetric_NotFound_Returns404`
-- Use `net/http/httptest` with `echo.New()` — no real server needed for
-  unit tests
-- Call handlers directly: `e.ServeHTTP(rec, req)` — assert on
-  `rec.Code` and `rec.Body`
-- Integration tests use a real Echo server on a random port — start in
-  `TestMain`, share across test functions
-- Integration tests in `internal/metrics/*_integration_test.go` behind
-  a build tag: `//go:build integration`
-- No mocking of the database in integration tests — use a test database
+- Test naming: `Test<UnitOfWork>_<State>_<Expected>` — e.g.
+  `TestGetMetric_NotFound_Returns404`
+- Use `net/http/httptest` with `echo.New()` — no real server needed
+  for unit tests; call handlers via `e.ServeHTTP(rec, req)` and
+  assert on `rec.Code` and `rec.Body`
+- Integration tests use a real Echo server on a random port — start
+  in `TestMain`, share across test functions
+- Integration tests live in `internal/metrics/*_integration_test.go`
+  behind a build tag: `//go:build integration`
+- No database mocking in integration tests — use a real test
+  PostgreSQL; reset state (truncate or rollback) between runs; never
+  substitute SQLite
+- Test auth: assert 401 for unauthenticated and 403 for
+  insufficient-permission requests; assert expired and revoked tokens
+  are rejected
+- New code MUST reach 90% coverage; total coverage MUST NOT regress
+  and SHOULD stay at or above 80%
 - Run before every commit: `go test ./... && go vet ./...`
 
----
+### 3.2 Observability
 
-## Documentation
+- Structured JSON logs in production, human-readable in development;
+  every entry includes timestamp, level, message, and the
+  `request_id` for that lifecycle
+- Default log level INFO in all environments — DEBUG and TRACE off in
+  production
+- Log errors once, at the top of the call stack; 4xx at INFO, 5xx at
+  ERROR; never log passwords, tokens, API keys, or PII
+- Expose `/healthz` — returns 200 when ready, 503 when a critical
+  dependency (PostgreSQL) is unavailable; requires no authentication
+- Assign a trace ID at the service boundary, propagate it via the W3C
+  `traceparent` header, and return it on errors (`X-Trace-Id`)
+- Instrument with OpenTelemetry; span names use route templates, not
+  URLs with IDs (`GET /metrics/:id`, not `GET /metrics/42`)
 
-- Keep `README.md` up to date with setup, run, and test instructions
-- Every public module, class, and function has a doc comment
-- Architecture decisions recorded as ADRs in `docs/decisions/`
+### 3.3 Quality gates
+
+- Lint: golangci-lint (`.golangci.yml`) at editor, pre-commit, and CI
+- Format: gofmt (`gofmt -l` fails CI on unformatted code)
+- Type check: `go vet ./...`
+- Security: govulncheck + platform SAST; secrets: gitleaks
+  (pre-commit + CI)
+- Tests: `go test ./...`; coverage `go test -cover` >= 80%
+- Build MUST succeed; lint errors, type errors, and high/critical
+  security findings are zero-tolerance — CI fails
+
+## 4. Identity
+
+Not applicable — this project has no design system or brand voice.
+MetricsHub is a backend service; its public contract is the HTTP API
+under `/api/v1/`.
+
+## 5. Review process
+
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority
+order (highest first):
+
+1. Security — auth validated and enforced at the service layer, no
+   secrets or token payloads in logs, HTTPS-only, no client-trusted
+   ownership checks, parameterised queries only
+2. Correctness — handlers thin, strict handler -> service ->
+   repository separation, errors classified and mapped through the
+   central handler, contexts and locks used correctly, goroutines
+   have a clear shutdown path
+3. Clarity — names are self-documenting, functions single-purpose,
+   cognitive complexity <= 15
+4. Conventions — gofmt / go vet / staticcheck clean, Effective Go
+   idioms, URI and query-parameter casing rules, RFC 9457 error shape
+
+Confirm CI is green. Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `go test ./... && go vet ./...` before every PR
+- Verify all routes are registered in `internal/server/server.go` and
+  every body-bearing handler calls `c.Bind` then `c.Validate`
+- Verify `.env.example` lists every required variable and `README.md`
+  documents the env reference and commands
+- Verify new endpoints have success, 400/422, 401/403, and 404 tests,
+  and that every feature flag has an owner and removal date
+- Run the audit after: new project, migration, a new feature domain,
+  or before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first
+   change
+2. Check the current branch — if not `main`, ask why before
+   proceeding
+3. Check `git status` — if uncommitted changes exist, ship the
+   previous session's wrap (branch, commit, push, merge) before any
+   new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest CI/CD deploy on `main` completed successfully —
+   flag if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable
+   for this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over
+  starting something new
+- Run `go test ./... && go vet ./...` after every change — do not
+  accumulate unverified changes
+- When a tool (formatter, sqlc generate, migration tool) touches
+  unrelated files, revert the drift before committing and file it
+  separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result)
+before moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a
+   new directory or content move between documents each needs an ADR
+6. Migrations — confirm every schema change has a reversible
+   migration committed and applied (`make migrate-up`)
+7. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep
+   each rule to one line
+8. README.md — for each new command, dependency, or env var, confirm
+   it is reflected; name the section
+9. docs/ONBOARDING.md — for each new tool, prerequisite, or setup
+   step, confirm it is documented; name the section
+10. docs/PLAYBOOK.md — for each new command, script, or workflow,
+    confirm it is documented; name the section
+11. Tests and vet — run `go test ./... && go vet ./...` and confirm
+    both pass
+12. Flag gaps — if any item cannot be completed this session, report
+    it as pending (never as done) before closing
+13. Summary — summarize what was done and what is next

--- a/examples/order-service/CLAUDE.md
+++ b/examples/order-service/CLAUDE.md
@@ -1,184 +1,432 @@
 # OrderService
 
-HTTP API for order management. Owned by the Platform team.
+HTTP API for order capture, validation, and fulfilment tracking.
 
----
+- Owner: Platform team
+- Repo: github.com/acme/order-service
+- Deployment: Docker image -> Kubernetes (cloud), Docker Compose (local)
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/python-fastapi.md` + `backend/auth.md`
+> - Resolved chain: `generated/stack-fastapi.md` (base + backend +
+>   python-fastapi)
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: OrderService — Platform team — Python 3.11 /
+>   FastAPI / Pydantic v2 / SQLAlchemy 2 async + Alembic /
+>   PostgreSQL — uv, ruff, mypy strict, pytest — JWT bearer auth,
+>   OpenAPI as the published contract — Docker on Kubernetes
 
-- **Name**: OrderService
-- **Owner**: Platform team
-- **Repo**: github.com/acme/order-service
-- **Deployment**: Docker → Kubernetes (cloud)
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: Python 3.11+
 - Framework: FastAPI
 - Runtime: asyncio (async/await throughout)
 - Validation: Pydantic v2
 - Package manager: uv
-- Linter: ruff
-- Formatter: ruff format
+- Linter / formatter: ruff + ruff format
 - Type checker: mypy (strict mode)
 - Test runner: pytest + httpx (AsyncClient)
-- Database: PostgreSQL via SQLAlchemy 2 (async) + Alembic
+- ORM: SQLAlchemy 2.x async + Alembic migrations
+- Database: PostgreSQL via `asyncpg`
 - Auth: JWT bearer tokens
 - ASGI server (production): uvicorn + gunicorn
-- Distribution: Docker image → Kubernetes
+- Distribution: Docker image -> Kubernetes
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 src/
   order_service/
     __init__.py
-    main.py              # FastAPI app instance, lifespan, router includes
+    main.py              # FastAPI app, lifespan, router includes
     config.py            # Settings via pydantic-settings
-    dependencies.py      # Shared FastAPI dependencies
+    dependencies.py      # Shared Depends() — db session, current user
     routers/
-      [feature].py       # APIRouter per feature domain
+      orders.py          # /orders endpoints
+      fulfilments.py     # /orders/{orderId}/fulfilments endpoints
+      auth.py            # /auth/login, /auth/refresh
+      health.py          # /health, /ready
     schemas/
-      [feature].py       # Pydantic request/response models
+      orders.py          # OrderCreate, OrderUpdate, OrderResponse
+      fulfilments.py
+      auth.py
     services/
-      [feature].py       # Business logic (pure, async)
+      orders.py          # business logic — pure async functions
+      fulfilments.py
     models/              # SQLAlchemy ORM models
-    db.py                # Async engine and session setup
+      order.py
+      order_line.py
+      fulfilment.py
+    db.py                # async engine, session factory
+    errors.py            # domain exceptions + handlers
 tests/
-  conftest.py            # async client fixture
+  conftest.py            # async client, test DB, fixtures
   component/
-    test_[feature].py
+    test_orders.py
+    test_fulfilments.py
   integration/
-    test_[feature].py
+    test_orders.py
+    test_auth.py
 pyproject.toml
 .env.example
 Dockerfile
+docker-compose.yml
 README.md
 CLAUDE.md
 ```
 
----
+- One directory per feature domain — not one directory per layer
+- `services/<feature>.py` holds business logic with no framework imports
+- All editable config in `config.py` — never hardcoded in source modules
 
-## Commands
+### 1.3 Commands
 
 ```bash
-uvicorn order_service.main:app --reload   # develop — hot reload at localhost:8000
-alembic upgrade head                      # apply migrations
-alembic revision --autogenerate -m "..."  # generate a migration
-pytest                                    # run tests
-mypy src/ --strict                        # type check
-gunicorn order_service.main:app -w 4 -k uvicorn.workers.UvicornWorker  # production
+uv run uvicorn order_service.main:app --reload   # develop — :8000
+uv run alembic upgrade head                      # apply migrations
+uv run alembic revision --autogenerate -m "describe change"
+uv run pytest                                     # run tests
+uv run mypy src/ --strict                         # type check
+uv run ruff check src/ tests/                     # lint
+uv run ruff format src/ tests/                    # format
+uv run gunicorn order_service.main:app -w 4 \
+  -k uvicorn.workers.UvicornWorker                # production server
+docker compose up                                 # start full stack
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Use conventional commit prefixes: `feat:`, `fix:`, `chore:`, `docs:`,
-  `refactor:`, `style:`, `test:`
-- Keep the subject line under 80 characters
-- Use the imperative mood: "add feature" not "added feature"
-- Always work on a branch — never commit directly to `main`
-- Branch naming: `feat/description`, `fix/description`, `chore/description`,
-  `docs/description`
-- PRs should be small and focused — one concern per PR
-- After a PR is merged: delete branch, pull main before starting new work
-- Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`
-- Alembic migrations are committed — never regenerate a migration already merged
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`,
+  `docs/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
+  docs, refactor, test; subject under 80 characters, imperative mood
+- PRs are small and focused — one concern per PR; require one approval
+  and passing CI before merge
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new work
+- Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`, `dist/`
+- Alembic migrations are committed — never regenerate a migration
+  already merged
+- Every repository MUST have a `.gitignore` and a committed lockfile
 
----
+### 2.2 Python
 
-## Code conventions
+- Follow PEP 8 (enforced by ruff) — fix the code, never disable a rule
+  to work around style
+- Follow PEP 257 Google-style docstrings — every public symbol has one
+- Follow PEP 484 / PEP 526 type annotations — all public functions and
+  class members annotated; run `mypy src/ --strict`
+- No bare `Any` — use specific types, `TypeVar`, or `TypeAlias`
+- Use `from __future__ import annotations` for forward references
+- Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`,
+  `dict` in public signatures
+- Keep functions small and single-purpose; cognitive complexity <= 15
+- Raise specific exceptions — never bare `except:` or `except Exception:`
+- No mutable default arguments
+- No debug statements (`print()`, `pdb.set_trace()`) in committed code
+- Source files UTF-8, ASCII content only, LF line endings
 
-### Application setup
+### 2.3 Application setup
 
 - One `FastAPI` instance in `main.py` — no global state elsewhere
-- Use `lifespan` context manager for startup/shutdown (not deprecated events)
-- Include all routers via `app.include_router()` in `main.py`
-- Set `title`, `version`, and `description` on the app instance
+- Use the `lifespan` context manager for startup/shutdown — not
+  deprecated event handlers
+- Initialise the database engine in `lifespan`, not at module level
+- Set `title`, `version`, and `description` on the app instance — these
+  become the OpenAPI document header
+- Register all routers via `app.include_router()` in `main.py`
 
-### Configuration
+### 2.4 Configuration
 
-- Use `pydantic-settings` (`BaseSettings`) for all configuration
-- `Settings` instantiated once and injected as a dependency — never imported
-  globally
-- Never read `os.Getenv` directly in application code outside the config loader
+- `pydantic-settings` `BaseSettings` in `config.py` — reads from the
+  environment automatically
+- One `Settings` class, instantiated once at startup, injected via
+  `Depends(get_settings)` — never imported as a global in service code
+- Never read `os.getenv` directly in application code outside the
+  config loader
+- `.env.example` committed with placeholders; `.env` in `.gitignore`
+- Required vars: `ORDER_DATABASE_URL`, `ORDER_JWT_SECRET`,
+  `ORDER_JWT_ISSUER`, `ORDER_JWT_AUDIENCE`, `ORDER_ALLOWED_ORIGINS`
+- Prefix every env var with `ORDER_` to avoid collisions
+- Fail fast: a missing required setting raises `ValidationError` on
+  startup
+- The port MUST be configurable via environment variable — never
+  hardcoded
 
-### Routing and dependencies
+### 2.5 Routing and HTTP
 
-- One `APIRouter` per feature domain with a prefix and tags
-- Routes thin — delegate business logic to service functions
-- Shared logic (auth, DB session, current user) via `Depends()`
-- Use `Annotated` for dependency injection — avoid bare `= Depends()` in
-  signatures
-- Return type annotations on all route functions
+- One `APIRouter` per feature domain, with a prefix and tags
+- Handlers are thin: decode request -> call service -> encode response;
+  no business logic in handlers
+- Inject auth, DB session, and current user via `Depends()` using
+  `Annotated` syntax — avoid bare `= Depends()` in signatures
+- Return type annotations on all route handlers — FastAPI uses them for
+  OpenAPI
+- Path segments MUST be lowercase plural nouns with hyphens:
+  `/orders`, `/orders/{orderId}/fulfilments` — no verbs, no trailing
+  slash
+- Address individual resources under their collection
+  (`/orders/{orderId}`); nest sub-resources under their parent
+- Query parameter names use camelCase; reserve `limit`, `skip`,
+  `offset`, `expand`, `sortedBy` for framework use
+- No unbounded list endpoints — always paginate with an explicit limit
+- JSON is the default format; date/time values use ISO 8601, currency
+  amounts use ISO 4217 codes
+- Serialise any integer above 2^53 - 1 as a string; reject non-finite
+  floats at the serialisation boundary
+- All traffic served over HTTPS — plain HTTP is not acceptable
 
-### Schemas
+### 2.6 Schemas
 
-- Separate request and response schemas — never reuse ORM models as responses
-- Use `model_config = ConfigDict(from_attributes=True)` for ORM-backed responses
+- Separate request and response schemas — ORM models are never returned
+  directly
+- `model_config = ConfigDict(from_attributes=True)` on ORM-backed
+  response schemas
 - All fields explicitly typed — no bare `Any`
-- Use `Field(...)` for validation constraints (min/max length, regex, ge/le)
+- `Field(...)` for all validation constraints (min/max length, regex,
+  ge/le) — e.g. order quantities `ge=1`, line totals `ge=0`
 - Validators via `@field_validator` — no custom `__init__`
+- Responses contain only the fields the caller needs — no padding
 
-### Async conventions
-
-- All route handlers and service functions `async def`
-- Blocking I/O (file reads, sync DB calls) must run in `asyncio.to_thread()`
-- Never `await` inside a list comprehension — use `asyncio.gather()` for
-  concurrency
-- Use `asyncpg` for the async PostgreSQL driver
-
-### Error handling
+### 2.7 Error handling
 
 - Raise `HTTPException` with explicit `status_code` and `detail`
-- Register custom exception handlers in `main.py` for domain exceptions
+- Map domain exceptions (`OrderNotFound`, `OrderAlreadyFulfilled`) to
+  HTTP errors via custom exception handlers registered in `main.py`
+- Follow RFC 9457 (`application/problem+json`) for the error body shape;
+  use 4xx for client errors, 5xx for server errors — never 200 for an
+  error
+- Never return stack traces, internal paths, or implementation details
+  to the client
+- Log every error once with the request ID for traceability
 
-### Database
+### 2.8 Database
 
-- SQLAlchemy 2.x with async engine (`create_async_engine`)
-- Session injected per request via `Depends(get_db)` — never a global session
-- Migrations managed by Alembic
-- Use `select()` style queries — no legacy `Query` API
+- SQLAlchemy 2.x with async engine (`create_async_engine`) and `asyncpg`
+- Session injected per request via `Depends(get_db)` — never a global
+  session; use the connection pool, never a connection per request
+- `select()` style queries only — no legacy `Query` API; avoid
+  `SELECT *`
+- No N+1 queries — use `selectinload` or `joinedload` for order lines
+  and fulfilments fetched with their parent order
+- Add an index for every foreign key explicitly in migrations
+- Wrap multi-step writes (order + lines, order + fulfilment) in a single
+  transaction; keep transactions short and never hold one across an HTTP
+  request boundary
+- All schema changes via Alembic — one migration per logical change,
+  each reversible with a `down`
 
-### Authentication
+### 2.9 Async conventions
 
-- JWT bearer tokens validated in a shared `Depends()` dependency
-- Never log or expose token payloads in error responses
+- All route handlers and service functions are `async def`
+- Blocking I/O runs in `asyncio.to_thread()` — never block the event
+  loop
+- Use `asyncio.gather()` for concurrent independent awaits — never
+  `await` inside a list comprehension or a sequential loop
+- Use structured concurrency (`asyncio.TaskGroup`) over fire-and-forget;
+  background tasks started in `lifespan` get a clean shutdown path
+- Pass request context (request ID, user identity) explicitly — never
+  via thread-locals
 
-### OpenAPI
+### 2.10 Authentication and authorization
 
-- All routes have `summary`, `tags`, and explicit `response_model`
-- Disable OpenAPI in production if the API is not public: `openapi_url=None`
-- Keep schema clean — avoid `include_in_schema=False` as a crutch
+- Keep authentication (who) and authorization (what) in separate layers;
+  never implement cryptographic primitives — use audited libraries
+- JWT bearer tokens — issued at `/auth/login`, validated via
+  `Depends(get_current_user)`; refreshed at `/auth/refresh`
+- Validate every JWT: signature, `exp`, `iss`, `aud` — reject tokens
+  missing any required claim
+- Token lifetime: access <= 15 min, refresh <= 7 days (rotated on use)
+- Access tokens MUST arrive in `Authorization: Bearer <token>` only —
+  never in cookies or query parameters
+- Refresh tokens stored server-side so they can be revoked, and held in
+  `httpOnly`, `Secure`, `SameSite=Strict` cookies on the client
+- Fail closed: deny by default, grant explicitly; centralise auth — no
+  scattered permission checks across handlers
+- Use RBAC as the baseline (customer, fulfilment-operator, admin); layer
+  ABAC only where fine-grained rules need it
+- Authorise at the service layer, not only in route handlers — a route
+  that passes auth may call a service that touches another customer's
+  order
+- Never trust client-supplied IDs for ownership checks — verify the
+  authenticated user owns the requested order
+- For service-to-service calls, issue minimum-scope API keys, hash them
+  before storing, and rotate on a schedule and on suspected compromise
+- Never log tokens, passwords, or secrets — even at DEBUG level
 
----
+### 2.11 OpenAPI (published contract)
 
-## Testing
+- The OpenAPI document is the published contract for this service —
+  consumers (fulfilment workers, the storefront, partner integrations)
+  generate clients from it, so schema drift is a breaking change
+- Every route has `summary`, `tags`, and an explicit `response_model` —
+  a route without a `response_model` is incomplete
+- Document every non-2xx status a route can return with a `responses`
+  entry; the RFC 9457 problem shape is declared once and reused
+- Pin `title`, `version`, and `description` on the app; bump the OpenAPI
+  `version` on any contract change and note it in the changelog
+- Keep the schema clean — avoid `include_in_schema=False` as a crutch
+  for hiding endpoints; an endpoint either belongs in the contract or
+  does not exist
+- Disable OpenAPI in production if the API is not public:
+  `openapi_url=None`
 
-- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient`
-  (sync)
-- One async `client` fixture in `conftest.py`
-- Test each route for: success (2xx), validation error (422), auth error
-  (401/403)
-- No mocking of the database in component integration tests — use a test
-  database
-- Override dependencies with `app.dependency_overrides` in tests
-- Component test naming: `test_<route_or_function>_<state>_<expected>`
-  e.g. `test_create_order_invalid_payload_returns_422`
+## 3. Quality
+
+### 3.1 Testing
+
+- `httpx.AsyncClient` with `ASGITransport` for all route tests — no sync
+  `TestClient`
+- One async `client` fixture in `conftest.py`; override dependencies via
+  `app.dependency_overrides`
+- Test DB is a real PostgreSQL schema, truncated between runs — no
+  database mocking, no SQLite substitution
+- Test each endpoint for: success (2xx), validation error (422), auth
+  error (401/403), not found (404)
+- Test auth explicitly: protected routes return 401 unauthenticated and
+  403 with insufficient role; an expired token and a revoked refresh
+  token are both rejected
+- Test naming: `test_<route_or_function>_<state>_<expected>` — e.g.
+  `test_create_order_invalid_payload_returns_422`,
+  `test_fulfil_order_already_fulfilled_returns_409`
 - Component tests in `tests/component/`, integration tests in
   `tests/integration/`
+- New code MUST reach 90% coverage; total coverage MUST NOT regress and
+  SHOULD stay at or above 80%
 - Run before every commit: `pytest && mypy src/ --strict`
-- Use `pytest-asyncio` for async test functions
 
----
+### 3.2 Observability
 
-## Documentation
+- Structured JSON logs in production, human-readable in development; the
+  request ID is included in every log entry for a request lifecycle;
+  default level INFO — DEBUG/TRACE off in production
+- Log errors once, at the top of the call stack; 4xx at INFO, 5xx at
+  ERROR; log auth failures at WARN with IP and username (never the
+  password)
+- Never log passwords, tokens, API keys, or PII (customer addresses,
+  payment references)
+- `/health` — shallow liveness check, returns 200 if the process is
+  alive; requires no authentication
+- `/ready` — deep readiness check, verifies PostgreSQL connectivity,
+  returns 503 when a critical dependency is down
+- Assign a trace ID at the service boundary, propagate it via the W3C
+  `traceparent` header, and return it on errors (`X-Trace-Id`)
+- Instrument with OpenTelemetry; span names use route templates, not
+  URLs with order IDs
 
-- Keep `README.md` up to date with setup, run, and test instructions
-- Every public module, class, and function has a docstring
-- Architecture decisions recorded as ADRs in `docs/decisions/`
+## 4. Identity
+
+Not applicable — this project has no design system or brand voice. Its
+public contract is the OpenAPI schema served at `/docs` (disabled in
+production via `openapi_url=None`).
+
+## 5. Review process
+
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority order
+(highest first):
+
+1. Security — auth enforced at the service layer, RBAC checks present, no
+   secrets or PII in logs, HTTPS-only, no client-trusted ownership checks
+2. Correctness — routes thin, services pure-async, no N+1 queries,
+   order/line/fulfilment writes transactional, OpenAPI `response_model`
+   matches the schema actually returned
+3. Clarity — names are self-documenting, functions single-purpose,
+   cognitive complexity <= 15
+4. Conventions — PEP 8 / mypy strict clean, schema separation, RFC 9457
+   error shape, URI and query-parameter casing rules
+
+Confirm CI is green. Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `pytest && mypy src/ --strict` before every PR
+- Verify `.env.example` lists every required variable and `README.md`
+  documents the env reference and commands
+- Verify every route has `summary`, `tags`, and an explicit
+  `response_model`, that documented error responses match the handlers,
+  and that the OpenAPI `version` was bumped if the contract changed
+- Verify new endpoints have success / 422 / auth / 404 tests
+- Run the audit after: new project, migration, a new feature domain, a
+  contract change, or before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first change
+2. Check the current branch — if not `main`, ask why before proceeding
+3. Check `git status` — if uncommitted changes exist, ship the previous
+   session's wrap (branch, commit, push, merge) before any new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest CI/CD deploy on `main` completed successfully — flag
+   if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable for
+   this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over starting
+  something new
+- Run `pytest && mypy src/ --strict` after every change — do not
+  accumulate unverified changes
+- When a tool (formatter, codemod, migration autogenerate) touches
+  unrelated files, revert the drift before committing and file it
+  separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish", "end
+session", "close out", or similar), print the full checklist below and
+execute each item sequentially. Mark each item done (with result) before
+moving to the next. Do not batch, skip, or summarize — visible
+sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a new
+   directory or content move between documents each needs an ADR
+6. Migrations — confirm every schema change has a reversible Alembic
+   migration committed and applied (`alembic upgrade head`)
+7. OpenAPI contract — confirm the `version` was bumped if any route,
+   schema, or error response changed, and the change is noted in the
+   changelog so consumers can regenerate clients
+8. CLAUDE.md — for each new convention, decide whether it belongs here
+   (a rule the agent MUST apply every turn) or in another doc; keep each
+   rule to one line
+9. README.md — for each new command, dependency, or env var, confirm it
+   is reflected; name the section
+10. docs/ONBOARDING.md — for each new tool, prerequisite, or setup step,
+    confirm it is documented; name the section
+11. docs/PLAYBOOK.md — for each new command, script, or workflow,
+    confirm it is documented; name the section
+12. Tests and types — run `pytest && mypy src/ --strict` and confirm
+    both pass
+13. Flag gaps — if any item cannot be completed this session, report it
+    as pending (never as done) before closing
+14. Summary — summarize what was done and what is next

--- a/examples/react-spa/CLAUDE.md
+++ b/examples/react-spa/CLAUDE.md
@@ -1,22 +1,32 @@
 # AdminFlow
 
-Analytics dashboard for monitoring SaaS subscription metrics and customer health.
+Analytics dashboard for monitoring SaaS subscription metrics and
+customer health.
 
----
+- Owner: Growth engineering
+- Repo: github.com/acme/adminflow
+- Deployment: Vercel — production on merge to `main`, preview per PR
+- Model: inline
 
-## Project identity
+> Generation inputs (per ADR-016 — examples are agent-generated
+> outputs of the documented pipeline):
+>
+> - Stack source: `stack/spa-react.md`
+> - Resolved chain: `generated/stack-react-spa.md` (base + frontend +
+>   spa-react)
+> - Output format: `base/core/agents.md` (inline model)
+> - Project brief: AdminFlow — Growth engineering — TypeScript /
+>   React 18 / Vite 5 / TanStack Router + Query v5 / Zustand /
+>   Tailwind CSS v3 — Vitest + RTL, Playwright, msw — pnpm — Vercel
 
-- **Name**: AdminFlow
-- **Owner**: Growth engineering
-- **Repo**: github.com/acme/adminflow
-- **Deployment**: Vercel (production + preview per PR)
-- **Stack source**: `stack/spa-react.md`
-- **Output format**: `base/core/agents.md`
+This file is self-contained: all rules are inlined, no external
+templates need to be read.
 
----
+## 1. Project
 
-## Stack
+### 1.1 Overview
 
+- Model: inline
 - Language: TypeScript (strict mode)
 - Framework: React 18
 - Bundler: Vite 5
@@ -27,12 +37,13 @@ Analytics dashboard for monitoring SaaS subscription metrics and customer health
 - HTTP client: TanStack Query + native fetch
 - Test runner: Vitest + React Testing Library
 - E2E: Playwright
+- Network mocking: msw (Mock Service Worker)
+- Linter: ESLint + `eslint-plugin-sonarjs` + `eslint-plugin-jsx-a11y`
+- Formatter: Prettier (owns all formatting decisions)
 - Package manager: pnpm
 - Deployment: Vercel — automatic on merge to `main`
 
----
-
-## Architecture
+### 1.2 Project structure
 
 ```
 src/
@@ -43,32 +54,33 @@ src/
     Filters/
       DateRangePicker.tsx
       DateRangePicker.test.tsx
-    UI/               # shared design system components
+    UI/                 # shared design-system components
       Button.tsx
       Badge.tsx
       Table.tsx
   pages/
-    Dashboard.tsx     # /
-    Customers.tsx     # /customers
-    Subscriptions.tsx # /subscriptions
-    Settings.tsx      # /settings
+    Dashboard.tsx       # /
+    Customers.tsx       # /customers
+    Subscriptions.tsx   # /subscriptions
+    Settings.tsx        # /settings
   hooks/
     useMetrics.ts
     useCustomers.ts
     useAuth.ts
   services/
-    api.ts            # base fetch wrapper, auth headers, error handling
+    api.ts              # base fetch wrapper, auth headers, errors
     metrics.ts
     customers.ts
   store/
-    authStore.ts      # Zustand — current user, session
-    uiStore.ts        # Zustand — sidebar state, active filters
+    authStore.ts        # Zustand — current user, session
+    uiStore.ts          # Zustand — sidebar state, active filters
   types/
-    api.ts            # API response types
-    domain.ts         # Customer, Subscription, Metric shapes
+    api.ts              # API response types
+    domain.ts           # Customer, Subscription, Metric shapes
   utils/
-    formatters.ts     # currency, date, percentage formatters
+    formatters.ts       # currency, date, percentage formatters
     validators.ts
+  index.css             # base resets, CSS custom properties
   App.tsx
   main.tsx
 e2e/
@@ -82,9 +94,11 @@ README.md
 CLAUDE.md
 ```
 
----
+- One directory per feature domain under `components/`
+- `src/services/` holds all API calls — no business logic in components
+- All editable visual values in `tailwind.config.ts` — never hardcoded
 
-## Commands
+### 1.3 Commands
 
 ```bash
 pnpm dev            # develop — hot reload at localhost:5173
@@ -93,98 +107,295 @@ pnpm preview        # preview production build locally
 pnpm test           # run unit tests (watch mode)
 pnpm test:run       # run unit tests once (CI)
 pnpm e2e            # run Playwright E2E tests
-tsc --noEmit        # type check without emitting
 pnpm lint           # ESLint check
+tsc --noEmit        # type check without emitting
 ```
 
----
+## 2. Code conventions
 
-## Git conventions
+### 2.1 Git
 
-- Branch: `main` (protected), feature branches as `feat/<scope>`
-- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore, style, test
-- PRs require one approval + passing CI (lint, type check, tests) before merge
+- Branch: `main` (protected) — never commit directly
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `chore/<scope>`,
+  `docs/<scope>`
+- Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
+  docs, refactor, style, test; subject under 80 characters,
+  imperative mood
+- PRs are small and focused — one concern per PR; require one approval
+  and passing CI (lint, type check, tests) before merge
+- Repeat the closing keyword before each issue number:
+  `Closes #a, closes #b` — a bare `#b` stays open
+- Never force-push a branch, including with `--force-with-lease`; when
+  behind `main`, merge `main` in or use `gh pr update-branch`
+- After a PR is merged, delete the branch and pull `main` before new
+  work
 - Do not commit `node_modules/`, `dist/`, `.env`, `.env.local`
-- Lock file (`pnpm-lock.yaml`) is committed — do not delete it
+- Lock file (`pnpm-lock.yaml`) is committed — never delete it
+- Every repository MUST have a `.gitignore` and a committed lockfile
 - Run `pnpm test:run && tsc --noEmit` before every commit
 
----
-
-## Code conventions
-
-### TypeScript
+### 2.2 TypeScript
 
 - `strict: true` in `tsconfig.json` — no exceptions
+- Follow `@typescript-eslint/recommended`
 - No `any` — use `unknown` and narrow, or define a proper type
 - Explicit return types on all non-trivial functions
-- `interface` for object shapes, `type` for unions and aliases
-- Import types with `import type { ... }` to keep runtime bundle clean
+- `interface` for object shapes; `type` for unions and aliases
+- Use discriminated unions (a literal `type`/`kind` field) for type
+  families — safer than class hierarchies
 - No enums — use `as const` objects or string literal unions
+- Import types with `import type { ... }` to keep the runtime bundle
+  clean
+- Booleans prefix with `is`, `has`, or `can` (`isActive`,
+  `hasPermission`)
+- `eslint-plugin-sonarjs` MUST be in the ESLint config; cognitive
+  complexity <= 15 per function
+- Prettier owns all formatting — no style discussion in review
+- Source files UTF-8, ASCII content only, LF line endings
 
-### Components
+### 2.3 Components
 
-- One component per file — filename matches component name (PascalCase)
+- One component per file — filename matches component name
+  (PascalCase)
 - Functional components only — no class components
 - Props typed with an explicit `interface` or `type` in the same file
-- No prop drilling beyond two levels — use Zustand store or TanStack Query
-- Extract reusable logic into custom hooks in `src/hooks/`
+- No prop drilling beyond two levels — use a Zustand store, context,
+  or TanStack Query
+- Separate container (data + state) from presentational (props only)
+  components — presentational components have no side effects
+- Extract reusable stateful logic into custom hooks
+  (`use[Name].ts` in `src/hooks/`)
 - Keep components under ~150 lines — split if larger
-
-### State management
-
-- **Server state** (API data): TanStack Query — `useQuery`, `useMutation`
-- **Client/global state** (auth, UI): Zustand slices in `src/store/`
-- **Local state** (component-scoped): `useState`, `useReducer`
-- Never duplicate server state in Zustand — TanStack Query is the cache
 - No direct DOM manipulation — all state flows through React
 
-### API integration
+### 2.4 State management
 
-- All API calls in `src/services/` — never inline `fetch` in components
-- `src/services/api.ts` is the only place that sets auth headers and handles
-  401 responses (redirect to login)
+| State type | Tool                     | When to use                     |
+| ---------- | ------------------------ | ------------------------------- |
+| Local UI   | `useState`, `useReducer` | Form inputs, toggles, counters  |
+| Shared UI  | Zustand                  | Auth session, sidebar, filters  |
+| Server     | TanStack Query           | Lists, detail views, paginated  |
+| URL        | TanStack Router params   | Bookmarkable filters, paging    |
+
+- Server state (API data) lives in TanStack Query — `useQuery`,
+  `useMutation`; never duplicate it in Zustand
+- Client/global state (auth, UI) lives in Zustand slices in
+  `src/store/` — one slice per domain concern
+- Never put derived state in the store — compute it from existing
+  state
+- Prefer URL state for anything the user should bookmark or share
+
+### 2.5 API integration
+
+- All API calls in `src/services/` — never inline `fetch` in
+  components
+- `src/services/api.ts` is the only place that sets auth headers and
+  handles 401 responses (redirect to login)
 - Return typed response objects — no untyped `any` at API boundaries
-- Handle loading, error, and empty states explicitly in every data-dependent view
-- Tokens stored in memory (Zustand `authStore`) — never in `localStorage`
+- Validate external responses at the boundary (Zod or equivalent) —
+  allowlist valid shapes, reject everything else
+- Handle loading, error, and empty states explicitly in every
+  data-dependent view
+- Tokens stored in memory (Zustand `authStore`) — never in
+  `localStorage`; prefer `httpOnly` cookies for refresh tokens
+- Encode dynamic data on output — never `dangerouslySetInnerHTML`
+  with user-supplied content
+- Never hardcode secrets, API keys, or tokens in source — use `.env`,
+  commit `.env.example` with placeholders only
 
-### Styling
+### 2.6 Styling
 
-- Tailwind utility classes only — no custom CSS files except `src/index.css`
-  for base resets and CSS custom properties
-- No inline styles except for dynamic computed values (e.g. chart widths)
-- No hardcoded colour or spacing values outside of `tailwind.config.ts`
-- Mobile-first: base styles for mobile, `md:` / `lg:` for larger breakpoints
+- Tailwind utility classes only — no custom CSS files except
+  `src/index.css` for base resets and CSS custom properties
+- No inline styles except for dynamic computed values (e.g. chart
+  widths)
+- No hardcoded colour or spacing values outside `tailwind.config.ts`
+- Mobile-first: base styles for mobile, `md:` / `lg:` for larger
+  breakpoints
+- Breakpoints: small mobile <=480px, mobile <=768px, tablet <=1024px
 
----
+## 3. Quality
 
-## Testing
+### 3.1 Testing
 
-- React Testing Library for component tests — test behaviour, not implementation
-- Prefer accessible queries: `getByRole`, `getByLabelText`, `getByText`
-  over `getByTestId`
-- Mock API calls at the network boundary with `msw` — not inside components
+- React Testing Library for component tests — test behaviour, not
+  implementation
+- Prefer accessible queries: `getByRole`, `getByLabelText`,
+  `getByText` over `getByTestId`
+- Mock API calls at the network boundary with `msw` — not inside
+  components
 - Vitest for unit tests on utils, hooks, and services
-- Name component tests using Given/When/Then:
-  `given an unauthenticated user, when they visit the dashboard, then they are redirected to login`
-- E2E tests MUST cover: login, dashboard load, customer search, date filter
+- Test factory defaults for optional fields MUST be `undefined`
+  (omitted), not convenient values like `false` or `0`
+- Component test naming uses Given/When/Then:
+  `given an unauthenticated user, when they visit the dashboard,
+  then they are redirected to login`
+- E2E (Playwright) MUST cover: login, dashboard load, customer
+  search, date filter
+- New code MUST reach 90% coverage; total coverage MUST NOT regress
+  and SHOULD stay at or above 80%
+- A failing test triggers an investigation before any other action —
+  never skip or suppress without a documented reason
 - Run before every commit: `pnpm test:run && tsc --noEmit`
 
----
+### 3.2 Accessibility
 
-## Accessibility
+Target WCAG 2.1 AA. Automated tools catch ~30-40% of issues; the
+rest require manual testing.
 
-- All interactive elements keyboard-accessible
-- Semantic HTML — `<button>` not `<div onClick>`, `<nav>` for navigation
+- All interactive elements keyboard-accessible and operable
+- Semantic HTML — `<button>` not `<div onClick>`, `<nav>` for
+  navigation; any `onClick` element MUST contain a real `<button>`
 - Every form input has an associated `<label>` or `aria-label`
-- Charts include a `<title>` and accessible text fallback for screen readers
-- Modals trap focus and restore it on close
-- WCAG 2.1 AA compliance — colour contrast ratio ≥ 4.5:1 for normal text
+- Icon-only or ambiguous links MUST have a descriptive `aria-label`
+- Use `:focus-visible` for focus indicators; all links and nav links
+  MUST show a visible focus outline
+- No content that relies on colour alone to convey meaning
+- Colour contrast >= 4.5:1 for normal text, >= 3:1 for large text
+- Charts include a `<title>` and an accessible text fallback for
+  screen readers
+- Modals trap focus, restore it on close, and close on Escape
+- Boolean table columns sort descending (true first) on first click
 
----
+Automated checks (run in CI):
 
-## Documentation
+- `jest-axe` (or `@axe-core/react`) — zero violations before merge
+- Lighthouse accessibility score >= 90 on all key pages
+- `eslint-plugin-jsx-a11y` — catches missing `alt`, bad ARIA, and
+  missing labels at write time
 
-- Single source of truth: this file + inline JSDoc on exported utilities
-- Architecture decisions in `docs/adr/` — numbered Markdown files
-- `README.md`: setup steps, env var reference, and test instructions only
-- No wiki or external docs — everything lives in the repo
+Manual checks (before shipping new interactive components):
+
+- Keyboard-only navigation — every action reachable, logical focus
+  order, no unintended focus traps
+- Screen reader walkthrough (NVDA + Chrome) — content and state
+  changes announced correctly
+- Zoom to 200% — no clipping or horizontal scroll at a 1280px
+  viewport
+
+### 3.3 Performance
+
+- Monitor Core Web Vitals (LCP, CLS, INP) — treat regressions as bugs
+- Keep client-side JS minimal — every dependency adds to bundle size;
+  defer non-critical scripts
+- Preload critical above-the-fold assets
+- Use skeleton loading and optimistic updates for perceived speed;
+  document the rollback path for every optimistic mutation
+
+## 4. Identity
+
+### 4.1 Design
+
+AdminFlow is an internal admin UI built on a small shared
+design system in `src/components/UI/`.
+
+- Use the shared design-system components (`Button`, `Badge`,
+  `Table`) — never build ad-hoc components that duplicate them
+- Design tokens (colours, spacing, typography, radii) come from
+  `tailwind.config.ts` — never hardcode visual values
+- Component-driven: build UI as a hierarchy of reusable,
+  self-contained components; avoid monolithic page views
+- New shared components SHOULD ship with a usage example before
+  merge
+- Least Surprise: if a control looks like a button it MUST behave
+  like a button; keep interaction patterns consistent across pages
+- Progressive disclosure: surface only what the user needs at each
+  step — dashboards default to summary, drill-downs on demand
+- No dark patterns — no misleading UI, forced actions, or hidden
+  costs
+
+## 5. Review process
+
+### 5.1 Code review
+
+Before merging, review the diff against the base branch in priority
+order (highest first):
+
+1. Security — responses validated at the boundary, no
+   `dangerouslySetInnerHTML` with user data, tokens in memory not
+   `localStorage`, no secrets in source
+2. Correctness — server state in TanStack Query (not duplicated in
+   Zustand), API calls only in `src/services/`, loading / error /
+   empty states handled, no direct DOM manipulation
+3. Clarity — names self-documenting, components single-purpose and
+   under ~150 lines, cognitive complexity <= 15
+4. Conventions — `strict` clean with no `any`, accessible queries in
+   tests, Given/When/Then test names, Tailwind tokens not hardcoded
+   values, `jsx-a11y` and `sonarjs` clean
+
+Confirm CI is green and the browser console is free of warnings.
+Only merge after the review passes.
+
+### 5.2 Structure audit
+
+- Run `pnpm test:run && tsc --noEmit && pnpm lint` before every PR
+- Verify `axe` reports zero violations and Lighthouse a11y >= 90 on
+  changed pages
+- Verify new components live under the correct feature directory and
+  reuse `src/components/UI/` rather than duplicating it
+- Verify `README.md` documents the env reference and commands, and
+  `.env.example` lists every required variable
+- Run the audit after: new project, new route or feature domain, a
+  new shared component, or before a release
+
+## 6. Session protocol
+
+### 6.1 Start of session
+
+1. Read this `CLAUDE.md` and `README.md` in full before the first
+   change
+2. Check the current branch — if not `main`, ask why before
+   proceeding
+3. Check `git status` — if uncommitted changes exist, ship the
+   previous session's wrap (branch, commit, push, merge) before any
+   new work
+4. Clean up stale branches: `git fetch --prune`, then delete local
+   branches whose PRs have merged
+5. Check the latest Vercel deploy on `main` completed successfully —
+   flag if stuck, failed, or pending
+6. Confirm the scope with the user before making changes
+7. If the task is ambiguous, ask: "What is the specific deliverable
+   for this session?"
+8. Review open issues related to the agreed scope before writing code
+
+### 6.2 During the session
+
+- Flag explicitly when a task grows beyond the agreed scope — do not
+  silently absorb new requests
+- Finishing and committing the current work takes priority over
+  starting something new
+- Run `pnpm test:run && tsc --noEmit` after every change — do not
+  accumulate unverified changes
+- When a tool (formatter, codemod) touches unrelated files, revert
+  the drift before committing and file it separately
+
+### 6.3 End of session
+
+When the user signals end of session ("wrap up", "let's finish",
+"end session", "close out", or similar), print the full checklist
+below and execute each item sequentially. Mark each item done (with
+result) before moving to the next. Do not batch, skip, or summarize
+— visible sequential execution prevents missed steps.
+
+1. Commits and push — all changes committed and pushed (via PR if
+   branch-protected)
+2. Close issues — close completed issues (verify auto-close worked)
+3. Epic checklists — update epic checklists if relevant
+4. Dev journal — add a session entry to `docs/dev-journal.md` (date,
+   tool, key changes, PRs merged, issues closed/created)
+5. ADRs — record any architectural decisions in `docs/decisions/`; a
+   new directory or content move between documents each needs an ADR
+6. CLAUDE.md — for each new convention, decide whether it belongs
+   here (a rule the agent MUST apply every turn) or in another doc;
+   keep each rule to one line
+7. README.md — for each new command, dependency, or env var, confirm
+   it is reflected; name the section
+8. docs/ONBOARDING.md — for each new tool, prerequisite, or setup
+   step, confirm it is documented; name the section
+9. docs/PLAYBOOK.md — for each new command, script, or workflow,
+   confirm it is documented; name the section
+10. Tests and types — run `pnpm test:run && tsc --noEmit && pnpm
+    lint` and confirm all pass
+11. Flag gaps — if any item cannot be completed this session, report
+    it as pending (never as done) before closing
+12. Summary — summarize what was done and what is next


### PR DESCRIPTION
## What

Regenerates every `examples/*/CLAUDE.md` through the documented local-agent pipeline, executing the maintenance model decided in ADR-016 (#13).

## How (per ADR-016)

Each example was regenerated by attaching its existing project brief + `generated/<stack>.md` (resolved chain) + `templates/base/core/agents.md` (output models) to a local agent — not hand-edited.

## Changes

| Example | Before | After |
|---------|--------|-------|
| fastapi-service, flask-api, go-service, metricshub, order-service, react-spa, astro-portfolio | pre-`agents.md` free-form (no §5/§6) | six-section **inline** model + §5 Review + §6 Session protocol (compliant §6.3) |
| hybrid-astro | six-section but duplicate `### 1.3` | fixed numbering, kept as the **hybrid**-model demo |

- **Disambiguation:** the two same-named Go examples now differ — `go-service` → **MetricStream** (chi); `metricshub` keeps **MetricsHub** (Echo).
- Each file records its generation inputs in a note near the top.
- Concrete project identity (real architecture, stack, conventions) preserved — restructured, not genericized. Addon rules (auth, caching, jobs) inlined where the resolved chain omits them.

## Docs

- `docs/PLAYBOOK.md` — new "Regenerate an example" procedure.
- `CLAUDE.md` §2.5 — one-line pointer: examples are generated per ADR-016, never hand-written.

## Checks

- `py tests/run_smoke.py` — 19/19 pass (SYS-05 gates §6.3 across all 8)
- `py tools/sync.py --check` — all files in sync
- Verified: all 8 have §1/§5/§6/§6.3, no duplicate subsection numbers, rename clean

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)