### PR TITLE
docs(360): make docs/audits the only audit-storage convention

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -277,8 +277,9 @@ dimensions). Run one before a major release, after a milestone, or
 quarterly.
 
 - Store each audit as a dated report at `docs/audits/YYYY-MM-DD-360.md`
-  (the §360-tracking option-b convention) — never the single-file
-  `docs/360-audit.md` form; keep all history in the folder.
+  (per §360-tracking) — this is the only audit location; never use a
+  single-file `docs/360-audit.md` history. All audit history lives in
+  the folder.
 - Each report carries a scores table, the issues created, the current
   bottleneck, and per-dimension findings tables with a grade rationale.
 - File a labelled issue for every actionable finding (CLAUDE.md §2.2)

--- a/templates/base/workflow/360.md
+++ b/templates/base/workflow/360.md
@@ -480,34 +480,40 @@ only as strong as its weakest perspective.
 Audit results MUST be persisted in the repository — agent memory is
 ephemeral and invisible to other contributors.
 
-- Audit history MUST live in one of two forms — pick one convention and
-  keep all history there, never split across both:
-  - **(a)** a single `docs/360-audit.md` history file: one score-table
-    row per audit (date, grade per category, issue references) plus a
-    "Current bottleneck" section naming the weakest category (structure
-    below)
-  - **(b)** verbose dated reports under `docs/audits/YYYY-MM-DD-360.md`,
-    each with per-dimension findings tables and the rationale for every
-    grade
-- Prefer (b) when preserving the reasoning behind each grade matters — a
-  bare score row ages poorly and loses how the grade was reached
-- The end-of-session checklist SHOULD update the chosen location after
-  running an audit
+- Each audit MUST be stored as a dated report at
+  `docs/audits/YYYY-MM-DD-360.md`. This is the only audit location —
+  do NOT add a separate single-file history (e.g. `docs/360-audit.md`).
+  All audit history lives in `docs/audits/`, one dated report per run.
+- Each report MUST contain a scores table (grade per dimension plus the
+  overall = lowest), the issues created, a "Current bottleneck" section
+  naming the weakest dimension, and per-dimension findings tables with
+  the rationale for every grade.
+- The end-of-session checklist SHOULD add the new dated report after
+  running an audit.
 
 ### Minimum file structure
 
 ```markdown
-# 360-Degree Audit History
+# 360-Degree Audit — YYYY-MM-DD
 
-## Audit history
+## Scores
 
-| Date       | Value | Quality | Viability | Discovery | Issues created |
-| ---------- | ----- | ------- | --------- | --------- | -------------- |
-| YYYY-MM-DD | [A–F] | [A–F]   | [A–F]     | [A–F]     | #N, #M, ...    |
+| Dimension   | Grade     | Findings | Critical |
+| ----------- | --------- | -------- | -------- |
+| ...         | [A–F]     | [n]      | [n]      |
+| **Overall** | **[A–F]** | **[n]**  | **[n]**  |
+
+## Issues created
+
+#N, #M, ...
 
 ## Current bottleneck
 
-**[Category] ([Grade])** — [key gaps]
+**[Dimension] ([Grade])** — [key gaps]
+
+## [Dimension] — Grade: [A–F]
+
+[one section per dimension: findings table + grade rationale]
 ```
 
 ---


### PR DESCRIPTION
## What

Remove the ambiguity in how 360-degree audits are stored: make
`docs/audits/YYYY-MM-DD-360.md` the **only** convention.

Previously `360.md` §360-tracking offered two forms — a single-file
`docs/360-audit.md` history (option a) or dated reports under
`docs/audits/` (option b) — and said "pick one." This change:

- Collapses §360-tracking to one rule: each audit MUST be a dated report
  at `docs/audits/YYYY-MM-DD-360.md`; the single-file form is explicitly
  prohibited.
- Updates the minimum-file-structure example to the dated-report shape
  (scores table, issues created, current bottleneck, per-dimension
  findings + rationale).
- Aligns the PLAYBOOK "Run a 360-degree audit" note.

Follows the actual migration done in #666 (the repo already moved to the
folder-only layout).

## Checks

- `py tests/run_smoke.py` → 20/20
- `py tools/sync.py --check` → clean
- No doc presents the single-file form as a valid option; the two
  remaining mentions are a historical migration note and the new
  prohibition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
