### PR TITLE
feat(stack): name go-lib idioms section "Go conventions" per ADR-017 (#660)

### DIFF
--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2036,8 +2036,8 @@ no HTTP layer.
 
 ---
 
-## Code quality
-[ID: go-lib-quality]
+## Go conventions
+[ID: go-lib-conventions]
 [EXTEND: base-quality]
 
 - Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2036,8 +2036,8 @@ no HTTP layer.
 
 ---
 
-## Code quality
-[ID: go-lib-quality]
+## Go conventions
+[ID: go-lib-conventions]
 [EXTEND: base-quality]
 
 - Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2036,8 +2036,8 @@ no HTTP layer.
 
 ---
 
-## Code quality
-[ID: go-lib-quality]
+## Go conventions
+[ID: go-lib-conventions]
 [EXTEND: base-quality]
 
 - Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2036,8 +2036,8 @@ no HTTP layer.
 
 ---
 
-## Code quality
-[ID: go-lib-quality]
+## Go conventions
+[ID: go-lib-conventions]
 [EXTEND: base-quality]
 
 - Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -42,8 +42,8 @@ no HTTP layer.
 
 ---
 
-## Code quality
-[ID: go-lib-quality]
+## Go conventions
+[ID: go-lib-conventions]
 [EXTEND: base-quality]
 
 - Follow **Effective Go** (https://go.dev/doc/effective_go) for idioms and


### PR DESCRIPTION
## Problem

ADR-017 clause 5 prescribes a `<Language> conventions` section name.
`python-lib`/`nodejs-lib`/`c-embedded` comply, but the Go stack family
surfaced its idioms (Effective Go, Code Review Comments, gofmt/vet/
staticcheck) under a "Code quality" heading — inconsistent with the
convention (not a SYS-06 MUST failure, but a naming gap).

## Change

Renamed `## Code quality` → `## Go conventions` and `[ID: go-lib-quality]`
→ `[ID: go-lib-conventions]` in `go-lib.md`. The ID is referenced nowhere
else (no EXTEND/OVERRIDE breaks); `[EXTEND: base-quality]` retained.

All four Go chains inherit it: `go-lib`, `go-service`, `go-echo`,
`grpc-go`.

## Verification

- `## Go conventions` present in all four resolved Go chains ✓
- Regenerated `generated/` (only the 4 Go chains changed) ✓
- `py tools/resolve.py --check` clean; `py tests/run_smoke.py` → 22/22 ✓

Closes #660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)