### PR TITLE
chore(tooling): drop vestigial mobile section from manifest iteration (#656)

### DIFF
--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -67,7 +67,7 @@ def _load_manifest():
         data = yaml.safe_load(f)
 
     entries = {}
-    for section in ("base", "platform", "frontend", "mobile", "backend", "stacks"):
+    for section in ("base", "platform", "frontend", "backend", "stacks"):
         for entry in data.get(section, []):
             entries[entry["id"]] = entry
 
@@ -688,7 +688,7 @@ def check_sys_03():
         manifest = yaml.safe_load(f)
 
     manifest_files = set()
-    for section in ("core", "base", "platform", "frontend", "mobile",
+    for section in ("core", "base", "platform", "frontend",
                     "backend", "stacks"):
         for entry in manifest.get(section, []):
             if isinstance(entry, dict) and "file" in entry:
@@ -720,14 +720,14 @@ def check_sys_04():
 
     # Build id→file and file→depends_on(as files) maps
     id_to_file = {}
-    for section in ("core", "base", "platform", "frontend", "mobile",
+    for section in ("core", "base", "platform", "frontend",
                     "backend", "stacks"):
         for entry in manifest.get(section, []):
             if isinstance(entry, dict):
                 id_to_file[entry["id"]] = entry["file"]
 
     file_manifest_deps = {}
-    for section in ("base", "platform", "frontend", "mobile",
+    for section in ("base", "platform", "frontend",
                     "backend", "stacks"):
         for entry in manifest.get(section, []):
             if isinstance(entry, dict):

--- a/tools/resolve.py
+++ b/tools/resolve.py
@@ -132,7 +132,7 @@ def load_manifest():
     manifest = _parse_manifest(text)
 
     entries = {}
-    for section in ("base", "platform", "frontend", "mobile", "backend", "stacks"):
+    for section in ("base", "platform", "frontend", "backend", "stacks"):
         for entry in manifest.get(section, []):
             entries[entry["id"]] = entry
 


### PR DESCRIPTION
## Problem

The `mobile/` layer was removed in v2.26, but the manifest section
tuples in `tools/resolve.py` and `tests/run_smoke.py` still iterated a
`"mobile"` section that no longer exists. Harmless dead code, but a
stale reference to sweep.

## Change

Removed all five `"mobile"` occurrences:
- `tools/resolve.py` — `load_manifest`
- `tests/run_smoke.py` — `_load_manifest`, `check_sys_03`, and both
  id/dep maps in `check_sys_04`

## Verification

- No `"mobile"` references remain in either file ✓
- `py tests/run_smoke.py` → 22/22 ✓
- `py tools/resolve.py --check` clean ✓

Closes #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)