### PR TITLE
refactor(stack): align stack templates to canonical structure (#640)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,10 @@ base/ ──┬── frontend/ ──┐
 - A mechanically-checkable output constraint MUST name its
   agent-runnable check (command + pass condition); subjective
   constraints stay declarative (see `quality-gates-pair-check`)
+- Stack templates follow the canonical section structure (ADR-017):
+  MUST sections are Stack, Commands, Project structure (pure
+  libraries exempt from the last); see ADR-017 for SHOULD/MAY tiers,
+  ordering, and the `<Language> conventions` naming — gated by SYS-06
 
 ### 2.8 manifest.yaml
 

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -16,6 +16,11 @@ composition model.
    - One section per concern, each tagged `[ID: <name>]`
    - Use `[EXTEND: <id>]` to add rules on top of a parent section
    - Use `[OVERRIDE: <id>]` to replace a parent section entirely
+   - Follow the canonical section structure (ADR-017): MUST sections
+     are Stack, Commands, Project structure (pure libraries exempt
+     from the last); name the language section `<Language> conventions`.
+     SYS-06 gates the MUST tier on the resolved chain, so a derived
+     stack may inherit a MUST section from its parent
 3. Review for terminology carry-over from the source template:
    - All framework and runtime names match the target stack
    - CLI commands reference the correct package manager and tools

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2239,6 +2239,21 @@ Extends the static site stack with Astro-specific rules.
 
 ---
 
+## Project structure
+[ID: astro-structure]
+
+- `src/pages/` — file-based routes; each `.astro` file is a page
+- `src/layouts/` — shared page shells (`<head>`, base HTML)
+- `src/components/` — `.astro` components; interactive islands in
+  `src/components/interactive/`
+- `src/content/` — content collections (Markdown + schema in
+  `src/content/config.ts`)
+- `src/data/` — structured data (JSON) when not using content collections
+- `public/` — static assets served as-is (favicon, `robots.txt`)
+- `astro.config.mjs` — integrations, `trailingSlash`, and site URL
+
+---
+
 ## Component architecture
 [OVERRIDE: static-site-architecture]
 
@@ -2439,6 +2454,24 @@ files into `src/content/`.
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead
+
+---
+
+## Testing
+[ID: astro-testing]
+
+A static site has no unit-test suite by default — "testing" means
+verifying the built output. Each check below is enforced by the Quality
+gates table:
+
+- Build MUST succeed with zero errors: `astro build`, plus `astro check`
+  for type and content-schema validation
+- Internal and external links MUST resolve — `lychee` over `dist/`
+  (`--root-dir dist`, so root-relative paths resolve)
+- Lighthouse CI MUST meet budgets: accessibility ≥ 90 (error),
+  performance / SEO / best practices ≥ 90 (warn)
+- Add component or unit tests (e.g. vitest, single-run via `npm test`)
+  only for non-trivial client scripts or content utilities
 
 ---
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1509,7 +1509,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## C conventions
 [ID: c-embedded-code]
 
 - Use C17 -- do not use compiler extensions unless unavoidable; mark them

--- a/generated/stack-celery-worker.md
+++ b/generated/stack-celery-worker.md
@@ -2875,7 +2875,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3478,7 +3478,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3478,7 +3478,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3478,7 +3478,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2786,7 +2786,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1710,6 +1710,23 @@ integration, and testing. Language-agnostic — compose with any backend stack
 
 ---
 
+## Project structure
+[ID: htmx-structure]
+
+HTMX composes with a backend stack that owns the overall layout. HTMX
+adds a fragment-oriented template tree:
+
+- `templates/` — full-page templates that extend a base layout
+- `templates/partials/` — HTML fragments returned by HTMX endpoints,
+  one file per swappable component
+- Name partials by the component they render, not the route that
+  returns them: `partials/cart_items.html`, not `partials/get_cart.html`
+- Keep each fragment renderable both standalone (HTMX swap) and
+  included in a full page (initial load) — no logic that assumes one
+  context
+
+---
+
 ## Core principles
 [ID: htmx-principles]
 

--- a/generated/stack-hugo.md
+++ b/generated/stack-hugo.md
@@ -1759,6 +1759,23 @@ CLAUDE.md
 
 ---
 
+## Testing
+[ID: hugo-testing]
+
+A Hugo site has no unit-test suite — "testing" means verifying the
+built output:
+
+- Build MUST succeed with zero errors and zero warnings:
+  `hugo --gc --minify` (treat `WARN` as a failure in CI)
+- Internal and external links MUST resolve — run `lychee` over
+  `public/` after the build
+- Lighthouse CI SHOULD meet budgets: accessibility ≥ 90, performance /
+  SEO / best practices ≥ 90
+- Validate generated HTML (e.g. `html-validate`) when the theme is
+  hand-authored
+
+---
+
 ## Git conventions
 [EXTEND: base-git]
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2035,7 +2035,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3478,7 +3478,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/generated/stack-rust-lib.md
+++ b/generated/stack-rust-lib.md
@@ -1579,7 +1579,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Rust conventions
 [ID: rust-lib-conventions]
 
 - Follow **Rust API Guidelines** (https://rust-lang.github.io/api-guidelines/)

--- a/generated/stack-terraform.md
+++ b/generated/stack-terraform.md
@@ -1680,7 +1680,7 @@ and testing.
 
 ---
 
-## Repository structure
+## Project structure
 [ID: terraform-structure]
 
 ```
@@ -1770,7 +1770,7 @@ CLAUDE.md
 
 ---
 
-## Coding conventions
+## Terraform conventions
 [ID: terraform-conventions]
 
 - `main.tf`: resource definitions

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2239,6 +2239,21 @@ Extends the static site stack with Astro-specific rules.
 
 ---
 
+## Project structure
+[ID: astro-structure]
+
+- `src/pages/` — file-based routes; each `.astro` file is a page
+- `src/layouts/` — shared page shells (`<head>`, base HTML)
+- `src/components/` — `.astro` components; interactive islands in
+  `src/components/interactive/`
+- `src/content/` — content collections (Markdown + schema in
+  `src/content/config.ts`)
+- `src/data/` — structured data (JSON) when not using content collections
+- `public/` — static assets served as-is (favicon, `robots.txt`)
+- `astro.config.mjs` — integrations, `trailingSlash`, and site URL
+
+---
+
 ## Component architecture
 [OVERRIDE: static-site-architecture]
 
@@ -2439,6 +2454,24 @@ files into `src/content/`.
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead
+
+---
+
+## Testing
+[ID: astro-testing]
+
+A static site has no unit-test suite by default — "testing" means
+verifying the built output. Each check below is enforced by the Quality
+gates table:
+
+- Build MUST succeed with zero errors: `astro build`, plus `astro check`
+  for type and content-schema validation
+- Internal and external links MUST resolve — `lychee` over `dist/`
+  (`--root-dir dist`, so root-relative paths resolve)
+- Lighthouse CI MUST meet budgets: accessibility ≥ 90 (error),
+  performance / SEO / best practices ≥ 90 (warn)
+- Add component or unit tests (e.g. vitest, single-run via `npm test`)
+  only for non-trivial client scripts or content utilities
 
 ---
 

--- a/templates/stack/c-embedded.md
+++ b/templates/stack/c-embedded.md
@@ -47,7 +47,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## C conventions
 [ID: c-embedded-code]
 
 - Use C17 -- do not use compiler extensions unless unavoidable; mark them

--- a/templates/stack/htmx.md
+++ b/templates/stack/htmx.md
@@ -18,6 +18,23 @@ integration, and testing. Language-agnostic — compose with any backend stack
 
 ---
 
+## Project structure
+[ID: htmx-structure]
+
+HTMX composes with a backend stack that owns the overall layout. HTMX
+adds a fragment-oriented template tree:
+
+- `templates/` — full-page templates that extend a base layout
+- `templates/partials/` — HTML fragments returned by HTMX endpoints,
+  one file per swappable component
+- Name partials by the component they render, not the route that
+  returns them: `partials/cart_items.html`, not `partials/get_cart.html`
+- Keep each fragment renderable both standalone (HTMX swap) and
+  included in a full page (initial load) — no logic that assumes one
+  context
+
+---
+
 ## Core principles
 [ID: htmx-principles]
 

--- a/templates/stack/iac-terraform.md
+++ b/templates/stack/iac-terraform.md
@@ -21,7 +21,7 @@ and testing.
 
 ---
 
-## Repository structure
+## Project structure
 [ID: terraform-structure]
 
 ```
@@ -111,7 +111,7 @@ CLAUDE.md
 
 ---
 
-## Coding conventions
+## Terraform conventions
 [ID: terraform-conventions]
 
 - `main.tf`: resource definitions

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -41,7 +41,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Python conventions
 [ID: python-lib-conventions]
 
 - Follow **PEP 8** for style — enforced by `ruff`; do not override ruff rules

--- a/templates/stack/rust-lib.md
+++ b/templates/stack/rust-lib.md
@@ -117,7 +117,7 @@ CLAUDE.md
 
 ---
 
-## Code conventions
+## Rust conventions
 [ID: rust-lib-conventions]
 
 - Follow **Rust API Guidelines** (https://rust-lang.github.io/api-guidelines/)

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -16,6 +16,21 @@ Extends the static site stack with Astro-specific rules.
 
 ---
 
+## Project structure
+[ID: astro-structure]
+
+- `src/pages/` — file-based routes; each `.astro` file is a page
+- `src/layouts/` — shared page shells (`<head>`, base HTML)
+- `src/components/` — `.astro` components; interactive islands in
+  `src/components/interactive/`
+- `src/content/` — content collections (Markdown + schema in
+  `src/content/config.ts`)
+- `src/data/` — structured data (JSON) when not using content collections
+- `public/` — static assets served as-is (favicon, `robots.txt`)
+- `astro.config.mjs` — integrations, `trailingSlash`, and site URL
+
+---
+
 ## Component architecture
 [OVERRIDE: static-site-architecture]
 
@@ -216,6 +231,24 @@ files into `src/content/`.
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead
+
+---
+
+## Testing
+[ID: astro-testing]
+
+A static site has no unit-test suite by default — "testing" means
+verifying the built output. Each check below is enforced by the Quality
+gates table:
+
+- Build MUST succeed with zero errors: `astro build`, plus `astro check`
+  for type and content-schema validation
+- Internal and external links MUST resolve — `lychee` over `dist/`
+  (`--root-dir dist`, so root-relative paths resolve)
+- Lighthouse CI MUST meet budgets: accessibility ≥ 90 (error),
+  performance / SEO / best practices ≥ 90 (warn)
+- Add component or unit tests (e.g. vitest, single-run via `npm test`)
+  only for non-trivial client scripts or content utilities
 
 ---
 

--- a/templates/stack/static-site-hugo.md
+++ b/templates/stack/static-site-hugo.md
@@ -120,6 +120,23 @@ CLAUDE.md
 
 ---
 
+## Testing
+[ID: hugo-testing]
+
+A Hugo site has no unit-test suite — "testing" means verifying the
+built output:
+
+- Build MUST succeed with zero errors and zero warnings:
+  `hugo --gc --minify` (treat `WARN` as a failure in CI)
+- Internal and external links MUST resolve — run `lychee` over
+  `public/` after the build
+- Lighthouse CI SHOULD meet budgets: accessibility ≥ 90, performance /
+  SEO / best practices ≥ 90
+- Validate generated HTML (e.g. `html-validate`) when the theme is
+  hand-authored
+
+---
+
 ## Git conventions
 [EXTEND: base-git]
 


### PR DESCRIPTION
## What

Applies **ADR-017** — fixes the concrete structure drift across stack templates (A2 of v2.24 — Stack structure).

## Changes

**MUST-tier (Project structure)** — added to the non-library stacks whose resolved chains lacked it:
- `htmx` — fragment-oriented template tree
- `static-site-astro` — `src/pages|layouts|components|content`, `public/`, config
- `iac-terraform` — renamed existing "Repository structure" → canonical "Project structure"

**Testing (SHOULD)** — added to static sites:
- `static-site-astro` — verification practices, cross-referencing the existing Quality gates table (no duplication)
- `static-site-hugo` — build (zero warnings), link check (lychee), Lighthouse, HTML/a11y

**Language-section rename** → `<Language> conventions`:
- python-lib → Python, c-embedded → C, rust-lib → Rust, iac-terraform → Terraform

## Course-corrections vs. the original plan (from the resolved-chain analysis)
- **Dropped python-service Commands** — its chain already inherits Commands from python-lib; adding one would duplicate downstream.
- **rust-lib**: renamed its "Code conventions" (the real language section), kept "Crate conventions" (packaging).
- **static-site base "Code conventions"** kept — it's the language-agnostic shared section ADR-017 reserves that name for.

## Verification
- 15 `generated/` chains regenerated; the 3 fixed stacks now have Project structure in-chain.
- `py tests/run_smoke.py` 19/19; `py tools/sync.py --check` clean.
- SYS-06 (the enforcing gate) lands next in #641.

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)