### PR TITLE
chore: add markdownlint config matching the template house style (#650)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": { "line_length": 80, "code_blocks": false, "tables": false },
+  "MD022": false,
+  "MD031": false,
+  "MD032": false,
+  "MD040": false
+}


### PR DESCRIPTION
## What

Adds a committed `.markdownlint.json` so the editor stops flagging the deliberate template/journal house style.

## Disabled (conflict with house style)
- **MD022** — `## Heading` directly followed by `[ID: ...]`
- **MD032** — lists directly under a `**Label:**` line
- **MD031** / **MD040** — bare ``` blocks (project trees, command lists)

## Kept
- **MD013** line-length at 80 for prose (project authoring rule); off for tables/code

markdownlint is not in CI (CI = smoke + gitleaks), so this only affects the editor; it documents the project's markdown conventions.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)