### PR TITLE
docs(audits): add 2026-06-26 360 audit and adopt dated-report convention

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -268,6 +268,24 @@ hand.
 
 ---
 
+## Run a 360-degree audit
+
+Per `templates/base/workflow/360.md`, a 360 assesses the whole project
+from independent stakeholder perspectives as parallel, context-isolated
+subagents (the headless adaptation re-projects Quality into engineering
+dimensions). Run one before a major release, after a milestone, or
+quarterly.
+
+- Store each audit as a dated report at `docs/audits/YYYY-MM-DD-360.md`
+  (the §360-tracking option-b convention) — never the single-file
+  `docs/360-audit.md` form; keep all history in the folder.
+- Each report carries a scores table, the issues created, the current
+  bottleneck, and per-dimension findings tables with a grade rationale.
+- File a labelled issue for every actionable finding (CLAUDE.md §2.2)
+  and reference it from the report.
+
+---
+
 ## Submit a pull request
 
 1. Ensure you are on a feature branch — never commit to `main` directly

--- a/docs/audits/2026-05-04-360.md
+++ b/docs/audits/2026-05-04-360.md
@@ -1,10 +1,11 @@
-# 360-Degree Audit History
+# 360-Degree Audit — 2026-05-04
 
-## Audit history
+> Migrated 2026-06-26 from the former single-file `docs/360-audit.md`
+> into the dated-report convention under `docs/audits/`
+> (360.md §360-tracking, option b). Content preserved as written.
 
-| Date       | Value | Quality | Viability | Discovery | Issues created            |
-| ---------- | ----- | ------- | --------- | --------- | ------------------------- |
-| 2026-05-04 | B+    | C+      | A-        | D+        | #168–#173 (pre-audit findings) |
+**Project state at audit time:** 30 stacks, 8 examples, 5 ADRs — pre the
+v2.21–v2.26 stack cleanup. Grades reflect that state.
 
 ## Current bottleneck
 
@@ -17,8 +18,6 @@ Until the project is actively placed where its audience gathers
 is irrelevant because nobody will find them.
 
 ---
-
-## 2026-05-04 — Full audit
 
 ### Value — Grade: B+
 

