### PR TITLE
feat(360): lock audit storage to docs/audits with ADR-018 and SYS-07

### DIFF
--- a/docs/decisions/018-audit-storage-convention.md
+++ b/docs/decisions/018-audit-storage-convention.md
@@ -1,0 +1,66 @@
+---
+id: "018"
+status: Accepted
+date: 2026-06-26
+category: process
+supersedes: []
+superseded_by: []
+---
+
+# ADR-018: docs/audits is the sole 360 audit-storage convention
+
+## Context
+
+The 360-degree audit template offered two ways to persist results: a
+single-file history (`docs/360-audit.md`) holding one score row per
+audit, or verbose dated reports under `docs/audits/YYYY-MM-DD-360.md`.
+The template told authors to "pick one and never split across both,"
+but stated no project-level choice — so the repository could (and did)
+drift: history started in the single-file form, while sibling projects
+used the dated-folder form.
+
+Two forms with a per-project choice is an ambiguity, not a convention.
+It invites split history, makes "where does the audit go?" a judgement
+call on every run, and leaves nothing to mechanically verify. A single
+prescribed location removes all three problems.
+
+## Decision
+
+1. **Single location** — Each 360 audit MUST be stored as a dated report
+   at `docs/audits/YYYY-MM-DD-360.md`. This is the only audit location.
+2. **No single-file history** — The single-file `docs/360-audit.md`
+   form MUST NOT be used; all audit history lives in `docs/audits/`,
+   one dated report per run.
+3. **Mechanical enforcement** — A smoke check (`SYS-07`) MUST assert
+   that no audit report exists outside `docs/audits/` and that every
+   file there uses the dated `YYYY-MM-DD-360.md` name.
+
+## Alternatives considered
+
+- **Keep both forms with a per-project choice** — rejected; "pick one"
+  still permits divergence between projects and leaves the location
+  ambiguous on every run.
+- **Single-file history only** — rejected; a bare score row ages poorly
+  and loses the per-grade reasoning that makes an audit worth revisiting.
+- **Dated folder, documented but unenforced** — rejected; a
+  documentation-only rule drifts. Pair it with a mechanical check per
+  the pair-the-check convention.
+
+## Consequences
+
+- `templates/base/workflow/360.md` [ID: 360-tracking] collapses to one
+  convention and names its check; the `docs/PLAYBOOK.md` "Run a
+  360-degree audit" section is aligned.
+- The legacy `docs/360-audit.md` is migrated to
+  `docs/audits/2026-05-04-360.md`; the single-file form no longer exists.
+- A new smoke check `SYS-07` (spec `SAIT-SMK-SYS-07-001A`) guards the
+  rule; the smoke suite grows by one check.
+- Future audits append a new dated file under `docs/audits/`; no index
+  or rollup history file is maintained.
+
+## Related
+
+- ADR-003 — introduced the 360-degree analysis as a reusable template.
+- `templates/base/workflow/360.md` [ID: 360-tracking] — the audit
+  tracking rule this ADR fixes.
+- `SAIT-SMK-SYS-07-001A` — the paired mechanical check.

--- a/templates/base/workflow/360.md
+++ b/templates/base/workflow/360.md
@@ -490,6 +490,9 @@ ephemeral and invisible to other contributors.
   the rationale for every grade.
 - The end-of-session checklist SHOULD add the new dated report after
   running an audit.
+- Checked by `py tests/run_smoke.py SYS-07`: pass = no audit report
+  outside `docs/audits/`, and every file there uses the
+  `YYYY-MM-DD-360.md` name.
 
 ### Minimum file structure
 

--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -70,6 +70,8 @@ reused for a different component within the same area.
 | `03` | Manifest coverage — every template file has a manifest entry |
 | `04` | Header–manifest sync — DEPENDS ON headers match manifest depends_on |
 | `05` | Generation fidelity — end-of-session audit inlined verbatim or hard-delegated, never paraphrased |
+| `06` | Stack structure — every usable stack's resolved chain carries the ADR-017 MUST sections |
+| `07` | Audit storage — 360 audit reports live only under docs/audits/ with dated names |
 
 ### TPL - Template
 

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -15,6 +15,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-SMK-SYS-04-001A` | SMK | P0 | DEPENDS ON headers match manifest depends_on |
 | `SAIT-SMK-SYS-05-001A` | SMK | P1 | End-of-session audit is inlined verbatim or hard-delegated, never paraphrased |
 | `SAIT-SMK-SYS-06-001A` | SMK | P1 | Every usable stack's resolved chain carries the MUST sections |
+| `SAIT-SMK-SYS-07-001A` | SMK | P2 | 360 audit reports live only under docs/audits/ |
 | `SAIT-SMK-TPL-04-001A` | SMK | P1 | All EXTEND and OVERRIDE directives reference existing IDs |
 | `SAIT-INT-TPL-01-001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
 | `SAIT-INT-TPL-02-001A` | INT | P1 | EXTEND adds rules without removing base rules |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -1126,6 +1126,46 @@ def check_sys_06():
 
 
 # ---------------------------------------------------------------------------
