### PR TITLE
chore(tests): fix dangling STK-06 ref and phantom INDEX rows (#657)

### DIFF
--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -38,9 +38,6 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-E2E-STK-02-001A` | E2E | P0 | Full interview → CLAUDE.md for a Go Echo project |
 | `SAIT-E2E-FMT-01-001A` | E2E | P1 | Full interview → CLAUDE.md output format (Claude Code) |
 | `SAIT-E2E-FMT-02-001A` | E2E | P1 | Full interview → AGENTS.md output format (Codex CLI) |
-| `SAIT-E2E-FMT-03-001A` | E2E | P1 | Full interview → Cursor .mdc output format |
-| `SAIT-E2E-FMT-04-001A` | E2E | P1 | Full interview → Copilot output format |
-| `SAIT-E2E-FMT-05-001A` | E2E | P1 | Full interview → generic AI_CONTEXT.md output format |
 | `SAIT-E2E-STK-03-001A` | E2E | P1 | Full interview → CLAUDE.md for a Django project |
 | `SAIT-E2E-STK-04-001A` | E2E | P1 | Full interview → CLAUDE.md for a Node Express project |
 | `SAIT-E2E-STK-07-001A` | E2E | P1 | Full interview → CLAUDE.md for an Astro static site project |

--- a/tests/specs/SAIT-E2E-STK-07-001A.md
+++ b/tests/specs/SAIT-E2E-STK-07-001A.md
@@ -70,4 +70,4 @@ tags: [e2e, output, astro, static-site]
 
 ## Related
 
-- Related procedures: `SAIT-E2E-STK-06-001A`
+- Related procedures: `SAIT-E2E-STK-20-001A`


### PR DESCRIPTION
## Problem

Test-suite reference hygiene left by the v2.26 stack cull:

- `tests/specs/SAIT-E2E-STK-07-001A.md` (Astro) "Related procedures"
  pointed at `SAIT-E2E-STK-06-001A` — full-nextjs, retired in v2.26.
- `tests/INDEX.md` listed `FMT-03/04/05` as specs, but none has a spec
  file *or* a `cases.py` case — phantom rows that overstate coverage.

## Change

- Repointed STK-07's cross-ref to `SAIT-E2E-STK-20-001A` (HTMX) — the
  other remaining frontend stack, a genuinely related living procedure.
- Removed the three phantom FMT rows from INDEX.

`TPL-05` stays in INDEX — it has a real spec file (the ticket noted it
lacks a *smoke check*, but INDEX catalogs specs, not checks).

## Verification

- INDEX now lists exactly the 44 existing spec files — no phantom rows,
  none missing (verified programmatically) ✓
- No spec or INDEX row references any retired stack (STK-05/06/09/14/17/19) ✓
- `py tests/run_smoke.py` → 22/22 ✓

Closes #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)