--- a/docs/audits/2026-06-26-360.md
+++ b/docs/audits/2026-06-26-360.md
@@ -1,0 +1,257 @@
+# 360-Degree Audit — 2026-06-26
+
+Detailed project review requested after the v2.21–v2.26 stack-cleanup run
+and before the v3.0 restructure. Run as seven parallel, context-isolated
+subagents per `templates/base/workflow/360.md`. Because this is a headless
+project (no user-facing surface), the §360-headless adaptation applies:
+Value, Viability, and Discovery are kept as light lenses, and the Quality
+perspective is re-projected into four engineering dimensions (one isolated
+reviewer each — Architecture, Documentation, Authoring/ADR, Testing/CI).
+The overall grade is the lowest dimension grade. The mechanical layer
+(smoke 20/20, `sync --check`, `resolve --check`) was green before fan-out.
+
+## Scores
+
+| Dimension                   | Grade  | Findings | High+ |
+| --------------------------- | ------ | -------- | ----- |
+| Value (adopter)             | A      | 11       | 0     |
+| Viability (analyst)         | A      | 12       | 0     |
+| Documentation               | A      | 11       | 0     |
+| Testing, Tooling & CI       | A-     | 11       | 0     |
+| Authoring & ADR governance  | B+     | 12       | 0     |
+| Architecture & Composition  | C+     | 10       | 1     |
+| Discovery (marketer)        | C+     | 13       | 3     |
+| **Overall**                 | **C+** | **80**   | **4** |
+
+No finding is Critical-severity. The four High+ are one real shipped defect
+(the resolver dependency-drop) plus three pre-launch Discovery gaps. Overall
+= C+ (weakest dimension). The two C+ dimensions fail for opposite reasons:
+Architecture has a genuine shipped defect (fix it); Discovery simply reflects
+that the launch (issue #90) has not happened yet. Discounting the un-launched
+marketing surface, the engineering body grades A-/B+.
+
+## Issues created
+
+- **v2.27 — Correctness & generation integrity:** #654 (resolver bug, P1),
+  #655 (generated/ correctness gate, P1), #656 (mobile dead code, P3),
+  #657 (STK-06/INDEX hygiene, P3), #658 (opt-in orphan docs, P3)
+- **v2.28 — Authoring & test hygiene:** #659 (line length, P2), #660 (Go
+  conventions, P2), #661 (e2e cases, P3), #662 (examples gate, P3), #663
+  (hybrid-astro paths, P2); plus #638 (scope.md, milestoned here)
+- **v3.0 — Restructure:** #664 (README badges, P2), #665 (differentiation,
+  P3) — both feed launch #90
+
+## Current bottleneck
+
+**Architecture & Composition (C+)** — `tools/resolve.py`'s hand-rolled
+manifest parser silently drops `frontend-static-site`'s dependencies (the
+only multi-line `depends_on` in the manifest, `templates/manifest.yaml:122-123`),
+so `base-security`, `frontend-ux`, and `frontend-quality` are missing from
+the shipped `generated/stack-astro.md` and `generated/stack-tutorial.md`.
+Smoke uses real PyYAML and never sees the divergence, so the broken artifact
+ships green. This is the one must-fix (#654; guardrail #655). Discovery (C+)
+is co-weakest but strategic, not broken — it lifts when #90 ships.
+
+---
+
+## 1. Value (adopter perspective) — A
+
+**Method:** evaluated only user-facing materials (README "what it does",
+features, stacks/agents tables; `templates/INTERVIEW.md`; the `generated/`
+chains; `examples/`) with no access to developer docs.
+
+| #  | Sub-dimension                  | Status  | Sev | Finding |
+| -- | ------------------------------ | ------- | --- | ------- |
+| 1  | Stack count promise            | PASS    | —   | README lists 17 stacks; `templates/stack/` has 17; `generated/` has 17. Internally consistent. |
+| 2  | Generated chain coverage       | PASS    | —   | Every README-listed stack maps to an existing `generated/stack-<name>.md`. |
+| 3  | Examples exist & substantive   | PASS    | —   | 7 `examples/*/CLAUDE.md`, 196–475 lines, distinct real project names, no placeholders. |
+| 4  | INTERVIEW.md usability         | PASS    | —   | 153 lines; clear 4-phase guided entry (Explore→Clarify→Propose→Generate) with inline/reference/hybrid paths. |
+| 5  | End-to-end path plausible      | PASS    | —   | Attach INTERVIEW + stack → agent reads `generated/<stack>.md` → self-contained CLAUDE.md; examples confirm usable output. |
+| 6  | Multi-agent output claim       | PASS    | —   | Agents table (README:154-159) backed by real `templates/base/core/agents.md`. |
+| 7  | 360 promise                    | PASS    | —   | Backed by real `templates/base/workflow/360.md`. |
+| 8  | No build step                  | PASS    | —   | All surfaces static `.md`; chains pre-resolved, no compilation to consume. |
+| 9  | README links integrity         | PASS    | —   | All targets exist (examples/, LICENSE CC BY 4.0, agents.md, docs). No dead links. |
+| 10 | Clear what/who in 10s          | PASS    | Nit | Opens with ~4 prose paragraphs before the first concrete bullet; a one-line "what" above the narrative would sharpen the 5-second read. |
+| 11 | Hybrid example submodule paths | PARTIAL | Low | `examples/hybrid-astro/CLAUDE.md:30-41` references `docs/solid-ai-templates/base/quality.md`; real path is `templates/base/core/quality.md`. → #663 |
+
+**Why A:** every advertised stack has a real resolved chain, all 7 examples
+are substantive, and the "attach and generate" path holds end-to-end with no
+dead links or count contradictions. The only soft spots are cosmetic (README
+opener) and one low-severity path mismatch in a generated example.
+
+---
+
+## 2. Viability (business-analyst perspective) — A
+
+**Method:** assessed cost, risk, and operational health only (LICENSE,
+dependency surface, `.github/`, tooling, issue tracker). Solo owner:
+Imbra Ltd — B. Georgiev.
+
+| #  | Sub-dimension                | Status  | Sev    | Finding |
+| -- | ---------------------------- | ------- | ------ | ------- |
+| 1  | Licensing — present & stated | PASS    | —      | CC BY 4.0 in LICENSE, cross-referenced README:171-173. |
+| 2  | Licensing — fit for purpose  | PARTIAL | Low    | CC BY 4.0 is a content license; the repo also ships Python tooling that arguably wants a code license (patent/warranty). `static-site-tutorial` references CC BY-NC-SA (content-only, no conflict). |
+| 3  | Dependency licenses          | PASS    | —      | PyYAML (MIT, test/CI), anthropic (MIT, e2e only). `sync.py:14` hand-rolls YAML to avoid even PyYAML at runtime. |
+| 4  | Personal data collection     | PASS    | —      | None. No network calls in core tooling. `.env` gitignored and untracked. |
+| 5  | Infra cost                   | PASS    | —      | Markdown + stdlib + one Actions workflow; effectively zero on GitHub free tier. |
+| 6  | Vendor lock-in               | PASS    | Low    | GitHub + optional Anthropic API (e2e only, gated). Trivially portable. |
+| 7  | Onboarding from docs         | PASS    | —      | ONBOARDING (129), PLAYBOOK (308), SPEC (562) + CLAUDE + ADRs. `git clone` + `pip install pyyaml`. |
+| 8  | Bus factor (solo owner)      | PARTIAL | Medium | Single owner; mitigated by docs, 20-check smoke, sync/resolve automation, ADRs, dev-journal — but knowledge concentration is the structural SPOF. |
+| 9  | Roadmap / backlog            | PASS    | —      | 20 open issues, all labeled; active v3.0 milestone. |
+| 10 | Maintenance burden           | PASS    | —      | Dependabot pip + actions weekly; near-zero patch surface; no runtime. |
+| 11 | Dependency surface           | PASS    | —      | stdlib-only core; PyYAML + anthropic both optional. |
+| 12 | Rebuild & disaster recovery  | PASS    | —      | Everything in git; no submodules; `generated/` reproducible via `resolve.py --generate`. |
+
+**Why A:** zero infra cost, minimal dependency surface, no data/privacy
+exposure, complete DR from git alone. The two risks are structural, not acute:
+solo bus factor (well-mitigated) and the CC BY license-fit nuance over shipped
+tooling. Long-term sustainability is strong.
+
+---
+
+## 3. Documentation (engineer perspective) — A
+
+**Method:** cross-doc consistency and freshness across the CLAUDE.md §2.9
+normative set (README, CLAUDE, SPEC, ONBOARDING, PLAYBOOK, INTERVIEW,
+manifest) against the true state (17 stacks, 66 templates, 17 chains).
+
+| #  | Sub-dimension                   | Status | Sev | Finding |
+| -- | ------------------------------- | ------ | --- | ------- |
+| 1  | Stale counts (normative)        | PASS   | —   | None. `sync.py --check` reports "All files in sync". |
+| 2  | Removed-stack names as supported| PASS   | —   | Zero. README:121 / PLAYBOOK:189 "Full-stack" is a budget label; PLAYBOOK:30 "Rust" a generic language example. |
+| 3  | README stacks table             | PASS   | —   | 17 rows match `resolve --list` + manifest. |
+| 4  | README agents table             | PASS   | —   | Matches agents.md; cross-referenced, not duplicated. |
+| 5  | CLAUDE.md §2.3 naming table      | PASS   | —   | python-/go-/node-/nodejs-/static-site-/c- + htmx exactly match `templates/stack/`. |
+| 6  | SPEC layer structure            | PASS   | —   | Matches actual tree; no `templates/mobile/`. |
+| 7  | Cross-doc consistency           | PASS   | —   | All regenerate from manifest; sync clean. |
+| 8  | INTERVIEW.md stack table        | PASS   | —   | 17 rows match `resolve --list`. |
+| 9  | Present-tense / duplication     | PASS   | Nit | Only hit (CLAUDE.md:247) is a conditional ADR rule, not stale prose. |
+| 10 | Broken internal links           | PASS   | —   | All relative links resolve. |
+| 11 | Non-normative meta docs         | PASS   | Low | The dated 360 audit and frozen ADRs (005/009) carry old counts but are archival/immutable, outside the normative set. |
+
+**Why A:** every normative doc reflects the true current state; the
+v2.21–v2.26 cull was thoroughly drained (no removed-stack name appears as
+supported anywhere); all internal links resolve. Stale counts live only in
+explicitly historical/immutable artifacts.
+
+---
+
+## 4. Testing, Tooling & CI (engineer perspective) — A-
+
+**Method:** e2e coverage vs stacks, retired-case hygiene, smoke completeness,
+CI config, and ran both runners.
+
+| #  | Sub-dimension                | Status  | Sev | Finding |
+| -- | ---------------------------- | ------- | --- | ------- |
+| 1  | E2E stack coverage           | PARTIAL | Low | 14/17 stacks have an STK case. Uncovered: `c-embedded`, `node-nestjs`, `static-site-tutorial`. Canary = python-lib (STK-15). → #661 |
+| 2  | Retired-case hygiene (IDs)   | PASS    | —   | STK-05/06/09/14/17/19 cleanly removed; CODIFICATION.md documents each; E2E-01 passes. |
+| 3  | Dangling spec cross-ref      | FAIL    | Nit | `tests/specs/SAIT-E2E-STK-07-001A.md:73` references retired STK-06. → #657 |
+| 4  | INDEX / spec drift           | PARTIAL | Low | `tests/INDEX.md:39-41` lists FMT-03/04/05 + TPL-05 with no implementing case. → #657 |
+| 5  | Smoke run                    | PASS    | —   | `run_smoke.py` → 20/20, 0 failed, 0 errors. |
+| 6  | sync / resolve freshness     | PASS    | —   | Both `--check` clean; wired into CI as separate steps. |
+| 7  | CI gates on PR + push/main   | PASS    | —   | smoke + `sync --check` + `resolve --check` + gitleaks; `permissions: contents: read`; markdownlint correctly NOT in CI. |
+| 8  | Dependabot                   | PASS    | —   | pip + github-actions, weekly. |
+| 9  | SAST                         | PARTIAL | Low | No CodeQL/Semgrep. Acceptable (Markdown repo, two small first-party tools); gitleaks covers secrets. |
+| 10 | examples/ existence not gated| PARTIAL | Low | No smoke check asserts a concrete stack has a matching example. → #662 |
+| 11 | Tooling parser divergence    | PARTIAL | Low | `resolve.py`/`sync.py` hand-rolled parser fails open on malformed manifest; backstopped by PyYAML-based MNF-01 in CI. → root of #654 |
+
+**Why A-:** strong gates (smoke + freshness + gitleaks on PR and main;
+Dependabot). Gaps are minor/cosmetic — a dangling STK-06 ref, INDEX rows
+without cases, three uncovered stacks, no examples-existence gate, and a
+fail-open parser backstopped in CI. No critical or high issues.
+
+---
+
+## 5. Authoring & ADR governance (engineer perspective) — B+
+
+**Method:** Part A — authoring rules (CLAUDE.md §2.7) across the 66 templates.
+Part B — ADR governance (ADR-010) across the 17 ADRs.
+
+| #  | Sub-dimension                         | Status  | Sev    | Finding |
+| -- | ------------------------------------- | ------- | ------ | ------- |
+| A1 | Line length <80                       | PARTIAL | Medium | 157 non-code/non-table lines across 46 files exceed 80; worst by far is `ai-workflow.md` (up to 891 chars, L460). Reference-only. → #659 |
+| A2 | Line length — `[DEPENDS ON:]` headers | PARTIAL | Low    | Single-line directives commonly exceed 80 (e.g. node-nestjs L2=479); mechanical metadata, arguably table-exempt. → #659 |
+| A3 | Line length — rule bullets            | PARTIAL | Nit    | Tail of 81–95 char bullets; worst prose outside ai-workflow: `backend/api.md:28` (113). → #659 |
+| A4 | RFC 2119 / no hedging                 | PASS    | —      | No "try to"/"it's good to"; the few "consider" uses are normative. |
+| A5 | Imperative style / no prose-in-rules  | PARTIAL | Medium | `ai-workflow.md` is multi-paragraph narrative, not imperative rule lists (reference-only, reflective "lessons" purpose). → #659 |
+| A6 | No HTML                               | PASS    | —      | All HTML tags are backtick-wrapped inline code or inside fenced blocks. |
+| A7 | Pair-the-check (SYS-05)               | PASS    | —      | quality-gates `[quality-gates-pair-check]` defines rule + agent-runnable shape; nothing else found unpaired. |
+| A8 | ADR-017 `<Language> conventions`      | PARTIAL | Low    | Go stack family has no "Go conventions" section — idioms live under "Code quality". c/python/node comply. Not a SYS-06 (MUST) violation. → #660 |
+| B1 | ADR schema (ADR-010)                  | PASS    | —      | All 17 ADRs: quoted id, valid status/category, well-formed date, all fields present. TEMPLATE uses placeholders. |
+| B2 | Reciprocal supersession links         | PASS    | —      | Only pair 012↔013 (data-quality split); reciprocal and resolved. No dangling. |
+| B3 | One concern per ADR (ADR-014)         | PASS    | —      | Spot-check (002/005/014/015/016) single-concern; ADR-015 scoped to ordering only. |
+| B4 | Status consistency                    | PASS    | —      | No Superseded-without-link; no superseded_by-while-Accepted. 012 → 013. |
+
+**Why B+:** ADR governance is effectively clean (schema, reciprocal links,
+status, one-concern all pass). Authoring is strong (no hedging, no raw HTML,
+pair-the-check honored) with two soft spots: widespread-but-mild line-length
+debt (concentrated in reference-only ai-workflow.md) and inconsistent
+`<Language> conventions` naming. Consistency/style debt, not correctness.
+
+---
+
+## 6. Architecture & Composition (engineer perspective) — C+
+
+**Method:** composition-model integrity beyond what smoke (20/20) already
+covers — orphans/reachability, dead layers post-cull, graph health,
+manifest↔file consistency. Crux finding independently reproduced by the
+parent agent before grading.
+
+| #  | Sub-dimension                       | Status      | Sev  | Finding |
+| -- | ----------------------------------- | ----------- | ---- | ------- |
+| 1  | Resolver parser correctness         | FAIL        | High | `resolve.py:91-99` handles only single-line `key: [..]`. `frontend-static-site` is the only multi-line `depends_on` (`manifest.yaml:122-123`) → parses empty → `base-security`, `frontend-ux`, `frontend-quality` dropped from stack-astro AND stack-tutorial (astro resolves to 10, should be 13). → #654 |
+| 2  | Generated-output integrity          | FAIL        | High | Bug baked into `generated/stack-astro.md` + `generated/stack-tutorial.md`. `resolve.py --check` reports "up to date" because it regenerates from the same broken parser. → #654/#655 |
+| 3  | Two divergent manifest parsers      | FAIL        | High | smoke uses `yaml.safe_load` (13 files); resolve.py custom (10). No check reconciles; the authoritative `generated/` artifact is the wrong one. → #655 |
+| 4  | Orphan: frontend-ux / -quality      | FAIL        | High | Reached by zero chains — NOT intentional. Manifest + in-file DEPENDS ON correctly list them; they vanish only via #1. Post-cull these are the frontend layer's substance. → #654 |
+| 5  | Orphan classification (other 16)    | PASS        | Low  | 16/18 orphans intentional: platform github/gitlab, workflow 360/ai-workflow/review/release/deployment (SPEC-orthogonal), backend caching/jobs/microservices/monitoring/webhooks (register-only), agents.md, communication.md. |
+| 6  | data-governance / data-migration    | PARTIAL     | Low  | Orphaned + opt-in by design, but not named in SPEC's opt-in lists (`SPEC:227-246`) — undocumented intentional orphans. → #658 |
+| 7  | Manifest ↔ in-file DEPENDS ON       | PASS        | —    | 0 mismatches across all files (also SYS-04). |
+| 8  | Graph acyclicity & layering         | PASS        | —    | DAG acyclic; no layering violations. |
+| 9  | Core-tier guarantee                 | PASS        | —    | All 17 stacks include `[base-quality, base-git, base-docs, base-readme, base-testing]`. Cull did not break it. |
+| 10 | Vestigial `mobile` section          | PASS (nit)  | Nit  | `resolve.py:120` + `run_smoke.py:70` still iterate a removed `mobile` section — dead code. → #656 |
+
+**Why C+:** the inheritance model is structurally sound — acyclic, correctly
+layered, manifest and headers agree, core-tier holds for all 17 stacks, 16/18
+orphans intentional. The grade is dragged down by one real, shipped defect that
+smoke cannot see (findings 1-4, a single root cause), made invisible by two
+divergent parsers no check reconciles.
+
+---
+
+## 7. Discovery (marketer perspective) — C+
+
+**Method:** evaluated discoverability and first impression of a GitHub-hosted
+OSS dev tool (no website) — README-as-landing-page + repo metadata. Target
+audience: developers wanting AI agent context files.
+
+| #  | Sub-dimension                  | Status  | Sev    | Finding |
+| -- | ------------------------------ | ------- | ------ | ------- |
+| 1  | Positioning — clarity          | PASS    | —      | Sharp pain-narrative opener (README:6-17); what/who clear in ~5s. |
+| 2  | Value prop stated              | PASS    | —      | "What it does" is a concrete verb-led list (README:23-30). |
+| 3  | Differentiation                | PARTIAL | Medium | Implied (the "three copies" story) but never stated head-on; no vs-alternatives framing. → #665 |
+| 4  | Name / SOLID pun               | PARTIAL | Low    | Pun never explained — lands for the in-group only; title vs slug casing differ. → #665 |
+| 5  | Repo "About" one-liner         | PASS    | —      | 80-char description leads with CLAUDE.md/AGENTS.md — search-snippet friendly. |
+| 6  | GitHub topics                  | PASS    | —      | 14 well-targeted topics (claude-md, agents-md, claude-code, …). |
+| 7  | Heading hierarchy              | PASS    | —      | Scannable Try/Use/Adopt onboarding ladder. |
+| 8  | Search terms surface           | PARTIAL | Medium | Topics good, but 3 stars + zero backlinks → real Google rank ≈ nil. |
+| 9  | Social proof (stars/forks)     | FAIL    | High   | 3 stars, 0 forks, no testimonials. Biggest click/share deterrent. |
+| 10 | Badges                         | FAIL    | Medium | Zero badges; CI + releases exist but unsurfaced. → #664 |
+| 11 | Shareable content              | PASS    | —      | The composable system is genuinely shareable reference material; packaging absent. |
+| 12 | Distribution presence          | FAIL    | High   | #90 open; no awesome-list, launch post, or directory presence. → #90 |
+| 13 | ≥2 discovery channels          | FAIL    | High   | Effectively one (GitHub topic search); `homepageUrl` empty. → #90 |
+
+**Why C+:** the message is excellent (sharp README, 14 targeted topics,
+80-char optimized description) but the megaphone is absent — 3 stars, zero
+badges, no testimonials, distribution still sitting in open issue #90. The
+highest-leverage fixes are pure marketing (#90 + #664 + #665), not product.
+
+---
+
+## Method note
+
+Headless-360 adaptation per §360-headless: seven isolated reviewers, clean
+contexts, adversarial per-finding verification, letter grades, persisted
+report. The crux Architecture defect (#654) was independently reproduced by
+the parent agent (`resolve.py stack-astro` → 10 files; section IDs absent from
+`generated/stack-astro.md`) before grading. Mechanical checks at audit time:
+smoke 20/20, `sync --check` clean, `resolve --check` clean.

--- a/docs/dev-journal.md
+++ b/docs/dev-journal.md
@@ -284,8 +284,8 @@ recorded in ADR-004.
 **Issues closed:** #168, #169, #170, #171, #172, #173
 
 **Key changes:**
-- First 360-degree audit (`docs/360-audit.md`) — grades: Value B+,
-  Quality C+, Viability A-, Discovery D+
+- First 360-degree audit (`docs/audits/2026-05-04-360.md`) — grades:
+  Value B+, Quality C+, Viability A-, Discovery D+
 - Recovered lost agents.md move from orphaned branch
   `fix/claude-md-review` (formats/ → base/core/)
 - Fixed E2E test paths broken after ADR-005 restructuring (27/30


### PR DESCRIPTION
## What

Persist the 2026-06-26 360-degree audit and adopt the dated-report
storage convention.

- Add `docs/audits/2026-06-26-360.md` — the full audit. Seven-dimension
  headless adaptation per `360.md` §360-headless: Value / Viability /
  Discovery kept light, Quality re-projected into Architecture,
  Documentation, Authoring & ADR, and Testing/CI. Overall **C+**;
  bottleneck is the resolver dependency-drop defect (#654).
- Migrate the prior audit to `docs/audits/2026-05-04-360.md` and remove
  the single-file `docs/360-audit.md`, so history lives only in the
  folder (`360.md` §360-tracking option b — never split across both).
- Fix the stale dev-journal pointer; document the convention in a new
  PLAYBOOK "Run a 360-degree audit" section.

## Findings

Actionable findings are filed as #654–#665 across milestones **v2.27**
(correctness — incl. the #654 resolver bug), **v2.28** (authoring & test
hygiene), and **v3.0** (launch readiness).

## Checks

- `py tests/run_smoke.py` → 20/20
- `py tools/sync.py --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
