### PR TITLE
test(smoke): add SYS-06 gate for required stack sections (#641)

### DIFF
--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -14,6 +14,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-SMK-SYS-03-001A` | SMK | P0 | Every template file has a corresponding manifest entry |
 | `SAIT-SMK-SYS-04-001A` | SMK | P0 | DEPENDS ON headers match manifest depends_on |
 | `SAIT-SMK-SYS-05-001A` | SMK | P1 | End-of-session audit is inlined verbatim or hard-delegated, never paraphrased |
+| `SAIT-SMK-SYS-06-001A` | SMK | P1 | Every usable stack's resolved chain carries the MUST sections |
 | `SAIT-SMK-TPL-04-001A` | SMK | P1 | All EXTEND and OVERRIDE directives reference existing IDs |
 | `SAIT-INT-TPL-01-001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
 | `SAIT-INT-TPL-02-001A` | INT | P1 | EXTEND adds rules without removing base rules |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -1079,6 +1079,54 @@ def check_sys_05():
 
 
 # ---------------------------------------------------------------------------
+# SYS-06 — every usable stack's resolved chain carries the MUST sections
+# ---------------------------------------------------------------------------
+# ADR-017 defines the canonical stack-template section structure. The MUST
+# tier — Stack, Commands, Project structure — is the stack-unique
+# contribution the core tier cannot supply. Membership is judged on the
+# resolved chain, so a derived stack may inherit a MUST section from its
+# parent. Pure-library stacks (manifest layer: library) prescribe no
+# directory tree and are exempt from Project structure.
+
+_MUST_SECTIONS = ("Stack", "Commands", "Project structure")
+
+
+def check_sys_06():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    core_ids, entries, _ = _load_manifest()
+    failures = []
+
+    stacks = [e for e in entries.values()
+              if e["file"].startswith("templates/stack/")]
+
+    for stack in sorted(stacks, key=lambda e: e["id"]):
+        sid = stack["id"]
+        is_lib = stack.get("layer") == "library"
+        files, _ = _resolve_stack(sid, core_ids, entries)
+
+        blob = "\n".join(
+            read(os.path.join(ROOT, f))
+            for f in files
+            if os.path.isfile(os.path.join(ROOT, f))
+        )
+
+        for section in _MUST_SECTIONS:
+            if section == "Project structure" and is_lib:
+                continue
+            heading = re.compile(
+                r"^##\s+" + re.escape(section) + r"\s*$", re.MULTILINE)
+            if not heading.search(blob):
+                failures.append(
+                    f"  {sid}: resolved chain missing MUST section "
+                    f"'## {section}' (ADR-017)"
+                )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Test registry
 # ---------------------------------------------------------------------------
 
@@ -1113,6 +1161,8 @@ CHECKS = [
      "title": "DEPENDS ON headers match manifest depends_on", "fn": check_sys_04},
     {"id": "SYS-05", "spec": "SAIT-SMK-SYS-05-001A",
      "title": "End-of-session audit inlined verbatim or hard-delegated", "fn": check_sys_05},
+    {"id": "SYS-06", "spec": "SAIT-SMK-SYS-06-001A",
+     "title": "Every usable stack's chain carries the MUST sections", "fn": check_sys_06},
     {"id": "TPL-08", "spec": "SAIT-SMK-TPL-08-001A",
      "title": "Every base template has at least one [ID:] tag", "fn": check_tpl_08},
     {"id": "TPL-09", "spec": "SAIT-SMK-TPL-09-001A",

--- a/tests/specs/SAIT-SMK-SYS-06-001A.md
+++ b/tests/specs/SAIT-SMK-SYS-06-001A.md
@@ -1,0 +1,72 @@
+---
+id: SAIT-SMK-SYS-06-001A
+title: Every usable stack's resolved chain carries the MUST sections
+product: sait
+type: smoke
+area: SYS
+priority: p1
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [stack, structure, sections, adr-017]
+---
+
+## Short description
+
+> **Given** the manifest and every stack's resolved dependency chain
+> **When** each stack chain is inspected for the ADR-017 MUST-tier
+> sections
+> **Then** every chain contains `## Stack`, `## Commands`, and
+> `## Project structure` — except pure-library stacks (layer: library),
+> which are exempt from Project structure
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every stack chain carries Stack, Commands, and Project structure (libraries exempt from the last) |
+| FAILED | One or more chains miss a required MUST section |
+| SKIPPED | — |
+| BLOCKED | PyYAML is not installed |
+| ERROR | File system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- PyYAML installed (`py -m pip install pyyaml`)
+
+### Setup
+
+1. Change to the repository root
+2. Load `templates/manifest.yaml`
+
+### Execution
+
+1. Enumerate every entry whose file is under `templates/stack/`
+2. Resolve each stack's full dependency chain (core tier + parents)
+3. Concatenate the chain's file contents
+4. For each MUST section, search the concatenated text for the exact
+   heading (`^## <Section>$`)
+
+### Assertions
+
+1. Assert `## Stack` is present in every stack chain
+2. Assert `## Commands` is present in every stack chain
+3. Assert `## Project structure` is present, except where the stack's
+   manifest `layer` is `library`
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- ADR-017 — canonical stack-template section structure (the rule this
+  check pairs with)
+- Issue #641 — implement the SYS-06 gate
+- `quality-gates-pair-check` — pair-the-check convention


### PR DESCRIPTION
## What

Implements **SYS-06**, the smoke gate named by ADR-017 (pair-the-check) — A3 of v2.24 — Stack structure.

## The check

For every stack, assert the **resolved chain** contains the MUST-tier sections:
- `## Stack`
- `## Commands`
- `## Project structure` — except pure-library stacks (manifest `layer: library`)

Judged on the resolved chain, so a derived stack may satisfy a section via its parent (the ADR inheritance rule).

## Validation

- Negative test: renaming a stack's `## Project structure` makes SYS-06 fail with `stack-htmx: resolved chain missing MUST section '## Project structure' (ADR-017)`; reverting passes.
- `py tests/run_smoke.py` — **20/20** (SYS-06 added).
- `py tools/sync.py --check` — clean.

## Also

- Spec `tests/specs/SAIT-SMK-SYS-06-001A.md` + `tests/INDEX.md` row.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)