### PR TITLE
feat(workflow): validate handoff candidates against tracker (#638)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3430,8 +3430,14 @@ before it becomes planned work:
   "next: continue on X" pointer marks the cheapest resumption of the last
   thread, not the highest-priority move. Before acting, re-check X's
   milestone and priority against the project's current milestone — if
-  they differ, ask first. The wrap-up writer SHOULD record each pointer's
-  milestone and priority inline so the next session sees the mismatch.
+  they differ, ask first. The wrap-up writer MUST validate each candidate
+  against the tracker before listing it (`gh issue view <N>` or
+  equivalent — still open, in the current milestone, not blocked), drop
+  closed or out-of-milestone candidates, and record each surviving
+  pointer's milestone and priority inline so the next session sees any
+  mismatch. A breadcrumb is captured from session memory, not synced from
+  the tracker, so a stale entry burns the next session's setup time on
+  already-done work.
 
 ## Default scope boundaries
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -111,8 +111,14 @@ before it becomes planned work:
   "next: continue on X" pointer marks the cheapest resumption of the last
   thread, not the highest-priority move. Before acting, re-check X's
   milestone and priority against the project's current milestone — if
-  they differ, ask first. The wrap-up writer SHOULD record each pointer's
-  milestone and priority inline so the next session sees the mismatch.
+  they differ, ask first. The wrap-up writer MUST validate each candidate
+  against the tracker before listing it (`gh issue view <N>` or
+  equivalent — still open, in the current milestone, not blocked), drop
+  closed or out-of-milestone candidates, and record each surviving
+  pointer's milestone and priority inline so the next session sees any
+  mismatch. A breadcrumb is captured from session memory, not synced from
+  the tracker, so a stale entry burns the next session's setup time on
+  already-done work.
 
 ## Default scope boundaries
 


### PR DESCRIPTION
## Problem

The wrap-up writer captures session-handoff "next session" candidates
from session memory, but the tracker keeps moving between sessions
(sub-issues close as PR side-effects, items move milestones). The next
session then opens with a stale candidate list and burns triage time. In
a downstream project, **5 of 6** listed candidates were already
closed/moved by the next session start — trusting the pointer would have
meant multi-step setup for already-done work.

## Change

Strengthened `scope.md`'s handoff-breadcrumb rule (under "Reconcile
candidates against scope before planning"): the wrap-up writer **MUST**
now validate each candidate against the tracker before listing it
(`gh issue view <N>` — open, in the current milestone, not blocked),
**drop** closed/out-of-milestone candidates, and keep the existing
milestone/priority-inline note for survivors.

## Verification

- No new >80 lines in scope.md ✓
- Regenerated the tutorial chain (scope.md's only chain);
  `resolve.py --check` clean ✓
- `py tests/run_smoke.py` → 22/22 ✓

Reusable upstream template rule (lives in `base/workflow/scope.md`), so
downstream projects deriving their memory-pointer step inherit it.

Closes #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)