+# SYS-07 — 360 audit reports live only under docs/audits/
+# ---------------------------------------------------------------------------
+# templates/base/workflow/360.md [ID: 360-tracking] mandates one audit-storage
+# convention: each audit is a dated report at docs/audits/YYYY-MM-DD-360.md,
+# and the single-file docs/360-audit.md form is prohibited. This guards the
+# rule mechanically — no audit report may live outside docs/audits/, and a
+# file inside it MUST use the dated YYYY-MM-DD-360.md name.
+
+_AUDIT_DIR = "docs/audits"
+# An audit report file: the prohibited single-file form (360-audit*.md) or a
+# dated report (*-360.md). The 360.md template itself matches neither.
+_AUDIT_NAME = re.compile(r"(?:360-audit.*|.*-360)\.md$")
+_DATED_AUDIT_NAME = re.compile(r"^\d{4}-\d{2}-\d{2}-360\.md$")
+_SKIP_DIRS = {".git", ".venv", "node_modules", "__pycache__", ".idea", ".claude"}
+
+
+def check_sys_07():
+    failures = []
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            if not _AUDIT_NAME.match(name):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, name), ROOT)
+            rel = rel.replace(os.sep, "/")
+            if not rel.startswith(_AUDIT_DIR + "/"):
+                failures.append(
+                    f"  {rel}: 360 audit report outside {_AUDIT_DIR}/ — move "
+                    f"it to {_AUDIT_DIR}/YYYY-MM-DD-360.md "
+                    f"(360.md [ID: 360-tracking])"
+                )
+            elif not _DATED_AUDIT_NAME.match(name):
+                failures.append(
+                    f"  {rel}: audit file must use the YYYY-MM-DD-360.md "
+                    f"dated-report name (360.md [ID: 360-tracking])"
+                )
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Test registry
 # ---------------------------------------------------------------------------
 
@@ -1162,6 +1202,8 @@ CHECKS = [
      "title": "End-of-session audit inlined verbatim or hard-delegated", "fn": check_sys_05},
     {"id": "SYS-06", "spec": "SAIT-SMK-SYS-06-001A",
      "title": "Every usable stack's chain carries the MUST sections", "fn": check_sys_06},
+    {"id": "SYS-07", "spec": "SAIT-SMK-SYS-07-001A",
+     "title": "360 audit reports live only under docs/audits/", "fn": check_sys_07},
     {"id": "TPL-08", "spec": "SAIT-SMK-TPL-08-001A",
      "title": "Every base template has at least one [ID:] tag", "fn": check_tpl_08},
     {"id": "TPL-09", "spec": "SAIT-SMK-TPL-09-001A",

--- a/tests/specs/SAIT-SMK-SYS-07-001A.md
+++ b/tests/specs/SAIT-SMK-SYS-07-001A.md
@@ -1,0 +1,70 @@
+---
+id: SAIT-SMK-SYS-07-001A
+title: 360 audit reports live only under docs/audits/
+product: sait
+type: smoke
+area: SYS
+priority: p2
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [audit, 360, convention, adr-018]
+---
+
+## Short description
+
+> **Given** the repository tree
+> **When** every Markdown file whose name matches a 360 audit report
+> (`360-audit*.md` or `*-360.md`) is located
+> **Then** each one lives under `docs/audits/` and uses the dated
+> `YYYY-MM-DD-360.md` name — the single-file `docs/360-audit.md` form is
+> never present
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every audit report is under `docs/audits/` with a dated `YYYY-MM-DD-360.md` name |
+| FAILED | An audit report exists outside `docs/audits/`, or a file inside it uses a non-dated name |
+| SKIPPED | — |
+| BLOCKED | — |
+| ERROR | File system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+
+### Setup
+
+1. Change to the repository root
+
+### Execution
+
+1. Walk the repository tree, skipping VCS and tooling directories
+   (`.git`, `.venv`, `node_modules`, `__pycache__`, `.idea`, `.claude`)
+2. Match each filename against the audit-report pattern
+   (`360-audit*.md` or `*-360.md`)
+3. For each match, record its path relative to the repository root
+
+### Assertions
+
+1. Assert no matched file lives outside `docs/audits/`
+2. Assert every matched file under `docs/audits/` uses the
+   `YYYY-MM-DD-360.md` dated-report name
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- ADR-018 — `docs/audits/` is the sole audit-storage convention (the
+  rule this check pairs with)
+- `templates/base/workflow/360.md` [ID: 360-tracking] — the audit
+  tracking rule
+- `quality-gates-pair-check` — pair-the-check convention


### PR DESCRIPTION
## What

Lock the 360 audit-storage convention so it can't drift again — record
the decision and enforce it mechanically.

- **ADR-018** — `docs/audits/` is the sole audit location; the
  single-file `docs/360-audit.md` form is prohibited (`process`
  category, Accepted).
- **SYS-07** — new smoke check: no audit report (`360-audit*.md` or
  `*-360.md`) may live outside `docs/audits/`, and every file there
  MUST use the dated `YYYY-MM-DD-360.md` name. Smoke suite 20 → 21.
- **Pair-the-check** — `360.md` [ID: 360-tracking] now names its check
  (command + pass condition) per the §2.7 convention.
- Test artifacts: spec `SAIT-SMK-SYS-07-001A`, INDEX row, and
  CODIFICATION rows for SYS-07 (plus the previously-missing SYS-06).

## Verification

- `py tests/run_smoke.py` → **21/21**
- `py tests/run_smoke.py SYS-07` → PASS on the clean tree; a negative
  test (stray `docs/360-audit.md` + a misnamed file inside the folder)
  failed with both findings as expected.
- `py tests/run_smoke.py ADR-01` → PASS (validates ADR-018 schema +
  reciprocal links).
- `py tools/sync.py --check` → clean.

Follows #666 (the audit migration) and #667 (the template collapse to
one convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
