### PR TITLE
chore(templates): reflow prose under 80 chars; exempt directives (#659)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,9 @@ base/ ──┬── frontend/ ──┐
 - Use `[ID: ...]` on every section that another template might
   EXTEND or OVERRIDE
 - Optional sections are marked `(if applicable)` in the heading
-- Keep line length under 80 characters
+- Keep line length under 80 characters — exempt: table rows, fenced
+  code, single-line `[DEPENDS ON: ...]` directives, and unbreakable
+  tokens (long URLs / Markdown link targets)
 - No HTML — Markdown only
 - A mechanically-checkable output constraint MUST name its
   agent-runnable check (command + pass condition); subjective

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1871,11 +1880,13 @@ Prefer these patterns for frontend concerns:
   implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
   prefer over deeply nested prop drilling
 - **Render Props / Slot** — pass render logic as a prop or slot to invert
-  control over what is rendered; use sparingly — prefer custom hooks where possible
+  control over what is rendered; use sparingly — prefer custom hooks where
+  possible
 - **Observer** — subscribe to external state changes (store, event bus,
   WebSocket) via a single subscription point; unsubscribe on component unmount
 - **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
-  behind a thin project-owned interface; never scatter SDK calls across components
+  behind a thin project-owned interface; never scatter SDK calls across
+  components
 - **Optimistic Update** — apply the expected result of a mutation immediately
   in the UI and roll back on failure; document the rollback path
 
@@ -2745,7 +2756,8 @@ Extends the static site stack with Astro-specific rules.
 [OVERRIDE: static-site-stack]
 
 - Framework: Astro (static site generator, output: static / GitHub Pages)
-- Interactive components: [React / Vue / Svelte / plain JS / none] — islands only
+- Interactive components: [React / Vue / Svelte / plain JS / none] — islands
+  only
 - CSS: [plain CSS / Tailwind / CSS modules]
 - Content: [JSON files in `src/data/` / CMS / Markdown / hardcoded]
 - Deployed via GitHub Actions on push to `main`
@@ -3075,6 +3087,7 @@ Rules:
   ```
 - Layouts MUST render the description as `<meta name="description">`, OG
   description, and Twitter Card description
-- JSON-LD structured data SHOULD be rendered in a `<script type="application/ld+json">`
+- JSON-LD structured data SHOULD be rendered in a `<script
+  type="application/ld+json">`
   tag in the layout — use `JSON.stringify()` with `set:html` (acceptable
   exception to the `set:html` ban since the input is fully server-controlled)

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1578,7 +1587,8 @@ CLAUDE.md
 - Use Unity macros: `TEST_ASSERT_EQUAL`, `TEST_ASSERT_NULL`, etc.
 - Test naming: `test_<module>_<state>_<expected>`
   e.g. `test_uart_buffer_full_returns_error`
-- Run before every commit: `cmake --build build/tests && ctest --test-dir build/tests`
+- Run before every commit: `cmake --build build/tests && ctest --test-dir
+  build/tests`
 
 ---
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1661,7 +1670,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2292,13 +2302,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2403,7 +2415,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2488,7 +2501,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2524,7 +2538,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2542,7 +2557,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2607,7 +2623,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2679,7 +2696,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3472,7 +3490,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -3526,7 +3545,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`
@@ -3698,7 +3718,8 @@ Overridden by each framework stack. The common principle:
 [EXTEND: backend-observability]
 
 - `/health` — liveness check
-- `/ready` — readiness check (verifies DB and any required external dependencies)
+- `/ready` — readiness check (verifies DB and any required external
+  dependencies)
 
 ---
 
@@ -3735,15 +3756,18 @@ Overridden by each framework stack. The common principle:
 | Messaging | Async, fire-and-forget, event-driven                                                                        |
 
 - Start with REST — only deviate with a stated reason in an ADR
-- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot paths
+- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot
+  paths
 - Never use gRPC as the primary interface for browser clients
-- GraphQL and REST in the same service require strong justification — dual surfaces double the maintenance burden
+- GraphQL and REST in the same service require strong justification — dual
+  surfaces double the maintenance burden
 - SOAP and other legacy protocols require a per-case ADR
 
 ## OpenAPI specification
 - Every API MUST have an OpenAPI specification
 - The spec MUST be kept up to date — a stale spec is worse than no spec
-- Include: all resources, methods, parameters, response schemas, error responses,
+- Include: all resources, methods, parameters, response schemas, error
+  responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
 - Prefer design-first: hand-author the spec as the single source of
@@ -3798,7 +3822,8 @@ Sunset: <HTTP-date>
 
 ## Statelessness
 [ID: backend-api-statelessness]
-- APIs MUST be stateless — no client context stored on the server between requests
+- APIs MUST be stateless — no client context stored on the server between
+  requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
   API service
@@ -3864,7 +3889,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 
@@ -4010,7 +4036,8 @@ CLAUDE.md
 - Use `router.register()` to wire ViewSets — do not hardcode URL patterns
 - Pagination: use `PageNumberPagination` or `LimitOffsetPagination` globally;
   never return unbounded lists
-- Versioning: URI prefix (`/api/v1/`, `/api/v2/`) — set `DEFAULT_VERSIONING_CLASS`
+- Versioning: URI prefix (`/api/v1/`, `/api/v2/`) — set
+  `DEFAULT_VERSIONING_CLASS`
 
 ---
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1713,7 +1722,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -1751,15 +1761,18 @@ DEBUG=false
 | Messaging | Async, fire-and-forget, event-driven                                                                        |
 
 - Start with REST — only deviate with a stated reason in an ADR
-- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot paths
+- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot
+  paths
 - Never use gRPC as the primary interface for browser clients
-- GraphQL and REST in the same service require strong justification — dual surfaces double the maintenance burden
+- GraphQL and REST in the same service require strong justification — dual
+  surfaces double the maintenance burden
 - SOAP and other legacy protocols require a per-case ADR
 
 ## OpenAPI specification
 - Every API MUST have an OpenAPI specification
 - The spec MUST be kept up to date — a stale spec is worse than no spec
-- Include: all resources, methods, parameters, response schemas, error responses,
+- Include: all resources, methods, parameters, response schemas, error
+  responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
 - Prefer design-first: hand-author the spec as the single source of
@@ -1814,7 +1827,8 @@ Sunset: <HTTP-date>
 
 ## Statelessness
 [ID: backend-api-statelessness]
-- APIs MUST be stateless — no client context stored on the server between requests
+- APIs MUST be stateless — no client context stored on the server between
+  requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
   API service
@@ -2313,7 +2327,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 
@@ -2535,13 +2550,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2646,7 +2663,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2731,7 +2749,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2767,7 +2786,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2785,7 +2805,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2850,7 +2871,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2922,7 +2944,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3067,7 +3090,8 @@ CLAUDE.md
 
 - All config in `src/config/index.ts` as a typed object parsed from env vars
   using Zod or `envalid` — fail fast if required vars are missing
-- Import the config object; never read `process.env` directly in application code
+- Import the config object; never read `process.env` directly in application
+  code
 
 ---
 
@@ -3103,10 +3127,12 @@ CLAUDE.md
 ## Testing
 [EXTEND: base-testing]
 
-- Supertest for HTTP-level tests — import `app` directly, no server listen needed
+- Supertest for HTTP-level tests — import `app` directly, no server listen
+  needed
 - Vitest for unit tests on services, repositories, and utilities
 - No mocking of the database in integration tests — use a real test database
-- Test each route for: success (2xx), validation error (400), auth error (401/403)
+- Test each route for: success (2xx), validation error (400), auth error
+  (401/403)
 - Component test naming: `<METHOD> <path> <state> returns <status>`
   e.g. `POST /users with duplicate email returns 409`
 - Run before every commit: `npm test && tsc --noEmit`

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1661,7 +1670,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2292,13 +2302,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2403,7 +2415,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2488,7 +2501,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2524,7 +2538,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2542,7 +2557,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2607,7 +2623,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2679,7 +2696,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3472,7 +3490,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -3526,7 +3545,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`
@@ -3698,7 +3718,8 @@ Overridden by each framework stack. The common principle:
 [EXTEND: backend-observability]
 
 - `/health` — liveness check
-- `/ready` — readiness check (verifies DB and any required external dependencies)
+- `/ready` — readiness check (verifies DB and any required external
+  dependencies)
 
 ---
 
@@ -3714,7 +3735,8 @@ Overridden by each framework stack. The common principle:
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 
@@ -3870,8 +3892,10 @@ CLAUDE.md
 - One `APIRouter` per feature domain with a prefix and tags
 - Routes thin — delegate business logic to service functions
 - Shared logic (auth, DB session, current user) via `Depends()`
-- Use `Annotated` for dependency injection — avoid bare `= Depends()` in signatures
-- Return type annotations on all route functions (FastAPI uses these for OpenAPI)
+- Use `Annotated` for dependency injection — avoid bare `= Depends()` in
+  signatures
+- Return type annotations on all route functions (FastAPI uses these for
+  OpenAPI)
 
 ---
 
@@ -3891,7 +3915,8 @@ CLAUDE.md
 
 - All route handlers and service functions `async def`
 - Blocking I/O (file reads, sync DB calls) must run in `asyncio.to_thread()`
-- Never `await` inside a list comprehension — use `asyncio.gather()` for concurrency
+- Never `await` inside a list comprehension — use `asyncio.gather()` for
+  concurrency
 - Use `asyncpg` or `aiosqlite` for async database drivers
 
 ---
@@ -3917,7 +3942,8 @@ CLAUDE.md
 ## Testing
 [EXTEND: python-service-testing]
 
-- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient` (sync)
+- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient`
+  (sync)
 - One async `client` fixture in `conftest.py`
 - Override dependencies with `app.dependency_overrides` in tests
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1661,7 +1670,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2292,13 +2302,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2403,7 +2415,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2488,7 +2501,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2524,7 +2538,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2542,7 +2557,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2607,7 +2623,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2679,7 +2696,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3472,7 +3490,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -3526,7 +3545,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`
@@ -3698,7 +3718,8 @@ Overridden by each framework stack. The common principle:
 [EXTEND: backend-observability]
 
 - `/health` — liveness check
-- `/ready` — readiness check (verifies DB and any required external dependencies)
+- `/ready` — readiness check (verifies DB and any required external
+  dependencies)
 
 ---
 
@@ -3769,7 +3790,8 @@ CLAUDE.md
 - Always use the application factory pattern (`create_app(config=None)`)
 - Never use the global `app` object outside of `create_app`
 - Register all blueprints and extensions inside `create_app`
-- Extensions instantiated in `extensions.py`, initialised with `ext.init_app(app)`
+- Extensions instantiated in `extensions.py`, initialised with
+  `ext.init_app(app)`
 
 ---
 
@@ -3787,7 +3809,8 @@ CLAUDE.md
 - One blueprint per feature domain (e.g. `auth`, `api`, `admin`)
 - Blueprint registered with a URL prefix (`/api/v1`, `/auth`, etc.)
 - No cross-blueprint imports — shared logic goes in a service module
-- Routes thin — business logic delegated to service functions, not in route handlers
+- Routes thin — business logic delegated to service functions, not in route
+  handlers
 - For multiple API versions that share one contract (same params,
   validation, and response — differing only in implementation), use a
   version registry (`{"v1": ImplV1, "v2": ImplV2}`) plus a blueprint

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1996,7 +2005,8 @@ records and asserts Y-equality across them.
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
+Never used directly for services — always extended by
+`templates/stack/go-service.md`.
 Can be used directly for pure Go libraries or standalone CLI tools with
 no HTTP layer.
 
@@ -2183,7 +2193,8 @@ staticcheck ./...     # additional static analysis
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2365,8 +2376,10 @@ looks wrong" becomes a probe session reconstructing intermediate state.
 [ID: backend-errors]
 [DEPENDS ON: templates/backend/http.md, templates/backend/observability.md]
 
-Error response format and logging rules are defined in `templates/backend/http.md` and
-`templates/backend/observability.md`. This template covers classification, propagation,
+Error response format and logging rules are defined in
+`templates/backend/http.md` and
+`templates/backend/observability.md`. This template covers classification,
+propagation,
 and recovery.
 
 ---
@@ -2900,13 +2913,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/concurrency.md -->
@@ -2914,7 +2929,8 @@ Prefer these patterns for backend concerns:
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 
@@ -3094,7 +3110,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -3179,7 +3196,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -3215,7 +3233,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -3233,7 +3252,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -3298,7 +3318,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -3370,7 +3391,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1996,7 +2005,8 @@ records and asserts Y-equality across them.
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
+Never used directly for services — always extended by
+`templates/stack/go-service.md`.
 Can be used directly for pure Go libraries or standalone CLI tools with
 no HTTP layer.
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1996,7 +2005,8 @@ records and asserts Y-equality across them.
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
+Never used directly for services — always extended by
+`templates/stack/go-service.md`.
 Can be used directly for pure Go libraries or standalone CLI tools with
 no HTTP layer.
 
@@ -2183,7 +2193,8 @@ staticcheck ./...     # additional static analysis
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2365,8 +2376,10 @@ looks wrong" becomes a probe session reconstructing intermediate state.
 [ID: backend-errors]
 [DEPENDS ON: templates/backend/http.md, templates/backend/observability.md]
 
-Error response format and logging rules are defined in `templates/backend/http.md` and
-`templates/backend/observability.md`. This template covers classification, propagation,
+Error response format and logging rules are defined in
+`templates/backend/http.md` and
+`templates/backend/observability.md`. This template covers classification,
+propagation,
 and recovery.
 
 ---
@@ -2900,13 +2913,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/concurrency.md -->
@@ -2914,7 +2929,8 @@ Prefer these patterns for backend concerns:
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 
@@ -3094,7 +3110,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -3179,7 +3196,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -3215,7 +3233,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -3233,7 +3252,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -3298,7 +3318,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -3370,7 +3391,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1996,7 +2005,8 @@ records and asserts Y-equality across them.
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
+Never used directly for services — always extended by
+`templates/stack/go-service.md`.
 Can be used directly for pure Go libraries or standalone CLI tools with
 no HTTP layer.
 
@@ -2183,7 +2193,8 @@ staticcheck ./...     # additional static analysis
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2518,7 +2529,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 
@@ -2677,7 +2689,8 @@ file with runtime conventions, project structure, and tooling.
 
 - Package all protos under a versioned namespace: `package [org].[service].v1`
 - One proto file per service — do not mix unrelated services in one file
-- Field names in `snake_case` — generated code adapts to each language's conventions
+- Field names in `snake_case` — generated code adapts to each language's
+  conventions
 - Use `google.protobuf.Timestamp` for all timestamps — never raw integers
 - Use `google.protobuf.FieldMask` for partial update (patch) operations
 - Never remove or renumber existing fields — mark deprecated fields with
@@ -2728,7 +2741,8 @@ file with runtime conventions, project structure, and tooling.
 ## Authentication
 [EXTEND: backend-auth]
 
-- Pass credentials via gRPC metadata: key `authorization`, value `Bearer <token>`
+- Pass credentials via gRPC metadata: key `authorization`, value `Bearer
+  <token>`
 - Validate in the auth interceptor — not in service handlers
 - Mutual TLS (mTLS) for service-to-service calls in production — certificate
   rotation managed at the infrastructure layer (cert-manager, Vault)
@@ -2777,7 +2791,8 @@ file with runtime conventions, project structure, and tooling.
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 
@@ -2868,7 +2883,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2886,7 +2902,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2951,7 +2968,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -3023,7 +3041,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1661,7 +1670,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -1996,7 +2006,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 
@@ -2155,7 +2166,8 @@ file with runtime conventions, project structure, and tooling.
 
 - Package all protos under a versioned namespace: `package [org].[service].v1`
 - One proto file per service — do not mix unrelated services in one file
-- Field names in `snake_case` — generated code adapts to each language's conventions
+- Field names in `snake_case` — generated code adapts to each language's
+  conventions
 - Use `google.protobuf.Timestamp` for all timestamps — never raw integers
 - Use `google.protobuf.FieldMask` for partial update (patch) operations
 - Never remove or renumber existing fields — mark deprecated fields with
@@ -2206,7 +2218,8 @@ file with runtime conventions, project structure, and tooling.
 ## Authentication
 [EXTEND: backend-auth]
 
-- Pass credentials via gRPC metadata: key `authorization`, value `Bearer <token>`
+- Pass credentials via gRPC metadata: key `authorization`, value `Bearer
+  <token>`
 - Validate in the auth interceptor — not in service handlers
 - Mutual TLS (mTLS) for service-to-service calls in production — certificate
   rotation managed at the infrastructure layer (cert-manager, Vault)
@@ -2255,7 +2268,8 @@ file with runtime conventions, project structure, and tooling.
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 
@@ -2780,7 +2794,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -2834,7 +2849,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`
@@ -2896,7 +2912,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2914,7 +2931,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2979,7 +2997,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -3051,7 +3070,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3149,7 +3169,8 @@ CLAUDE.md
 - Inject dependencies via `__init__` — never import service singletons
   at module level
 - Access request metadata with `context.invocation_metadata()`
-- Set response status codes with `await context.abort(grpc.StatusCode.NOT_FOUND, "detail")`
+- Set response status codes with `await context.abort(grpc.StatusCode.NOT_FOUND,
+  "detail")`
 
 ---
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1713,7 +1722,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -1751,15 +1761,18 @@ DEBUG=false
 | Messaging | Async, fire-and-forget, event-driven                                                                        |
 
 - Start with REST — only deviate with a stated reason in an ADR
-- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot paths
+- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot
+  paths
 - Never use gRPC as the primary interface for browser clients
-- GraphQL and REST in the same service require strong justification — dual surfaces double the maintenance burden
+- GraphQL and REST in the same service require strong justification — dual
+  surfaces double the maintenance burden
 - SOAP and other legacy protocols require a per-case ADR
 
 ## OpenAPI specification
 - Every API MUST have an OpenAPI specification
 - The spec MUST be kept up to date — a stale spec is worse than no spec
-- Include: all resources, methods, parameters, response schemas, error responses,
+- Include: all resources, methods, parameters, response schemas, error
+  responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
 - Prefer design-first: hand-author the spec as the single source of
@@ -1814,7 +1827,8 @@ Sunset: <HTTP-date>
 
 ## Statelessness
 [ID: backend-api-statelessness]
-- APIs MUST be stateless — no client context stored on the server between requests
+- APIs MUST be stateless — no client context stored on the server between
+  requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
   API service
@@ -2313,7 +2327,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 
@@ -2535,13 +2550,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2646,7 +2663,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2731,7 +2749,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2767,7 +2786,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2785,7 +2805,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2850,7 +2871,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2922,7 +2944,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3023,7 +3046,8 @@ CLAUDE.md
 ## Modules
 [ID: nestjs-modules]
 
-- One module per feature domain — `@Module({ imports, controllers, providers, exports })`
+- One module per feature domain — `@Module({ imports, controllers, providers,
+  exports })`
 - Modules are self-contained: controller, service, repository, DTOs, and
   entities live inside the feature directory
 - Export only what other modules genuinely need — favour encapsulation
@@ -3090,7 +3114,8 @@ the module wiring — not hidden AOP proxies.
   never mix authn and authz in one guard
 - Logging interceptor at the global level — logs request ID, method, path,
   duration, and status code
-- Transform interceptor for consistent response envelope (if required by API contract)
+- Transform interceptor for consistent response envelope (if required by API
+  contract)
 
 ---
 
@@ -3098,7 +3123,8 @@ the module wiring — not hidden AOP proxies.
 [EXTEND: base-config]
 
 - Use `@nestjs/config` with a typed `configuration.ts` factory function
-- Inject `ConfigService` via DI — never read `process.env` directly in application code
+- Inject `ConfigService` via DI — never read `process.env` directly in
+  application code
 - Validate config at startup with Joi or class-validator schema
 
 ---
@@ -3116,7 +3142,8 @@ the module wiring — not hidden AOP proxies.
 [EXTEND: backend-features]
 
 - Inject the flag client as an `@Injectable()` provider
-- Evaluate flags in the service layer — not deep inside domain logic or repositories
+- Evaluate flags in the service layer — not deep inside domain logic or
+  repositories
 
 ---
 
@@ -3125,17 +3152,20 @@ the module wiring — not hidden AOP proxies.
 
 - Use `@nestjs/microservices` for broker integration (Kafka, RabbitMQ, Redis)
 - Define message handlers with `@MessagePattern()` or `@EventPattern()`
-- Keep message handlers thin — delegate to the same service layer used by HTTP controllers
+- Keep message handlers thin — delegate to the same service layer used by HTTP
+  controllers
 
 ---
 
 ## Testing
 [EXTEND: base-testing]
 
-- Unit tests with Jest: test each service in isolation using `Test.createTestingModule()`
+- Unit tests with Jest: test each service in isolation using
+  `Test.createTestingModule()`
   with mocked dependencies
 - Integration/e2e tests with Supertest: spin up the full NestJS app against
-  a test database — test each endpoint for success, validation error, and auth error
+  a test database — test each endpoint for success, validation error, and auth
+  error
 - No mocking of the database in e2e tests — use a real test database
 - Component test naming: `<method> <resource> <state> returns <expected>`
   e.g. `POST /users with duplicate email returns 409`

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1596,7 +1605,8 @@ CLAUDE.md
 [ID: nodejs-lib-cli]
 
 - Entry point in `src/cli.ts` — wired to `bin` in `package.json`
-- Parse arguments with [commander / yargs / citty] — never `process.argv` directly
+- Parse arguments with [commander / yargs / citty] — never `process.argv`
+  directly
 - Exit codes: `0` for success, `1` for user error, `2` for internal error
 - Write output to `stdout`; write errors and logs to `stderr`
 - Support `--help` and `--version` flags — both generated automatically

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -2029,7 +2038,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -2083,7 +2093,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1661,7 +1670,8 @@ DEBUG=false
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation
@@ -2292,13 +2302,15 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them
 
 <!-- templates/backend/features.md -->
@@ -2403,7 +2415,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -2488,7 +2501,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)
@@ -2524,7 +2538,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -2542,7 +2557,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -2607,7 +2623,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories
@@ -2679,7 +2696,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 
@@ -3472,7 +3490,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -3526,7 +3545,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`
@@ -3698,7 +3718,8 @@ Overridden by each framework stack. The common principle:
 [EXTEND: backend-observability]
 
 - `/health` — liveness check
-- `/ready` — readiness check (verifies DB and any required external dependencies)
+- `/ready` — readiness check (verifies DB and any required external
+  dependencies)
 
 ---
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -356,7 +356,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 
@@ -409,7 +410,8 @@ maintainer time on phantom fixes.
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -442,7 +444,8 @@ maintainer time on phantom fixes.
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -562,7 +565,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -606,7 +610,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories
@@ -719,9 +724,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -886,7 +893,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly
@@ -1168,7 +1176,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention
@@ -1871,11 +1880,13 @@ Prefer these patterns for frontend concerns:
   implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
   prefer over deeply nested prop drilling
 - **Render Props / Slot** — pass render logic as a prop or slot to invert
-  control over what is rendered; use sparingly — prefer custom hooks where possible
+  control over what is rendered; use sparingly — prefer custom hooks where
+  possible
 - **Observer** — subscribe to external state changes (store, event bus,
   WebSocket) via a single subscription point; unsubscribe on component unmount
 - **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
-  behind a thin project-owned interface; never scatter SDK calls across components
+  behind a thin project-owned interface; never scatter SDK calls across
+  components
 - **Optimistic Update** — apply the expected result of a mutation immediately
   in the UI and roll back on failure; document the rollback path
 
@@ -2745,7 +2756,8 @@ Extends the static site stack with Astro-specific rules.
 [OVERRIDE: static-site-stack]
 
 - Framework: Astro (static site generator, output: static / GitHub Pages)
-- Interactive components: [React / Vue / Svelte / plain JS / none] — islands only
+- Interactive components: [React / Vue / Svelte / plain JS / none] — islands
+  only
 - CSS: [plain CSS / Tailwind / CSS modules]
 - Content: [JSON files in `src/data/` / CMS / Markdown / hardcoded]
 - Deployed via GitHub Actions on push to `main`
@@ -3075,7 +3087,8 @@ Rules:
   ```
 - Layouts MUST render the description as `<meta name="description">`, OG
   description, and Twitter Card description
-- JSON-LD structured data SHOULD be rendered in a `<script type="application/ld+json">`
+- JSON-LD structured data SHOULD be rendered in a `<script
+  type="application/ld+json">`
   tag in the layout — use `JSON.stringify()` with `set:html` (acceptable
   exception to the `set:html` ban since the input is fully server-controlled)
 
@@ -3142,7 +3155,8 @@ the work is sized.
 
 ## Epic
 
-A large initiative too big for one task. Tracks progress via child issue checklist.
+A large initiative too big for one task. Tracks progress via child issue
+checklist.
 
 **Title:** descriptive goal (no prefix — the `epic` label identifies the type)
 
@@ -3195,7 +3209,8 @@ As a [user type], I want [capability] so that [benefit].
 - Scoped to a single concern — do not mix refactoring with features
 - The agent SHOULD be able to complete it in one conversation turn
 - If a task needs multiple sub-tasks, it is an epic
-- Acceptance criteria MUST be verifiable (build passes, page renders, score matches)
+- Acceptance criteria MUST be verifiable (build passes, page renders, score
+  matches)
 
 ---
 
@@ -3318,7 +3333,8 @@ finished.
 Before starting any work, the agent MUST:
 
 1. Read all documents referenced in the project's CLAUDE.md (e.g.
-   `docs/solid-ai-templates/templates/base/core/git.md`, `templates/base/core/docs.md`, etc.)
+   `docs/solid-ai-templates/templates/base/core/git.md`,
+   `templates/base/core/docs.md`, etc.)
 2. These contain binding conventions that CLAUDE.md inherits — do not
    proceed until you have read and understood them
 3. Check which branch you are on — if not `main`, ask why before
@@ -3361,7 +3377,8 @@ The startup block MUST:
 - State the consequence: "If you respond without reading them, you are
   violating project rules"
 
-This requirement exists because `templates/base/workflow/scope.md` says "read all documents
+This requirement exists because `templates/base/workflow/scope.md` says "read
+all documents
 referenced in CLAUDE.md" — but `scope.md` is one of the files that needs
 to be read first. The startup block breaks this chicken-and-egg problem
 by placing the instruction directly in CLAUDE.md, the one file that is
@@ -3560,7 +3577,7 @@ and Quiz sections.
   `[Section Name](#section-name)`
 - The Astro build rewrites chapter cross-references automatically
   via a remark plugin (see
-  [Single-source content pattern](static-site-astro.md#single-source-content-pattern))
+  [Single-source pattern](static-site-astro.md#single-source-content-pattern))
 
 ---
 

--- a/templates/INTERVIEW.md
+++ b/templates/INTERVIEW.md
@@ -74,10 +74,12 @@ DEPENDS ON chain. If you have shell access, run
 `py tools/resolve.py <stack-id> --concat` to get the full resolved
 content. Otherwise, read the pre-resolved file from `generated/<stack-id>.md`.
 Apply any adjustments from Phase 3.
-Generate the output file using the format rules in `templates/base/core/agents.md`.
+Generate the output file using the format rules in
+`templates/base/core/agents.md`.
 All rules are inlined — the output file is self-contained.
 The user should review and adjust the output before adopting it.
-End the file with: `<!-- Generated with solid-ai-templates (github.com/braboj/solid-ai-templates) -->`
+End the file with: `<!-- Generated with solid-ai-templates
+(github.com/braboj/solid-ai-templates) -->`
 
 Also generate `docs/ONBOARDING.md` and `docs/PLAYBOOK.md` following the
 required structures in `templates/base/core/docs.md`.
@@ -94,7 +96,8 @@ inlining them. The output file:
    read for each)
 4. Contains only project-specific overrides and additions inline
 
-End the file with: `<!-- Generated with solid-ai-templates (github.com/braboj/solid-ai-templates) -->`
+End the file with: `<!-- Generated with solid-ai-templates
+(github.com/braboj/solid-ai-templates) -->`
 
 Tell the user to add the submodule:
 ```
@@ -120,7 +123,8 @@ templates for the rest. Follow the hybrid model structure in
    checklist verbatim or hard-delegating ("execute each item; do not
    summarize") — never paraphrased into bullets (see `agents.md` §6.3)
 
-End the file with: `<!-- Generated with solid-ai-templates (github.com/braboj/solid-ai-templates) -->`
+End the file with: `<!-- Generated with solid-ai-templates
+(github.com/braboj/solid-ai-templates) -->`
 
 Tell the user to add the submodule:
 ```

--- a/templates/backend/api.md
+++ b/templates/backend/api.md
@@ -23,15 +23,18 @@
 | Messaging | Async, fire-and-forget, event-driven                                                                        |
 
 - Start with REST — only deviate with a stated reason in an ADR
-- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot paths
+- REST + gRPC is valid: REST for external/ops endpoints, gRPC for internal hot
+  paths
 - Never use gRPC as the primary interface for browser clients
-- GraphQL and REST in the same service require strong justification — dual surfaces double the maintenance burden
+- GraphQL and REST in the same service require strong justification — dual
+  surfaces double the maintenance burden
 - SOAP and other legacy protocols require a per-case ADR
 
 ## OpenAPI specification
 - Every API MUST have an OpenAPI specification
 - The spec MUST be kept up to date — a stale spec is worse than no spec
-- Include: all resources, methods, parameters, response schemas, error responses,
+- Include: all resources, methods, parameters, response schemas, error
+  responses,
   and authentication requirements
 - Provide a changelog documenting API changes across versions
 - Prefer design-first: hand-author the spec as the single source of
@@ -86,7 +89,8 @@ Sunset: <HTTP-date>
 
 ## Statelessness
 [ID: backend-api-statelessness]
-- APIs MUST be stateless — no client context stored on the server between requests
+- APIs MUST be stateless — no client context stored on the server between
+  requests
 - All information needed to process a request MUST be in the request itself
 - Session state belongs in the client or a dedicated session store, not in the
   API service

--- a/templates/backend/auth.md
+++ b/templates/backend/auth.md
@@ -52,7 +52,8 @@ security template with backend-specific depth.
 - For fine-grained needs, layer attribute-based access control (ABAC) on top
   of RBAC — do not replace RBAC entirely
 - Authorise at the service layer, not only at the route layer:
-  a route that passes auth may call a service that operates on another user's data
+  a route that passes auth may call a service that operates on another user's
+  data
 - Never trust client-supplied IDs for ownership checks — always verify that
   the authenticated user owns or has access to the requested resource
 

--- a/templates/backend/caching.md
+++ b/templates/backend/caching.md
@@ -17,11 +17,13 @@ cache technology (Redis, Memcached, in-process).
 
 ## Patterns
 
-- **Cache-aside (lazy loading)**: read from cache first; on miss, load from source,
+- **Cache-aside (lazy loading)**: read from cache first; on miss, load from
+  source,
   populate cache, return result — default pattern for read-heavy workloads
 - **Write-through**: write to cache and source together on every update —
   use when stale reads are unacceptable and write latency is acceptable
-- **Write-behind**: write to cache immediately, persist to source asynchronously —
+- **Write-behind**: write to cache immediately, persist to source asynchronously
+  —
   avoid unless throughput requirements justify the added complexity and risk
 - Never cache at more than one layer for the same data — multiple caches
   create inconsistency and make invalidation impossible to reason about

--- a/templates/backend/concurrency.md
+++ b/templates/backend/concurrency.md
@@ -2,7 +2,8 @@
 [ID: backend-concurrency]
 
 Universal rules for multi-threading, multi-processing, and async I/O.
-Language-specific rules belong in the stack template via [EXTEND: backend-concurrency].
+Language-specific rules belong in the stack template via [EXTEND:
+backend-concurrency].
 
 ---
 

--- a/templates/backend/errors.md
+++ b/templates/backend/errors.md
@@ -2,8 +2,10 @@
 [ID: backend-errors]
 [DEPENDS ON: templates/backend/http.md, templates/backend/observability.md]
 
-Error response format and logging rules are defined in `templates/backend/http.md` and
-`templates/backend/observability.md`. This template covers classification, propagation,
+Error response format and logging rules are defined in
+`templates/backend/http.md` and
+`templates/backend/observability.md`. This template covers classification,
+propagation,
 and recovery.
 
 ---

--- a/templates/backend/grpc.md
+++ b/templates/backend/grpc.md
@@ -24,7 +24,8 @@ file with runtime conventions, project structure, and tooling.
 
 - Package all protos under a versioned namespace: `package [org].[service].v1`
 - One proto file per service — do not mix unrelated services in one file
-- Field names in `snake_case` — generated code adapts to each language's conventions
+- Field names in `snake_case` — generated code adapts to each language's
+  conventions
 - Use `google.protobuf.Timestamp` for all timestamps — never raw integers
 - Use `google.protobuf.FieldMask` for partial update (patch) operations
 - Never remove or renumber existing fields — mark deprecated fields with
@@ -75,7 +76,8 @@ file with runtime conventions, project structure, and tooling.
 ## Authentication
 [EXTEND: backend-auth]
 
-- Pass credentials via gRPC metadata: key `authorization`, value `Bearer <token>`
+- Pass credentials via gRPC metadata: key `authorization`, value `Bearer
+  <token>`
 - Validate in the auth interceptor — not in service handlers
 - Mutual TLS (mTLS) for service-to-service calls in production — certificate
   rotation managed at the infrastructure layer (cert-manager, Vault)

--- a/templates/backend/http.md
+++ b/templates/backend/http.md
@@ -76,7 +76,8 @@
 - Use consistent error response shape across all endpoints
 - Follow RFC 9457 (`application/problem+json`) for error format
 - Use 4xx for client errors, 5xx for server errors — never use 200 for errors
-- Never return stack traces, internal paths, or implementation details to the client
+- Never return stack traces, internal paths, or implementation details to the
+  client
 - Set explicit `Content-Type: application/json` on all JSON responses
 
 ## Authentication and authorisation

--- a/templates/backend/jobs.md
+++ b/templates/backend/jobs.md
@@ -13,7 +13,8 @@ Applies regardless of technology (Celery, asynq, Sidekiq, BullMQ, etc.).
   webhook fanout, long-running data imports
 - Do NOT use jobs for work that the caller needs the result of immediately —
   use async/await or streaming instead
-- Do NOT use jobs to paper over a slow synchronous path — fix the root cause first
+- Do NOT use jobs to paper over a slow synchronous path — fix the root cause
+  first
 
 ---
 

--- a/templates/backend/messaging.md
+++ b/templates/backend/messaging.md
@@ -9,7 +9,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 ## When to use async messaging
 
 - Use messaging when the producer does not need an immediate response
-- Use messaging for workloads that must survive producer restarts — fire-and-forget
+- Use messaging for workloads that must survive producer restarts —
+  fire-and-forget
   with durability
 - Use messaging to decouple services that scale independently
 - Do NOT use messaging when the caller needs a synchronous result — use HTTP or
@@ -94,7 +95,8 @@ Applies regardless of message broker (Kafka, RabbitMQ, SQS, or equivalent).
 
 ## Observability
 
-- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer group
+- Log at consumer entry: message ID, topic/queue name, correlation ID, consumer
+  group
 - Log at consumer exit: processing duration, outcome (success / retry / DLQ)
 - Track per topic/queue:
   - Consumer lag (Kafka) or queue depth (RabbitMQ / SQS)

--- a/templates/backend/microservices.md
+++ b/templates/backend/microservices.md
@@ -101,7 +101,8 @@ Choose the communication style based on the interaction type:
 - Use a service registry or platform-native discovery (Kubernetes DNS,
   Consul, AWS Cloud Map) — never hardcode service URLs in configuration
 - Health checks MUST be implemented on every service (see
-  `templates/backend/observability.md`) — the registry uses them to route traffic only
+  `templates/backend/observability.md`) — the registry uses them to route
+  traffic only
   to healthy instances
 
 ---

--- a/templates/backend/quality.md
+++ b/templates/backend/quality.md
@@ -63,11 +63,13 @@ Prefer these patterns for backend concerns:
 
 ## Performance
 - Prefer async I/O for network-bound operations
-- Cache only when there is a measured need — document cache invalidation strategy
+- Cache only when there is a measured need — document cache invalidation
+  strategy
 - Avoid N+1 queries — use eager loading or batch fetching
 - Set timeouts on all outbound calls (HTTP clients, DB queries)
 
 ## API stability
 - Never remove or rename a field in a response without a deprecation period
-- Increment the API version (`/v2/`) for breaking changes — keep the old version alive
+- Increment the API version (`/v2/`) for breaking changes — keep the old version
+  alive
 - Document deprecated endpoints; set a removal date before retiring them

--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -305,9 +305,11 @@ extend the root.
 ## Companion documents
 
 All three models MUST also generate:
-- `docs/ONBOARDING.md` — following the structure in `templates/base/core/docs.md`
+- `docs/ONBOARDING.md` — following the structure in
+  `templates/base/core/docs.md`
 - `docs/PLAYBOOK.md` — following the structure in `templates/base/core/docs.md`
-- `docs/dev-journal.md` — following the structure in `templates/base/core/docs.md`
+- `docs/dev-journal.md` — following the structure in
+  `templates/base/core/docs.md`
 
 ---
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -87,9 +87,11 @@ of tool changes.
 
 Before every commit, update all relevant documentation:
 
-- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions change
+- **`CLAUDE.md`** — update if architecture, stack, design rules, or conventions
+  change
 - **`README.md`** — update if project structure, stack, or setup steps change
-- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process change
+- **`docs/PLAYBOOK.md`** — update if commands, workflow, or release process
+  change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
 ## Decision logs
@@ -254,7 +256,8 @@ is incomplete.
 
 ## Writing style
 
-- Write in present tense — past or future tense indicates out-of-sync documentation
+- Write in present tense — past or future tense indicates out-of-sync
+  documentation
 - Write as little as necessary but as much as needed — documentation that goes
   out of sync is worse than no documentation
 - Remove redundant, inconsistent, or outdated documentation promptly

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -4,7 +4,8 @@
 ## Committer identity
 - Configure git with your full name and a consistent, professional email address
 - Do not use private or personal email addresses for work repositories
-- Identity must not change — git history and tooling depend on consistent authorship
+- Identity must not change — git history and tooling depend on consistent
+  authorship
 
 ## Commit messages
 - Use conventional commit prefixes:
@@ -37,7 +38,8 @@
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
 - **Before merging**, review the diff against the base branch. Follow
-  `templates/base/core/review.md` priority order: security → correctness → clarity →
+  `templates/base/core/review.md` priority order: security → correctness →
+  clarity →
   conventions. Check CI passes. Only merge after the review passes.
 - **Before pushing or creating a PR**, check `git status` and list open PRs.
   If the previous PR is closed or merged, create a new branch rather than
@@ -157,7 +159,8 @@ When NOT to close-and-resubmit:
 
 ## README
 - Every repository MUST contain a `README.md`
-- The README MUST conform to the structure and rules defined in `templates/base/core/readme.md`
+- The README MUST conform to the structure and rules defined in
+  `templates/base/core/readme.md`
 
 ## Versioning
 - Use [Semantic Versioning](https://semver.org/) — `MAJOR.MINOR.PATCH`
@@ -201,7 +204,8 @@ When NOT to close-and-resubmit:
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
-     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>" --generate-notes`
+     `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
+     --generate-notes`
 
 ## General
 - Do not commit build output, secrets, or dependency directories

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -350,7 +350,8 @@ maintainer time on phantom fixes.
 - No debug statements in committed code: no `print()`, `console.log()`,
   `fmt.Println()`, or equivalent used for debugging
 - No hardcoded breakpoints (`debugger`, `pdb.set_trace()`) in committed code
-- No commented-out code blocks — delete dead code; version control is the history
+- No commented-out code blocks — delete dead code; version control is the
+  history
 - Debug tooling (profilers, REPL helpers, verbose loggers) MUST be
   gated behind a flag or environment variable, never on by default
 

--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -13,7 +13,8 @@
 ## Priority order
 
 Apply the following order when reviewing, from most to least critical.
-Use `templates/base/core/quality.md` (and any language-specific quality template such as
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
 `templates/base/language/typescript.md`) as the standard for items 2–4.
 
 1. **Security exposure** — anything that could be exploited, any credential
@@ -92,7 +93,8 @@ completeness. Run a structure audit after:
 
 Verify every MUST from:
 
-- `templates/base/core/docs.md` — standard documents (README, ONBOARDING, PLAYBOOK, ADRs)
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
 - `templates/base/core/readme.md` — README has all 8 required sections
 - `templates/base/core/git.md` — .gitignore, README exist
 - The relevant frontend or backend layer template — required assets,
@@ -101,7 +103,8 @@ Verify every MUST from:
 
 When a section contains multiple MUST sub-clauses, verify each sub-clause
 independently — do not pass the section as a whole. For example,
-`templates/base/core/readme.md` Usage requires both usage examples AND expected output
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
 per example — these are two separate checks.
 
 SHOULD also check:

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -32,7 +32,8 @@ driver is TDD — tests are written alongside or before the code.
 - MUST achieve 90% coverage of new code before merging
 - SHOULD cover negative scenarios and edge cases
 - The total codebase SHOULD maintain 80% unit test coverage — see
-  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for new projects,
+  `templates/base/workflow/quality-gates.md` for the coverage policy (80% for
+  new projects,
   warn-only for legacy)
 - Coverage MUST NOT regress between releases
 - MUST be runnable from CI without human intervention

--- a/templates/base/infra/cicd.md
+++ b/templates/base/infra/cicd.md
@@ -10,7 +10,8 @@ merged PR and a deployed artifact — humans approve, machines execute.
 ## Quality gates
 
 - Stages 2–4 (lint, test, security scan) are defined in detail in
-  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool constraints
+  `templates/base/workflow/quality-gates.md` — categories, thresholds, and tool
+  constraints
 - Platform-specific CI integration is in `platform/github.md` or
   `platform/gitlab.md`
 
@@ -28,7 +29,8 @@ A pipeline MUST include, in order:
 2. **Lint / format check** — fail on style violations
 3. **Test** — run unit and integration tests; fail on any failure
 4. **Security scan** — SAST, secret detection, SCA
-5. **Package** — build the deployable artifact (container image, binary, package)
+5. **Package** — build the deployable artifact (container image, binary,
+   package)
 6. **Deploy to staging** — automated deployment to a staging/QA environment
 7. **DAST** — automated security scan against the running staging environment
 8. **Deploy to production** — triggered manually or on a release tag
@@ -93,7 +95,8 @@ historical tag with `--notes-start-tag`.
 
 ## Pipeline as code
 
-- Pipeline definitions MUST live in the repository alongside the application code
+- Pipeline definitions MUST live in the repository alongside the application
+  code
 - Pipeline changes follow the same review process as application code
 - Shared pipeline logic MUST be extracted into reusable templates — never
   copy-paste pipeline stages across repositories

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -63,7 +63,8 @@ not after deployment.
 - Never run DAST against production
 - Automated DAST scans MUST complete before any production release
 - Critical findings MUST block the release and be treated as incidents
-- Lower-severity findings MUST be tracked and resolved within a defined timeframe
+- Lower-severity findings MUST be tracked and resolved within a defined
+  timeframe
 
 ## IaC scanning (Infrastructure-as-Code)
 

--- a/templates/base/workflow/360.md
+++ b/templates/base/workflow/360.md
@@ -548,7 +548,9 @@ and are maintained.
 
 - `templates/base/core/review.md` — peer review checks changed files in a PR;
   360 checks the whole project
-- `templates/base/workflow/scope.md` — end-of-session audit is operational (did I
+- `templates/base/workflow/scope.md` — end-of-session audit is operational (did
+  I
   update docs?); 360 is strategic (is this project healthy?)
-- `templates/base/workflow/quality-gates.md` — defines enforcement layers; 360 checks
+- `templates/base/workflow/quality-gates.md` — defines enforcement layers; 360
+  checks
   whether they are configured and effective

--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -1,13 +1,16 @@
 # AI-Assisted Development Workflow
 [ID: base-ai-workflow]
 
-How to structure work when collaborating with AI coding agents. Covers the project lifecycle, work item hierarchy, and practices that maximize agent effectiveness.
+How to structure work when collaborating with AI coding agents. Covers the
+project lifecycle, work item hierarchy, and practices that maximize agent
+effectiveness.
 
 ## Lifecycle Phases
 
 ### 1. Spike (Explore)
 
-Conversational research to understand the problem space and generate recommendations.
+Conversational research to understand the problem space and generate
+recommendations.
 
 **What the human does:**
 - Defines the question or area to explore
@@ -19,9 +22,11 @@ Conversational research to understand the problem space and generate recommendat
 - Compares alternatives with tradeoffs
 - Produces a recommendation with rationale
 
-**Output:** A decision or ADR (Architecture Decision Record) documenting the choice and why.
+**Output:** A decision or ADR (Architecture Decision Record) documenting the
+choice and why.
 
-**Anti-pattern:** Skipping the spike and jumping to code. The agent will build whatever you ask — the question is whether it's the right thing to build.
+**Anti-pattern:** Skipping the spike and jumping to code. The agent will build
+whatever you ask — the question is whether it's the right thing to build.
 
 ### 2. Prototype
 
@@ -29,12 +34,16 @@ A throwaway implementation to validate feasibility and UX direction.
 
 **What changes with AI:**
 - Prototypes are nearly free — an agent can build one in a single session
-- The bottleneck shifts from building to deciding. Have the conversation about what you want before generating code
-- Prototype code should be disposable. Don't polish it — test the concept, then rebuild properly
+- The bottleneck shifts from building to deciding. Have the conversation about
+  what you want before generating code
+- Prototype code should be disposable. Don't polish it — test the concept, then
+  rebuild properly
 
-**Output:** A working demo the stakeholder can interact with. Keep or discard based on feedback.
+**Output:** A working demo the stakeholder can interact with. Keep or discard
+based on feedback.
 
-**Anti-pattern:** Polishing the prototype into the product. Prototype code carries technical debt from speed-first decisions.
+**Anti-pattern:** Polishing the prototype into the product. Prototype code
+carries technical debt from speed-first decisions.
 
 ### 3. Design
 
@@ -44,9 +53,12 @@ Define the MVP scope, data model, architecture, and conventions.
 - Architecture Decision Records for non-obvious choices
 - Data model (types/interfaces)
 - Page/component structure
-- Convention file (CLAUDE.md or equivalent) so the agent follows project rules across sessions
+- Convention file (CLAUDE.md or equivalent) so the agent follows project rules
+  across sessions
 
-**Key principle:** The convention file is the agent's long-term memory. Anything not written down will be forgotten between sessions. Invest time in CLAUDE.md — it pays back on every future conversation.
+**Key principle:** The convention file is the agent's long-term memory. Anything
+not written down will be forgotten between sessions. Invest time in CLAUDE.md —
+it pays back on every future conversation.
 
 ### 4. Development
 
@@ -74,15 +86,18 @@ Iterative implementation using epics, stories, and tasks.
 
 Set up CI/CD, configure hosting, verify in production.
 
-**Agent role:** Write the workflow files, configure build steps, troubleshoot deployment failures.
+**Agent role:** Write the workflow files, configure build steps, troubleshoot
+deployment failures.
 
-**Human role:** DNS, domain registration, secrets, access tokens — things that require account access.
+**Human role:** DNS, domain registration, secrets, access tokens — things that
+require account access.
 
 ### 6. Monitor
 
 Track errors, performance, and user feedback.
 
-**Agent role:** Set up monitoring config, analyze logs, investigate reported issues.
+**Agent role:** Set up monitoring config, analyze logs, investigate reported
+issues.
 
 **Human role:** Watch dashboards, collect user feedback, prioritize fixes.
 
@@ -94,7 +109,8 @@ Track errors, performance, and user feedback.
 
 A large initiative spanning multiple sessions. Too big for one task.
 
-**Good epic:** "Genre Scoring System" — clear goal, multiple components, measurable completion.
+**Good epic:** "Genre Scoring System" — clear goal, multiple components,
+measurable completion.
 
 **Bad epic:** "Make the site better" — no clear scope or completion criteria.
 
@@ -106,21 +122,27 @@ A large initiative spanning multiple sessions. Too big for one task.
 
 ### User Story
 
-Describes a capability from the user's perspective. Guides the agent toward the right outcome.
+Describes a capability from the user's perspective. Guides the agent toward the
+right outcome.
 
 **Format:** "As a [user type], I want [capability] so that [benefit]."
 
 **Examples:**
-- "As a budget photographer, I want to sort lenses by optical quality and price so that I can find the best value."
-- "As a nightscape shooter, I want to filter lenses by coma score so that I only see lenses suitable for astrophotography."
+- "As a budget photographer, I want to sort lenses by optical quality and price
+  so that I can find the best value."
+- "As a nightscape shooter, I want to filter lenses by coma score so that I only
+  see lenses suitable for astrophotography."
 
-**Why stories matter for AI agents:** Agents take instructions literally. A user story gives the agent the user's perspective, not just a technical specification. This produces better UX decisions when the agent has latitude.
+**Why stories matter for AI agents:** Agents take instructions literally. A user
+story gives the agent the user's perspective, not just a technical
+specification. This produces better UX decisions when the agent has latitude.
 
 ### Task
 
 An atomic, implementable unit of work. One task = one branch = one PR.
 
-**Good task:** "Add OQ column to Lens Explorer table and mobile cards, computed from weighted optical field average."
+**Good task:** "Add OQ column to Lens Explorer table and mobile cards, computed
+from weighted optical field average."
 
 **Bad task:** "Improve the lens explorer."
 
@@ -149,7 +171,9 @@ A defect in existing functionality.
 - Screenshots or error messages if available
 - Browser/environment if relevant
 
-**Why context matters for AI agents:** "The page broke" forces the agent to guess. "The wiki filter shows 0 entries on preview after the Content Collections migration" lets the agent diagnose immediately.
+**Why context matters for AI agents:** "The page broke" forces the agent to
+guess. "The wiki filter shows 0 entries on preview after the Content Collections
+migration" lets the agent diagnose immediately.
 
 ---
 
@@ -368,7 +392,8 @@ judgment to N inputs, fan out across agents instead of looping:
 
 ### Decide before delegating
 
-The agent will build whatever you ask. The expensive mistake is building the wrong thing fast. Spend time on:
+The agent will build whatever you ask. The expensive mistake is building the
+wrong thing fast. Spend time on:
 - Which option to pursue (spike first)
 - What the acceptance criteria are
 - What's in scope and what's not
@@ -383,9 +408,12 @@ Don't queue up 10 tasks and review at the end. Review after each task:
 
 ### Use feedback loops
 
-When the agent does something wrong, say so explicitly — it corrects immediately. When it does something right in a non-obvious way, confirm it — the agent learns what to repeat.
+When the agent does something wrong, say so explicitly — it corrects
+immediately. When it does something right in a non-obvious way, confirm it — the
+agent learns what to repeat.
 
-Corrections: "Don't mock the database in tests — we got burned when mocked tests passed but prod failed."
+Corrections: "Don't mock the database in tests — we got burned when mocked tests
+passed but prod failed."
 
 Confirmations: "Yes, the single bundled PR was the right call here."
 
@@ -409,7 +437,8 @@ A productive session with an AI agent follows this rhythm:
 5. **Merge** — commit, PR, merge to main
 6. **Repeat or stop** — pick another task or end the session
 
-Keep sessions focused. One theme per session (e.g., "wiki migration" or "lens detail pages") produces better results than jumping between unrelated topics.
+Keep sessions focused. One theme per session (e.g., "wiki migration" or "lens
+detail pages") produces better results than jumping between unrelated topics.
 
 ---
 
@@ -417,49 +446,141 @@ Keep sessions focused. One theme per session (e.g., "wiki migration" or "lens de
 
 ### When to revert vs when to iterate
 
-AI agents make changes cheap, which creates a temptation to keep iterating on a failing approach. Recognize the difference:
+AI agents make changes cheap, which creates a temptation to keep iterating on a
+failing approach. Recognize the difference:
 
-- **Iterate** when the approach is right but the details need adjustment — styling tweaks, field mapping errors, off-by-one bugs.
-- **Revert** when the approach itself is wrong — the architecture doesn't fit, performance got worse, or the complexity isn't justified.
+- **Iterate** when the approach is right but the details need adjustment —
+  styling tweaks, field mapping errors, off-by-one bugs.
+- **Revert** when the approach itself is wrong — the architecture doesn't fit,
+  performance got worse, or the complexity isn't justified.
 
-The signal: if you're on the third round of fixes for the same feature and it still doesn't feel right, the approach is wrong. Revert cleanly, document why it failed (in the issue or an ADR), and try a different approach. Don't let sunk cost drive technical decisions.
+The signal: if you're on the third round of fixes for the same feature and it
+still doesn't feel right, the approach is wrong. Revert cleanly, document why it
+failed (in the issue or an ADR), and try a different approach. Don't let sunk
+cost drive technical decisions.
 
-A special case: when a new bug looks like a previously-fixed pattern, the instinct is to extend the existing fix mechanism. Try it — but measure the result against a concrete metric, not against "does it look right." If the metric regresses, revert immediately and document the rejected attempt inline (a code comment or PR note) so future sessions see the dead end. The framework-extension attempt is not waste: it falsifies the "same fix applies" hypothesis cheaply, which is information.
+A special case: when a new bug looks like a previously-fixed pattern, the
+instinct is to extend the existing fix mechanism. Try it — but measure the
+result against a concrete metric, not against "does it look right." If the
+metric regresses, revert immediately and document the rejected attempt inline (a
+code comment or PR note) so future sessions see the dead end. The
+framework-extension attempt is not waste: it falsifies the "same fix applies"
+hypothesis cheaply, which is information.
 
 ### Verify agent calculations against the system
 
-AI agents can do mental math — and get it wrong. When the agent computes a score, estimate, or comparison, **always verify against the actual build output.** The agent may use stale values, wrong field names, or misremember data from earlier in the conversation.
+AI agents can do mental math — and get it wrong. When the agent computes a
+score, estimate, or comparison, **always verify against the actual build
+output.** The agent may use stale values, wrong field names, or misremember data
+from earlier in the conversation.
 
-The build is the source of truth. `npm run build` then check the output. Don't trust "I calculated 7.9" — check what the page actually renders.
+The build is the source of truth. `npm run build` then check the output. Don't
+trust "I calculated 7.9" — check what the page actually renders.
 
 ### Verify before relying on a claim
 
-A claim about current state — a count in a memory note, a changelog's list of breaking changes, the assumption that one fix refreshed every view — is accurate when written and decays after. Before you scope work or declare a fix shipped on the strength of such a claim, re-measure the thing itself. The check is usually one command, and it replaces a guess with proof.
+A claim about current state — a count in a memory note, a changelog's list of
+breaking changes, the assumption that one fix refreshed every view — is accurate
+when written and decays after. Before you scope work or declare a fix shipped on
+the strength of such a claim, re-measure the thing itself. The check is usually
+one command, and it replaces a guess with proof.
 
-- **Counts in handoff notes decay fast.** A memory note, prior PR body, or journal "follow-ups" line that quantifies backlog ("33 stale logs", "5 open Dependabot PRs") was true at write time; sweep tasks then complete silently as side effects of other work. Re-run the underlying check (`--check`, `gh pr list`, `git log --since=`) before estimating effort, and note any large drift in the session entry — it is signal about which sweeps are finishing on their own. Treat the count as a question, not an answer.
-- **A dependency bump is verified by the gate, not the changelog.** Scanning a major bump's changelog sizes the question; running the project's lint/test/build against the new version answers it. If the local gate passes, the bump is safe regardless of changelog content; if it fails, the changelog names which breaking change fired. Patch and minor bumps may skip the run when the changelog shows no breaking changes.
-- **When the truth source changes, audit every downstream render.** When one source of truth feeds multiple rendered artifacts (design tokens → CSS + Storybook + docs; OpenAPI → SDKs + mocks + docs), updating the source does not refresh the renders. Before declaring the fix shipped, list every artifact derived from the changed truth and verify each — build-time caches, hand-tweaked files, and provenance artifacts that intentionally show the pre-fix state each behave differently; call out which.
-- **A plan-time placement is a hypothesis, not a fact.** Before writing a rule or fix to a planned target file or section, open it and confirm the gap is real and the home is semantically correct. Milestone plans routinely mis-place: the "missing" rule is already covered two files over, or the planned home conflates two concerns (a gate that *verifies* vs a diagnostic that *instruments*). The check is one read, and it replaces a guess with the file's actual contents.
+- **Counts in handoff notes decay fast.** A memory note, prior PR body, or
+  journal "follow-ups" line that quantifies backlog ("33 stale logs", "5 open
+  Dependabot PRs") was true at write time; sweep tasks then complete silently as
+  side effects of other work. Re-run the underlying check (`--check`, `gh pr
+  list`, `git log --since=`) before estimating effort, and note any large drift
+  in the session entry — it is signal about which sweeps are finishing on their
+  own. Treat the count as a question, not an answer.
+- **A dependency bump is verified by the gate, not the changelog.** Scanning a
+  major bump's changelog sizes the question; running the project's
+  lint/test/build against the new version answers it. If the local gate passes,
+  the bump is safe regardless of changelog content; if it fails, the changelog
+  names which breaking change fired. Patch and minor bumps may skip the run when
+  the changelog shows no breaking changes.
+- **When the truth source changes, audit every downstream render.** When one
+  source of truth feeds multiple rendered artifacts (design tokens → CSS +
+  Storybook + docs; OpenAPI → SDKs + mocks + docs), updating the source does not
+  refresh the renders. Before declaring the fix shipped, list every artifact
+  derived from the changed truth and verify each — build-time caches,
+  hand-tweaked files, and provenance artifacts that intentionally show the
+  pre-fix state each behave differently; call out which.
+- **A plan-time placement is a hypothesis, not a fact.** Before writing a rule
+  or fix to a planned target file or section, open it and confirm the gap is
+  real and the home is semantically correct. Milestone plans routinely
+  mis-place: the "missing" rule is already covered two files over, or the
+  planned home conflates two concerns (a gate that *verifies* vs a diagnostic
+  that *instruments*). The check is one read, and it replaces a guess with the
+  file's actual contents.
 
 ### Probe before acting on a hypothesis
 
-A bug ticket, a spike, or a prior-session note often arrives with a hypothesized mechanism, a proposed fix, or an inherited diagnosis. Treat it as a claim to disprove, not a foundation to build on. Before acting, run the cheapest probe — a throwaway script, a data dump, a single query — that would confirm or refute it. One run answers two questions: is the hypothesis correct, and where is the real signal? The frequent outcome is that the probe inverts the framing and the real cause sits in a different region than the text predicted.
+A bug ticket, a spike, or a prior-session note often arrives with a hypothesized
+mechanism, a proposed fix, or an inherited diagnosis. Treat it as a claim to
+disprove, not a foundation to build on. Before acting, run the cheapest probe —
+a throwaway script, a data dump, a single query — that would confirm or refute
+it. One run answers two questions: is the hypothesis correct, and where is the
+real signal? The frequent outcome is that the probe inverts the framing and the
+real cause sits in a different region than the text predicted.
 
 Run the probe at whichever decision point comes first:
 
-- **Before coding a fix the issue proposes** — when the body names a specific code surface and a predicted cause, the fix often belongs somewhere the text did not point.
-- **Before drafting an ADR** — when the investigation prompts are cheap to answer against real data, the measurement frequently flips the recommendation an estimate would have reached.
-- **At spike intake** — before treating a spike that asserts a specific failure ("X happens because Y") as actionable, confirm the assertion against the cheapest data dump that would refute it.
-- **At the start of a follow-up session** — re-verify any load-bearing diagnosis inherited from a prior session's memory; a coarse earlier conclusion may not survive a direct probe, and the proposed solution set may be unnecessary.
-- **Before filing a bug** — when a short probe (under ~30 min) costs less than the next agent's cost to orient, it turns a reproduction-only ticket into a root-cause brief with fix options.
+- **Before coding a fix the issue proposes** — when the body names a specific
+  code surface and a predicted cause, the fix often belongs somewhere the text
+  did not point.
+- **Before drafting an ADR** — when the investigation prompts are cheap to
+  answer against real data, the measurement frequently flips the recommendation
+  an estimate would have reached.
+- **At spike intake** — before treating a spike that asserts a specific failure
+  ("X happens because Y") as actionable, confirm the assertion against the
+  cheapest data dump that would refute it.
+- **At the start of a follow-up session** — re-verify any load-bearing diagnosis
+  inherited from a prior session's memory; a coarse earlier conclusion may not
+  survive a direct probe, and the proposed solution set may be unnecessary.
+- **Before filing a bug** — when a short probe (under ~30 min) costs less than
+  the next agent's cost to orient, it turns a reproduction-only ticket into a
+  root-cause brief with fix options.
 
-Probe the breadth before scoping the fix. When a quality gate flags an issue by reason code, or two items look like a duplicate, the first probe is how many items share the symptom — `grep -c <reason_code>` over the gate output, or a cohort-wide content hash. The breadth changes the category of work: an isolated 1/N case is one fix; a systemic pattern is a different effort and often resolves to wontdo-and-document an upstream cause (e.g. identical bytes served from distinct URLs). Designing the fix before measuring breadth risks an implementation spike on a non-systemic issue, or a small-fix framing on a cohort-wide one. The probe costs seconds; the misframing costs a wasted spike. The mechanism generalizes to any cohort with byte-identifiable artifacts — scraped assets, generated files, captured fixtures, computed reports.
+Probe the breadth before scoping the fix. When a quality gate flags an issue by
+reason code, or two items look like a duplicate, the first probe is how many
+items share the symptom — `grep -c <reason_code>` over the gate output, or a
+cohort-wide content hash. The breadth changes the category of work: an isolated
+1/N case is one fix; a systemic pattern is a different effort and often resolves
+to wontdo-and-document an upstream cause (e.g. identical bytes served from
+distinct URLs). Designing the fix before measuring breadth risks an
+implementation spike on a non-systemic issue, or a small-fix framing on a
+cohort-wide one. The probe costs seconds; the misframing costs a wasted spike.
+The mechanism generalizes to any cohort with byte-identifiable artifacts —
+scraped assets, generated files, captured fixtures, computed reports.
 
-Probe the artifact, not your reading of it. When the claim rests on a dense source-of-truth artifact — an overlay image, a generated SVG, a log, a chart, a database row — dump its raw representation (pixel scan, JSON dump, AST walk, `SELECT`) instead of re-interpreting the rendered view. Repeated reading is slower and can yield mutually inconsistent conclusions; one raw dump settles the question.
+Probe the artifact, not your reading of it. When the claim rests on a dense
+source-of-truth artifact — an overlay image, a generated SVG, a log, a chart, a
+database row — dump its raw representation (pixel scan, JSON dump, AST walk,
+`SELECT`) instead of re-interpreting the rendered view. Repeated reading is
+slower and can yield mutually inconsistent conclusions; one raw dump settles the
+question.
 
-Prefer the production harness over a throwaway probe when it already emits the classification. When the question is only "does the failure framing reproduce?" and the project ships a tool that already produces per-case verdicts — a test runner, a CI gate, a linter, an auto-triage runner — run that tool first. Its output is the authoritative classification, not a one-off recomputation; it needs no script to author or delete; and it re-runs next session without rebuilding the probe environment. A throwaway probe is justified only when the production tool cannot answer the question. Signs the harness is the right call: the issue cites a count from a manual triage you would be recomputing, its reason codes match the failure classes the issue lists, or its output is queryable. Thirty seconds of `<tool> --help` is cheaper than writing a probe to discover the tool already does the job.
+Prefer the production harness over a throwaway probe when it already emits the
+classification. When the question is only "does the failure framing reproduce?"
+and the project ships a tool that already produces per-case verdicts — a test
+runner, a CI gate, a linter, an auto-triage runner — run that tool first. Its
+output is the authoritative classification, not a one-off recomputation; it
+needs no script to author or delete; and it re-runs next session without
+rebuilding the probe environment. A throwaway probe is justified only when the
+production tool cannot answer the question. Signs the harness is the right call:
+the issue cites a count from a manual triage you would be recomputing, its
+reason codes match the failure classes the issue lists, or its output is
+queryable. Thirty seconds of `<tool> --help` is cheaper than writing a probe to
+discover the tool already does the job.
 
-Skipping the probe has two visible failure modes: a well-reasoned fix built against a wrong premise, and a premature ADR that needs same-day supersession. When the probe inverts the framing, the original text is a useful negative result — record it in the PR description or the ADR's "approaches ruled out." If the project exposes no cheap probe for the claim, surfacing that gap is itself the first output. Probes are throwaway: name them for the issue, delete them before the commit that uses their findings, and keep the findings in the issue, ADR, or PR.
+Skipping the probe has two visible failure modes: a well-reasoned fix built
+against a wrong premise, and a premature ADR that needs same-day supersession.
+When the probe inverts the framing, the original text is a useful negative
+result — record it in the PR description or the ADR's "approaches ruled out." If
+the project exposes no cheap probe for the claim, surfacing that gap is itself
+the first output. Probes are throwaway: name them for the issue, delete them
+before the commit that uses their findings, and keep the findings in the issue,
+ADR, or PR.
 
 ### Debugging multi-stage systems
 
@@ -486,16 +607,32 @@ in sequence on every report; that scales with stages × reports.
 
 ### Verify external state before a visible action
 
-Some actions land on someone else's surface — filing an issue or opening a PR on a third-party repo, taking on a dependency, pulling a vendored fixture. Before one of these, confirm the external state is what you assume. The check is cheap (a single API call or page load); the cost of skipping it is acting on stale or wrong information publicly, under the maintainer's identity.
+Some actions land on someone else's surface — filing an issue or opening a PR on
+a third-party repo, taking on a dependency, pulling a vendored fixture. Before
+one of these, confirm the external state is what you assume. The check is cheap
+(a single API call or page load); the cost of skipping it is acting on stale or
+wrong information publicly, under the maintainer's identity.
 
 Confirm, before acting:
 
-- **The target is the real project** — search ranking and name collisions lie. Verify against the README, the canonical source, or the site the dependency claims to be.
-- **The repo is live** — not archived, read-only, or migrated. An archived repo silently rejects new issues; a moved one routes your action to a dead fork.
-- **The channel is open** — issues are enabled, the branch accepts PRs, the package version still exists.
-- **The terms fit your repo** — an "official" or "recommended" action/tool's pricing and license model fits your repo's org type. "Official" is not always "drop-in": `gitleaks/gitleaks-action` is free on personal repos but requires a paid license secret on organization repos. Verify the pricing model before switching, not on the first failing run.
+- **The target is the real project** — search ranking and name collisions lie.
+  Verify against the README, the canonical source, or the site the dependency
+  claims to be.
+- **The repo is live** — not archived, read-only, or migrated. An archived repo
+  silently rejects new issues; a moved one routes your action to a dead fork.
+- **The channel is open** — issues are enabled, the branch accepts PRs, the
+  package version still exists.
+- **The terms fit your repo** — an "official" or "recommended" action/tool's
+  pricing and license model fits your repo's org type. "Official" is not always
+  "drop-in": `gitleaks/gitleaks-action` is free on personal repos but requires a
+  paid license secret on organization repos. Verify the pricing model before
+  switching, not on the first failing run.
 
-When a check fails, treat it as a signal about your own source of truth, not just a one-off filing problem. A repo that turns out archived, renamed, or wrong means the ADR, README, or memory that pointed there is stale — fix the pointer (or drop the dead trigger) in the same task, rather than working around the single blocked action.
+When a check fails, treat it as a signal about your own source of truth, not
+just a one-off filing problem. A repo that turns out archived, renamed, or wrong
+means the ADR, README, or memory that pointed there is stale — fix the pointer
+(or drop the dead trigger) in the same task, rather than working around the
+single blocked action.
 
 ### Middle scope: ship a novel data shape before the UI
 
@@ -522,27 +659,43 @@ both decisions together, which is what you want.
 
 ### Scope creep within sessions
 
-A productive session can cover a lot of ground. But jumping between unrelated topics (feature work, data fixes, epic triage, domain decisions) leads to:
+A productive session can cover a lot of ground. But jumping between unrelated
+topics (feature work, data fixes, epic triage, domain decisions) leads to:
 
 - Commits directly to main instead of feature branches
 - Incomplete work left uncommitted
 - Context switching that reduces quality
 
-**Recommendation:** Commit to a theme per session. When an unrelated topic surfaces, create an issue and return to it in the next session. If you do switch topics mid-session, commit and push the current work first.
+**Recommendation:** Commit to a theme per session. When an unrelated topic
+surfaces, create an issue and return to it in the next session. If you do switch
+topics mid-session, commit and push the current work first.
 
 ### Constraints can invalidate a plan mid-execution
 
-When an architectural constraint surfaces mid-execution that makes the agreed plan unreachable as stated, pause, name the constraint, and re-surface the option set — each option with its blast radius — for the user to re-decide. Do NOT scope-creep the fix to absorb the constraint silently: rewriting a fixed parameter, re-deriving anchor data, or otherwise expanding the blast radius ships a half-done architectural change. Re-surfacing is cheap; recovering from a half-done architectural change is not. When the constraint hits, the move is always stop and re-decide, not plough on.
+When an architectural constraint surfaces mid-execution that makes the agreed
+plan unreachable as stated, pause, name the constraint, and re-surface the
+option set — each option with its blast radius — for the user to re-decide. Do
+NOT scope-creep the fix to absorb the constraint silently: rewriting a fixed
+parameter, re-deriving anchor data, or otherwise expanding the blast radius
+ships a half-done architectural change. Re-surfacing is cheap; recovering from a
+half-done architectural change is not. When the constraint hits, the move is
+always stop and re-decide, not plough on.
 
 ### Data quality is the real bottleneck
 
-With AI agents, code changes take minutes. But the inputs to those changes — optical quality scores, prices, field validations — require human judgment and research. A single lens review can take longer to evaluate than the entire scoring engine took to build.
+With AI agents, code changes take minutes. But the inputs to those changes —
+optical quality scores, prices, field validations — require human judgment and
+research. A single lens review can take longer to evaluate than the entire
+scoring engine took to build.
 
 Plan for this asymmetry:
 
 - **Code tasks** — delegate freely, review the output
-- **Data tasks** — the agent can research and propose, but the human must validate against primary sources
-- **Judgment calls** — "Is this bokeh score 0.5 or 1.0?" requires domain knowledge the agent doesn't have. Expect these decisions to take time. They're the most valuable part of the process.
+- **Data tasks** — the agent can research and propose, but the human must
+  validate against primary sources
+- **Judgment calls** — "Is this bokeh score 0.5 or 1.0?" requires domain
+  knowledge the agent doesn't have. Expect these decisions to take time. They're
+  the most valuable part of the process.
 
 ### A local failure CI doesn't reproduce is host maintenance, not a code change
 

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -59,7 +59,8 @@ the work is sized.
 
 ## Epic
 
-A large initiative too big for one task. Tracks progress via child issue checklist.
+A large initiative too big for one task. Tracks progress via child issue
+checklist.
 
 **Title:** descriptive goal (no prefix — the `epic` label identifies the type)
 
@@ -112,7 +113,8 @@ As a [user type], I want [capability] so that [benefit].
 - Scoped to a single concern — do not mix refactoring with features
 - The agent SHOULD be able to complete it in one conversation turn
 - If a task needs multiple sub-tasks, it is an epic
-- Acceptance criteria MUST be verifiable (build passes, page renders, score matches)
+- Acceptance criteria MUST be verifiable (build passes, page renders, score
+  matches)
 
 ---
 

--- a/templates/base/workflow/release.md
+++ b/templates/base/workflow/release.md
@@ -2,7 +2,8 @@
 [ID: base-release]
 
 ## Versioning
-- All packages and services MUST follow semantic versioning (`MAJOR.MINOR.PATCH`)
+- All packages and services MUST follow semantic versioning
+  (`MAJOR.MINOR.PATCH`)
 - MAJOR — breaking changes
 - MINOR — new backward-compatible functionality
 - PATCH — backward-compatible bug fixes
@@ -26,7 +27,8 @@ at least as far:
 When a breaking change is unavoidable:
 
 1. Deploy the new version alongside the old one
-2. Notify all consumers that the old version is deprecated and set a removal date
+2. Notify all consumers that the old version is deprecated and set a removal
+   date
 3. Allow consumers to migrate at their own pace within the deprecation window
 4. Remove the old version only after the window has closed
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -14,7 +14,8 @@ finished.
 Before starting any work, the agent MUST:
 
 1. Read all documents referenced in the project's CLAUDE.md (e.g.
-   `docs/solid-ai-templates/templates/base/core/git.md`, `templates/base/core/docs.md`, etc.)
+   `docs/solid-ai-templates/templates/base/core/git.md`,
+   `templates/base/core/docs.md`, etc.)
 2. These contain binding conventions that CLAUDE.md inherits — do not
    proceed until you have read and understood them
 3. Check which branch you are on — if not `main`, ask why before
@@ -57,7 +58,8 @@ The startup block MUST:
 - State the consequence: "If you respond without reading them, you are
   violating project rules"
 
-This requirement exists because `templates/base/workflow/scope.md` says "read all documents
+This requirement exists because `templates/base/workflow/scope.md` says "read
+all documents
 referenced in CLAUDE.md" — but `scope.md` is one of the files that needs
 to be read first. The startup block breaks this chicken-and-egg problem
 by placing the instruction directly in CLAUDE.md, the one file that is

--- a/templates/frontend/quality.md
+++ b/templates/frontend/quality.md
@@ -22,11 +22,13 @@ Prefer these patterns for frontend concerns:
   implicit state via context (e.g. `<Tabs>`, `<Tab>`, `<TabPanel>`);
   prefer over deeply nested prop drilling
 - **Render Props / Slot** — pass render logic as a prop or slot to invert
-  control over what is rendered; use sparingly — prefer custom hooks where possible
+  control over what is rendered; use sparingly — prefer custom hooks where
+  possible
 - **Observer** — subscribe to external state changes (store, event bus,
   WebSocket) via a single subscription point; unsubscribe on component unmount
 - **Facade** — wrap third-party libraries (analytics, maps, payment SDKs)
-  behind a thin project-owned interface; never scatter SDK calls across components
+  behind a thin project-owned interface; never scatter SDK calls across
+  components
 - **Optimistic Update** — apply the expected result of a mutation immediately
   in the UI and roll back on failure; document the rollback path
 

--- a/templates/stack/c-embedded.md
+++ b/templates/stack/c-embedded.md
@@ -116,7 +116,8 @@ CLAUDE.md
 - Use Unity macros: `TEST_ASSERT_EQUAL`, `TEST_ASSERT_NULL`, etc.
 - Test naming: `test_<module>_<state>_<expected>`
   e.g. `test_uart_buffer_full_returns_error`
-- Run before every commit: `cmake --build build/tests && ctest --test-dir build/tests`
+- Run before every commit: `cmake --build build/tests && ctest --test-dir
+  build/tests`
 
 ---
 

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -2,7 +2,8 @@
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
-Never used directly for services — always extended by `templates/stack/go-service.md`.
+Never used directly for services — always extended by
+`templates/stack/go-service.md`.
 Can be used directly for pure Go libraries or standalone CLI tools with
 no HTTP layer.
 

--- a/templates/stack/node-express.md
+++ b/templates/stack/node-express.md
@@ -113,7 +113,8 @@ CLAUDE.md
 
 - All config in `src/config/index.ts` as a typed object parsed from env vars
   using Zod or `envalid` — fail fast if required vars are missing
-- Import the config object; never read `process.env` directly in application code
+- Import the config object; never read `process.env` directly in application
+  code
 
 ---
 
@@ -149,10 +150,12 @@ CLAUDE.md
 ## Testing
 [EXTEND: base-testing]
 
-- Supertest for HTTP-level tests — import `app` directly, no server listen needed
+- Supertest for HTTP-level tests — import `app` directly, no server listen
+  needed
 - Vitest for unit tests on services, repositories, and utilities
 - No mocking of the database in integration tests — use a real test database
-- Test each route for: success (2xx), validation error (400), auth error (401/403)
+- Test each route for: success (2xx), validation error (400), auth error
+  (401/403)
 - Component test naming: `<METHOD> <path> <state> returns <status>`
   e.g. `POST /users with duplicate email returns 409`
 - Run before every commit: `npm test && tsc --noEmit`

--- a/templates/stack/node-nestjs.md
+++ b/templates/stack/node-nestjs.md
@@ -69,7 +69,8 @@ CLAUDE.md
 ## Modules
 [ID: nestjs-modules]
 
-- One module per feature domain — `@Module({ imports, controllers, providers, exports })`
+- One module per feature domain — `@Module({ imports, controllers, providers,
+  exports })`
 - Modules are self-contained: controller, service, repository, DTOs, and
   entities live inside the feature directory
 - Export only what other modules genuinely need — favour encapsulation
@@ -136,7 +137,8 @@ the module wiring — not hidden AOP proxies.
   never mix authn and authz in one guard
 - Logging interceptor at the global level — logs request ID, method, path,
   duration, and status code
-- Transform interceptor for consistent response envelope (if required by API contract)
+- Transform interceptor for consistent response envelope (if required by API
+  contract)
 
 ---
 
@@ -144,7 +146,8 @@ the module wiring — not hidden AOP proxies.
 [EXTEND: base-config]
 
 - Use `@nestjs/config` with a typed `configuration.ts` factory function
-- Inject `ConfigService` via DI — never read `process.env` directly in application code
+- Inject `ConfigService` via DI — never read `process.env` directly in
+  application code
 - Validate config at startup with Joi or class-validator schema
 
 ---
@@ -162,7 +165,8 @@ the module wiring — not hidden AOP proxies.
 [EXTEND: backend-features]
 
 - Inject the flag client as an `@Injectable()` provider
-- Evaluate flags in the service layer — not deep inside domain logic or repositories
+- Evaluate flags in the service layer — not deep inside domain logic or
+  repositories
 
 ---
 
@@ -171,17 +175,20 @@ the module wiring — not hidden AOP proxies.
 
 - Use `@nestjs/microservices` for broker integration (Kafka, RabbitMQ, Redis)
 - Define message handlers with `@MessagePattern()` or `@EventPattern()`
-- Keep message handlers thin — delegate to the same service layer used by HTTP controllers
+- Keep message handlers thin — delegate to the same service layer used by HTTP
+  controllers
 
 ---
 
 ## Testing
 [EXTEND: base-testing]
 
-- Unit tests with Jest: test each service in isolation using `Test.createTestingModule()`
+- Unit tests with Jest: test each service in isolation using
+  `Test.createTestingModule()`
   with mocked dependencies
 - Integration/e2e tests with Supertest: spin up the full NestJS app against
-  a test database — test each endpoint for success, validation error, and auth error
+  a test database — test each endpoint for success, validation error, and auth
+  error
 - No mocking of the database in e2e tests — use a real test database
 - Component test naming: `<method> <resource> <state> returns <expected>`
   e.g. `POST /users with duplicate email returns 409`

--- a/templates/stack/nodejs-lib.md
+++ b/templates/stack/nodejs-lib.md
@@ -82,7 +82,8 @@ CLAUDE.md
 [ID: nodejs-lib-cli]
 
 - Entry point in `src/cli.ts` — wired to `bin` in `package.json`
-- Parse arguments with [commander / yargs / citty] — never `process.argv` directly
+- Parse arguments with [commander / yargs / citty] — never `process.argv`
+  directly
 - Exit codes: `0` for success, `1` for user error, `2` for internal error
 - Write output to `stdout`; write errors and logs to `stderr`
 - Support `--help` and `--version` flags — both generated automatically

--- a/templates/stack/python-django.md
+++ b/templates/stack/python-django.md
@@ -107,7 +107,8 @@ CLAUDE.md
 - Use `router.register()` to wire ViewSets — do not hardcode URL patterns
 - Pagination: use `PageNumberPagination` or `LimitOffsetPagination` globally;
   never return unbounded lists
-- Versioning: URI prefix (`/api/v1/`, `/api/v2/`) — set `DEFAULT_VERSIONING_CLASS`
+- Versioning: URI prefix (`/api/v1/`, `/api/v2/`) — set
+  `DEFAULT_VERSIONING_CLASS`
 
 ---
 

--- a/templates/stack/python-fastapi.md
+++ b/templates/stack/python-fastapi.md
@@ -75,8 +75,10 @@ CLAUDE.md
 - One `APIRouter` per feature domain with a prefix and tags
 - Routes thin — delegate business logic to service functions
 - Shared logic (auth, DB session, current user) via `Depends()`
-- Use `Annotated` for dependency injection — avoid bare `= Depends()` in signatures
-- Return type annotations on all route functions (FastAPI uses these for OpenAPI)
+- Use `Annotated` for dependency injection — avoid bare `= Depends()` in
+  signatures
+- Return type annotations on all route functions (FastAPI uses these for
+  OpenAPI)
 
 ---
 
@@ -96,7 +98,8 @@ CLAUDE.md
 
 - All route handlers and service functions `async def`
 - Blocking I/O (file reads, sync DB calls) must run in `asyncio.to_thread()`
-- Never `await` inside a list comprehension — use `asyncio.gather()` for concurrency
+- Never `await` inside a list comprehension — use `asyncio.gather()` for
+  concurrency
 - Use `asyncpg` or `aiosqlite` for async database drivers
 
 ---
@@ -122,7 +125,8 @@ CLAUDE.md
 ## Testing
 [EXTEND: python-service-testing]
 
-- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient` (sync)
+- `httpx.AsyncClient` with `ASGITransport` for route tests — no `TestClient`
+  (sync)
 - One async `client` fixture in `conftest.py`
 - Override dependencies with `app.dependency_overrides` in tests
 

--- a/templates/stack/python-flask.md
+++ b/templates/stack/python-flask.md
@@ -57,7 +57,8 @@ CLAUDE.md
 - Always use the application factory pattern (`create_app(config=None)`)
 - Never use the global `app` object outside of `create_app`
 - Register all blueprints and extensions inside `create_app`
-- Extensions instantiated in `extensions.py`, initialised with `ext.init_app(app)`
+- Extensions instantiated in `extensions.py`, initialised with
+  `ext.init_app(app)`
 
 ---
 
@@ -75,7 +76,8 @@ CLAUDE.md
 - One blueprint per feature domain (e.g. `auth`, `api`, `admin`)
 - Blueprint registered with a URL prefix (`/api/v1`, `/auth`, etc.)
 - No cross-blueprint imports — shared logic goes in a service module
-- Routes thin — business logic delegated to service functions, not in route handlers
+- Routes thin — business logic delegated to service functions, not in route
+  handlers
 - For multiple API versions that share one contract (same params,
   validation, and response — differing only in implementation), use a
   version registry (`{"v1": ImplV1, "v2": ImplV2}`) plus a blueprint

--- a/templates/stack/python-grpc.md
+++ b/templates/stack/python-grpc.md
@@ -66,7 +66,8 @@ CLAUDE.md
 - Inject dependencies via `__init__` — never import service singletons
   at module level
 - Access request metadata with `context.invocation_metadata()`
-- Set response status codes with `await context.abort(grpc.StatusCode.NOT_FOUND, "detail")`
+- Set response status codes with `await context.abort(grpc.StatusCode.NOT_FOUND,
+  "detail")`
 
 ---
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -35,7 +35,8 @@ README.md
 CLAUDE.md
 ```
 
-- Source layout (`src/`) — prevents accidental imports of the uninstalled package
+- Source layout (`src/`) — prevents accidental imports of the uninstalled
+  package
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 
@@ -89,7 +90,8 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
-- Dev/test dependencies in `[project.optional-dependencies]` or `[dependency-groups]`
+- Dev/test dependencies in `[project.optional-dependencies]` or
+  `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent
 - If `__version__` derives from `importlib.metadata.version(...)`, an
   editable install reports a stale version after a `[project].version`

--- a/templates/stack/python-service.md
+++ b/templates/stack/python-service.md
@@ -120,7 +120,8 @@ Overridden by each framework stack. The common principle:
 [EXTEND: backend-observability]
 
 - `/health` — liveness check
-- `/ready` — readiness check (verifies DB and any required external dependencies)
+- `/ready` — readiness check (verifies DB and any required external
+  dependencies)
 
 ---
 

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -9,7 +9,8 @@ Extends the static site stack with Astro-specific rules.
 [OVERRIDE: static-site-stack]
 
 - Framework: Astro (static site generator, output: static / GitHub Pages)
-- Interactive components: [React / Vue / Svelte / plain JS / none] — islands only
+- Interactive components: [React / Vue / Svelte / plain JS / none] — islands
+  only
 - CSS: [plain CSS / Tailwind / CSS modules]
 - Content: [JSON files in `src/data/` / CMS / Markdown / hardcoded]
 - Deployed via GitHub Actions on push to `main`
@@ -339,6 +340,7 @@ Rules:
   ```
 - Layouts MUST render the description as `<meta name="description">`, OG
   description, and Twitter Card description
-- JSON-LD structured data SHOULD be rendered in a `<script type="application/ld+json">`
+- JSON-LD structured data SHOULD be rendered in a `<script
+  type="application/ld+json">`
   tag in the layout — use `JSON.stringify()` with `set:html` (acceptable
   exception to the `set:html` ban since the input is fully server-controlled)

--- a/templates/stack/static-site-tutorial.md
+++ b/templates/stack/static-site-tutorial.md
@@ -70,7 +70,7 @@ and Quiz sections.
   `[Section Name](#section-name)`
 - The Astro build rewrites chapter cross-references automatically
   via a remark plugin (see
-  [Single-source content pattern](static-site-astro.md#single-source-content-pattern))
+  [Single-source pattern](static-site-astro.md#single-source-content-pattern))
 
 ---
 


### PR DESCRIPTION
## Problem

CLAUDE.md §2.7 requires <80-char lines. **136 genuine prose lines**
(excluding tables/code) violated it — 58 in `ai-workflow.md`, with
paragraphs up to **891 chars**.

## Change

1. **Documented the exemption** in §2.7: table rows, fenced code,
   single-line `[DEPENDS ON:]` directives, and unbreakable tokens (long
   URLs / Markdown link targets) are out of scope for the rule.
2. **Reflowed all 136 offenders** to <80 with a content-preserving
   splitter — each over-long line broken at its last space ≤80, the
   remainder re-indented to the repo's continuation style (2 spaces
   under a bullet, leading indent for prose). Exactly one space becomes a
   newline per break, so each file's **non-whitespace content is provably
   unchanged** (asserted per file during the run).
3. Shortened one unbreakable link label in `static-site-tutorial.md`
   (84 chars even un-indented) to fit.

## Verification

- 0 genuine prose violations remain (re-ran the detector) ✓
- Per-file content-identity assertion passed for all 38 reflowed files ✓
- Regenerated all 17 chains; `resolve.py --check` + `sync.py --check`
  clean ✓
- `py tests/run_smoke.py` → 22/22 ✓
- Spot-checked diffs (auth.md, ai-workflow.md): surgical word-boundary
  wraps, correct indent ✓

Closes #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)