### PR TITLE
feat(tests): gate resolve.py parser against PyYAML resolution (#655)

### DIFF
--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -95,6 +95,7 @@ reused for a different component within the same area.
 | `02` | Resolution — all stacks resolve to valid, non-empty file lists |
 | `03` | Core tier — resolved chains include core tier files |
 | `04` | Prompt assembly — prompt builds for all stacks |
+| `05` | Parser parity — resolve.py resolution matches the PyYAML resolution |
 
 ### STK - Stack
 

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -30,6 +30,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-INT-MNF-02-001A` | INT | P0 | All stacks resolve to valid, non-empty file lists |
 | `SAIT-INT-MNF-03-001A` | INT | P0 | All resolved chains include core tier files |
 | `SAIT-INT-MNF-04-001A` | INT | P1 | Prompt builds for all stacks |
+| `SAIT-INT-MNF-05-001A` | INT | P0 | resolve.py resolution matches the PyYAML resolution |
 | `SAIT-INT-ITV-01-001A` | INT | P0 | All REQUIRED interview questions are asked before output is generated |
 | `SAIT-INT-ITV-02-001A` | INT | P1 | DEFAULTED sections are pre-filled from the selected stack template |
 | `SAIT-INT-ITV-03-001A` | INT | P0 | Interview answers override stack and base template rules in the output |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -480,6 +480,56 @@ def check_mnf_04():
 
 
 # ---------------------------------------------------------------------------
+# MNF-05 — resolve.py resolution matches the PyYAML resolution
+# ---------------------------------------------------------------------------
+# The user-facing tools/resolve.py uses a stdlib-only hand-rolled manifest
+# parser; smoke (and the manifest's own semantics) use PyYAML. A divergence
+# between the two — e.g. the multi-line depends_on bug, #654 — ships a wrong
+# generated/ chain that `resolve.py --check` cannot catch, since it only
+# verifies self-consistency against the same parser. This gate resolves every
+# stack with BOTH parsers and fails on any mismatch, so the two can never
+# silently drift again regardless of which parser is edited next.
+
+def check_mnf_05():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    tools_dir = os.path.join(ROOT, "tools")
+    if tools_dir not in sys.path:
+        sys.path.insert(0, tools_dir)
+    try:
+        import resolve as resolve_tool
+    except Exception as e:
+        return [f"  cannot import tools/resolve.py: {e}"]
+
+    core_h, entries_h, stacks = resolve_tool.load_manifest()
+    core_y, entries_y, _ = _load_manifest()
+
+    failures = []
+    for stack in stacks:
+        sid = stack["id"]
+        hand = resolve_tool.resolve_chain(sid, core_h, entries_h)
+        ref, _ = _resolve_stack(sid, core_y, entries_y)
+        if hand == ref:
+            continue
+        missing = [f for f in ref if f not in hand]
+        extra = [f for f in hand if f not in ref]
+        parts = []
+        if missing:
+            parts.append(f"missing from resolve.py: {', '.join(missing)}")
+        if extra:
+            parts.append(f"extra in resolve.py: {', '.join(extra)}")
+        if not parts:
+            parts.append("same files, different order")
+        failures.append(
+            f"  {sid}: resolve.py chain != PyYAML chain — "
+            f"{'; '.join(parts)}"
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # TPL-06 — EXTEND/OVERRIDE targets reachable in resolved chain
 # ---------------------------------------------------------------------------
 
@@ -1184,6 +1234,8 @@ CHECKS = [
      "title": "All resolved chains include core tier files", "fn": check_mnf_03},
     {"id": "MNF-04", "spec": "SAIT-INT-MNF-04-001A",
      "title": "Prompt builds for all stacks", "fn": check_mnf_04},
+    {"id": "MNF-05", "spec": "SAIT-INT-MNF-05-001A",
+     "title": "resolve.py resolution matches PyYAML resolution", "fn": check_mnf_05},
     {"id": "TPL-01", "spec": "SAIT-INT-TPL-01-001A",
      "title": "DEPENDS ON chain from python-fastapi.md is complete", "fn": check_tpl_01},
     {"id": "TPL-02", "spec": "SAIT-INT-TPL-02-001A",

--- a/tests/specs/SAIT-INT-MNF-05-001A.md
+++ b/tests/specs/SAIT-INT-MNF-05-001A.md
@@ -1,0 +1,62 @@
+---
+id: SAIT-INT-MNF-05-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567823
+title: resolve.py resolution matches the PyYAML resolution
+product: sait
+type: int
+area: MANIF
+priority: p0
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [manifest, resolution, parser-parity]
+---
+
+## Short description
+
+> **Given** the repository is cloned and `manifest.yaml` is present
+> **When** every stack is resolved with both the stdlib-only parser in
+> `tools/resolve.py` and the PyYAML-based parser used by smoke
+> **Then** the two ordered file chains are identical for every stack
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Both parsers produce the same ordered file chain for every stack |
+| FAILED | One or more stacks resolve to different chains between the two parsers |
+| SKIPPED | `manifest.yaml` is absent or PyYAML is not installed |
+| BLOCKED | `SAIT-INT-MNF-02-001A` is failing |
+| ERROR | `tools/resolve.py` cannot be imported; file system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Python 3 with PyYAML installed
+
+### Execution
+
+1. Load `manifest.yaml` with the hand-rolled parser in
+   `tools/resolve.py` and resolve each stack's chain
+2. Load `manifest.yaml` with `yaml.safe_load` and resolve each stack's
+   chain with the same algorithm
+3. Compare the two ordered file lists per stack
+
+### Assertions
+
+1. Assert each stack's `resolve.py` chain equals its PyYAML chain,
+   element-for-element and in order
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- Related procedures: `SAIT-INT-MNF-02-001A`, `SAIT-INT-MNF-04-001A`
+- Implements: closes the divergent-parser gap behind #654 (#655)


### PR DESCRIPTION
## Problem

Smoke resolves chains with real `yaml.safe_load`; `tools/resolve.py`
uses a stdlib-only hand-rolled parser. No check compared the two, so the
multi-line `depends_on` divergence (#654) shipped a wrong `generated/`
chain **silently** — `resolve.py --check` only verifies self-consistency
against the same parser, never correctness.

## Change

Add smoke check **MNF-05** (`SAIT-INT-MNF-05-001A`): resolve every stack
with **both** parsers and fail on any ordered-file-list mismatch, with a
per-stack diff of the missing/extra files.

```
stack-astro: resolve.py chain != PyYAML chain — missing from resolve.py:
  templates/base/security/security.md, templates/frontend/ux.md,
  templates/frontend/quality.md
```

## Verification

- MNF-05 **fails** on the pre-fix parser (verified by neutering the
  bracket-continuation branch) and **passes** after — proving it gates,
  not just decorates ✓
- `py tests/run_smoke.py` → 22/22 ✓
- Spec registered in `tests/INDEX.md`; MNF-05 component group added to
  `tests/CODIFICATION.md` ✓
- No living doc carries a hardcoded smoke count (the runner prints it);
  the `20/20` references are in the immutable dated 360 audit (ADR-018)
  and are left as historical record

Makes the two parsers provably agree and prevents recurrence regardless
of which parser is edited next. Builds on #654 (#670).

Closes #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)