### PR TITLE
test(e2e): add STK cases for nestjs, c-embedded, tutorial (#661)

### DIFF
--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -121,6 +121,9 @@ reused for a different component within the same area.
 | `18` | Node.js lib — nodejs-lib stack interview flow |
 | `19` | — retired (rust-lib stack removed, v2.25) |
 | `20` | HTMX — htmx stack interview flow |
+| `21` | NestJS — node-nestjs stack interview flow |
+| `22` | C embedded — c-embedded stack interview flow |
+| `23` | Tutorial site — static-site-tutorial stack interview flow |
 
 ### FMT - Output Format
 

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -50,6 +50,9 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-E2E-STK-16-001A` | E2E | P2 | Full interview → CLAUDE.md for a generic Go service |
 | `SAIT-E2E-STK-18-001A` | E2E | P1 | Full interview → CLAUDE.md for a Node.js library project |
 | `SAIT-E2E-STK-20-001A` | E2E | P1 | Full interview → CLAUDE.md for an HTMX project |
+| `SAIT-E2E-STK-21-001A` | E2E | P1 | Full interview → CLAUDE.md for a NestJS project |
+| `SAIT-E2E-STK-22-001A` | E2E | P1 | Full interview → CLAUDE.md for a C embedded project |
+| `SAIT-E2E-STK-23-001A` | E2E | P1 | Full interview → CLAUDE.md for a tutorial site project |
 | `SAIT-E2E-DPL-01-001A` | E2E | P1 | Cloud deployment target produces correct deployment rules |
 | `SAIT-E2E-DPL-02-001A` | E2E | P1 | Hybrid deployment target produces correct deployment rules |
 | `SAIT-E2E-DPL-03-001A` | E2E | P1 | Offline deployment target produces correct deployment rules |

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -339,6 +339,67 @@ STK_TESTS = [
         # HTMX is server-rendered hypermedia — SPA patterns must not appear
         "forbidden": ["JSON API", "SPA routing"],
     },
+    {
+        "id": "STK-21",
+        "spec": "SAIT-E2E-STK-21-001A",
+        "stack": "templates/stack/node-nestjs.md",
+        "answers": {
+            "Project name": "PaymentsAPI",
+            "Language": "TypeScript",
+            "HTTP adapter": "Express",
+            "ORM": "Prisma",
+            "Auth": "JWT",
+            "Output format": "CLAUDE.md (inline model)",
+        },
+        "required": [
+            "1. Project", "Project structure", "Commands",
+            "Git", "Code conventions", "Testing",
+            "NestJS", "TypeScript",
+            "class-validator",
+            "Jest",
+            "feat:",
+        ],
+        "forbidden": ["[your project]", "[owner]", "[repo]"],
+    },
+    {
+        "id": "STK-22",
+        "spec": "SAIT-E2E-STK-22-001A",
+        "stack": "templates/stack/c-embedded.md",
+        "answers": {
+            "Project name": "SensorFirmware",
+            "Target": "STM32 (ARM Cortex-M4)",
+            "Toolchain": "arm-none-eabi-gcc",
+            "Test runner": "Unity (host build)",
+            "Output format": "CLAUDE.md (inline model)",
+        },
+        "required": [
+            "1. Project", "Project structure", "Commands",
+            "C conventions",
+            "C17", "CMake",
+            "Unity", "cppcheck",
+            "feat:",
+        ],
+        "forbidden": ["[your project]", "[owner]", "[repo]"],
+    },
+    {
+        "id": "STK-23",
+        "spec": "SAIT-E2E-STK-23-001A",
+        "stack": "templates/stack/static-site-tutorial.md",
+        "answers": {
+            "Project name": "LearnAstro",
+            "Content": "Multi-chapter Markdown in chapters/",
+            "Diagrams": "Mermaid",
+            "Output format": "CLAUDE.md (inline model)",
+        },
+        "required": [
+            "1. Project", "Commands",
+            "Astro",
+            "chapters/",
+            "Exercises", "Quiz",
+            "feat:",
+        ],
+        "forbidden": ["[your project]", "[owner]", "[repo]"],
+    },
 ]
 
 # -------------------------------------------------------------------------

--- a/tests/specs/SAIT-E2E-STK-21-001A.md
+++ b/tests/specs/SAIT-E2E-STK-21-001A.md
@@ -1,0 +1,73 @@
+---
+id: SAIT-E2E-STK-21-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567824
+title: Full interview produces a correct CLAUDE.md for a NestJS project
+product: sait
+type: e2e
+area: STK
+priority: p1
+status: ready
+environment: [local]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [e2e, output, nestjs, nodejs]
+---
+
+## Short description
+
+> **Given** `INTERVIEW.md` and `stack/node-nestjs.md` are attached to an agent
+> **When** the agent conducts the interview with a defined set of answers
+> **Then** the agent produces a `CLAUDE.md` containing NestJS-specific rules
+> alongside base and backend layer rules
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Output contains NestJS-specific rules (modules/providers, class-validator, Jest + Supertest); base and backend rules present |
+| FAILED | NestJS-specific rules absent; output indistinguishable from a generic Node backend |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-TPL-01-001A` is failing |
+| ERROR | Agent fails to load template files or produce output |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code available
+
+### Setup
+
+1. Open Claude Code
+2. Attach `INTERVIEW.md`, `stack/node-nestjs.md`, `base/core/agents.md`
+3. Interview answers:
+   - Project name: PaymentsAPI
+   - Language: TypeScript
+   - HTTP adapter: Express
+   - ORM: Prisma
+   - Auth: JWT
+   - Output: CLAUDE.md (inline model)
+
+### Execution
+
+1. Ask the agent to run the interview and generate `CLAUDE.md`
+2. Provide the prepared answers
+
+### Assertions
+
+1. Assert `## Stack` lists NestJS, TypeScript, class-validator
+2. Assert validation rules reference class-validator / class-transformer
+3. Assert Jest referenced in the testing section
+4. Assert canonical sections present (Project structure, Commands)
+5. Assert base git conventions present (`feat:`)
+
+### Teardown
+
+1. Delete generated `CLAUDE.md`
+
+## Related
+
+- Related procedures: `SAIT-E2E-STK-04-001A`

--- a/tests/specs/SAIT-E2E-STK-22-001A.md
+++ b/tests/specs/SAIT-E2E-STK-22-001A.md
@@ -1,0 +1,72 @@
+---
+id: SAIT-E2E-STK-22-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567825
+title: Full interview produces a correct CLAUDE.md for a C embedded project
+product: sait
+type: e2e
+area: STK
+priority: p1
+status: ready
+environment: [local]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [e2e, output, c, embedded]
+---
+
+## Short description
+
+> **Given** `INTERVIEW.md` and `stack/c-embedded.md` are attached to an agent
+> **When** the agent conducts the interview with a defined set of answers
+> **Then** the agent produces a `CLAUDE.md` containing C/embedded-specific
+> rules alongside base layer rules
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Output contains embedded-specific rules (C17, CMake firmware/host targets, Unity host tests, cppcheck); base rules present |
+| FAILED | Embedded-specific rules absent; output indistinguishable from a generic C project |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-TPL-01-001A` is failing |
+| ERROR | Agent fails to load template files or produce output |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code available
+
+### Setup
+
+1. Open Claude Code
+2. Attach `INTERVIEW.md`, `stack/c-embedded.md`, `base/core/agents.md`
+3. Interview answers:
+   - Project name: SensorFirmware
+   - Target: STM32 (ARM Cortex-M4)
+   - Toolchain: arm-none-eabi-gcc
+   - Test runner: Unity (host build)
+   - Output: CLAUDE.md (inline model)
+
+### Execution
+
+1. Ask the agent to run the interview and generate `CLAUDE.md`
+2. Provide the prepared answers
+
+### Assertions
+
+1. Assert `## Stack` lists C17, CMake, Unity, cppcheck
+2. Assert a `## C conventions` section is present
+3. Assert firmware/host build separation referenced (cross-compile vs host)
+4. Assert canonical sections present (Project structure, Commands)
+5. Assert base git conventions present (`feat:`)
+
+### Teardown
+
+1. Delete generated `CLAUDE.md`
+
+## Related
+
+- Related procedures: `SAIT-E2E-STK-15-001A`

--- a/tests/specs/SAIT-E2E-STK-23-001A.md
+++ b/tests/specs/SAIT-E2E-STK-23-001A.md
@@ -1,0 +1,73 @@
+---
+id: SAIT-E2E-STK-23-001A
+uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567826
+title: Full interview produces a correct CLAUDE.md for a tutorial site project
+product: sait
+type: e2e
+area: STK
+priority: p1
+status: ready
+environment: [local]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [e2e, output, astro, tutorial]
+---
+
+## Short description
+
+> **Given** `INTERVIEW.md` and `stack/static-site-tutorial.md` are attached
+> to an agent
+> **When** the agent conducts the interview with a defined set of answers
+> **Then** the agent produces a `CLAUDE.md` containing tutorial-site rules
+> (chapter content layer) on top of the Astro static-site rules
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Output contains tutorial-specific rules (chapters/ content layer, chapter structure with Exercises/Quiz) on top of Astro static-site rules |
+| FAILED | Tutorial-specific rules absent; output indistinguishable from a plain Astro static site |
+| SKIPPED | No agent available |
+| BLOCKED | `SAIT-INT-TPL-01-001A` is failing |
+| ERROR | Agent fails to load template files or produce output |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Claude Code available
+
+### Setup
+
+1. Open Claude Code
+2. Attach `INTERVIEW.md`, `stack/static-site-tutorial.md`,
+   `base/core/agents.md`
+3. Interview answers:
+   - Project name: LearnAstro
+   - Content: Multi-chapter Markdown in chapters/
+   - Diagrams: Mermaid
+   - Output: CLAUDE.md (inline model)
+
+### Execution
+
+1. Ask the agent to run the interview and generate `CLAUDE.md`
+2. Provide the prepared answers
+
+### Assertions
+
+1. Assert Astro static-site rules are present (inherited from the chain)
+2. Assert the `chapters/` content layer is described
+3. Assert the chapter structure references Exercises and Quiz
+4. Assert canonical Commands section present
+5. Assert base git conventions present (`feat:`)
+
+### Teardown
+
+1. Delete generated `CLAUDE.md`
+
+## Related
+
+- Related procedures: `SAIT-E2E-STK-07-001A`


### PR DESCRIPTION
## Problem

14 of 17 stacks had an `STK-*` e2e case. Uncovered: `node-nestjs`,
`c-embedded`, `static-site-tutorial` — and `node-nestjs` is a non-trivial
framework stack with no functional e2e at all.

## Change

Added three cases to `tests/cases.py`:
- **STK-21** — node-nestjs (NestJS, class-validator, Jest)
- **STK-22** — c-embedded (C17, CMake firmware/host, Unity, cppcheck)
- **STK-23** — static-site-tutorial (chapters/ content layer, Exercises/Quiz)

Each with realistic interview answers and required-string assertions
**verified present in the resolved chain**, plus spec files
(`SAIT-E2E-STK-21/22/23-001A`), INDEX rows, and CODIFICATION STK registry
entries (21–23; retired numbers not reused). Live e2e remains
API-gated/manual.

## Verification

- `cases.py` imports cleanly; STK 14→17, ALL 21→24 ✓
- `py tests/run_smoke.py E2E-01` passes (all paths/fields resolve) ✓
- `py tests/run_e2e.py STK-21 STK-22 STK-23 --dry-run` assembles valid
  prompts for all three (86k–163k chars) ✓
- `py tests/run_smoke.py` → 22/22 ✓

Closes #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)