### PR TITLE
docs(spec): name data-governance/migration as opt-in orphans (#658)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -224,8 +224,11 @@ They are not referenced in any stack's `depends_on` chain — users
 opt in via the `Extras` field in the declaration block or during the
 interview.
 
-Orthogonal templates include platform choices (github, gitlab) and
-workflow preferences (360, ai-workflow, review, release, deployment).
+Orthogonal templates include platform choices (github, gitlab),
+workflow preferences (360, ai-workflow, review, release, deployment),
+and the advanced data templates (data-governance, data-migration) —
+opt-in extras no stack pulls automatically (`data-quality` is the only
+data module reached by a chain, via python-service).
 
 Orthogonal templates are NOT expected to appear in stack resolution
 and are excluded from reachability checks.


### PR DESCRIPTION
## Problem

`templates/base/data/data-governance.md` and `data-migration.md` are
reached by **zero** chains by design (verified: `data-quality` is in 4
chains, the other two in 0). But unlike the platform/workflow
register-only extras, they were not named in SPEC's orthogonal/opt-in
lists, so they read as accidental orphans.

## Change

List both in the **Orthogonal templates** paragraph — whose definition
("NOT expected to appear in stack resolution ... excluded from
reachability checks") describes them exactly — and note `data-quality`
as the one data module that is chain-reached (via python-service).

## Verification

- `py tools/sync.py --check` clean (edit is outside generated markers) ✓
- `py tests/run_smoke.py` → 22/22 ✓
- All edited lines ≤ 70 chars ✓

Closes #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)