### PR TITLE
feat(tests): gate example existence for showcased stacks (#662)

### DIFF
--- a/tests/CODIFICATION.md
+++ b/tests/CODIFICATION.md
@@ -72,6 +72,7 @@ reused for a different component within the same area.
 | `05` | Generation fidelity — end-of-session audit inlined verbatim or hard-delegated, never paraphrased |
 | `06` | Stack structure — every usable stack's resolved chain carries the ADR-017 MUST sections |
 | `07` | Audit storage — 360 audit reports live only under docs/audits/ with dated names |
+| `08` | Example coverage — every showcased stack keeps its example CLAUDE.md |
 
 ### TPL - Template
 

--- a/tests/INDEX.md
+++ b/tests/INDEX.md
@@ -16,6 +16,7 @@ Spec files live in `tests/specs/`. See `CODIFICATION.md` for the ID scheme, area
 | `SAIT-SMK-SYS-05-001A` | SMK | P1 | End-of-session audit is inlined verbatim or hard-delegated, never paraphrased |
 | `SAIT-SMK-SYS-06-001A` | SMK | P1 | Every usable stack's resolved chain carries the MUST sections |
 | `SAIT-SMK-SYS-07-001A` | SMK | P2 | 360 audit reports live only under docs/audits/ |
+| `SAIT-SMK-SYS-08-001A` | SMK | P2 | Every showcased stack keeps its example CLAUDE.md |
 | `SAIT-SMK-TPL-04-001A` | SMK | P1 | All EXTEND and OVERRIDE directives reference existing IDs |
 | `SAIT-INT-TPL-01-001A` | INT | P0 | DEPENDS ON chain assembles a complete rule set |
 | `SAIT-INT-TPL-02-001A` | INT | P1 | EXTEND adds rules without removing base rules |

--- a/tests/run_smoke.py
+++ b/tests/run_smoke.py
@@ -1216,6 +1216,53 @@ def check_sys_07():
 
 
 # ---------------------------------------------------------------------------
+# SYS-08 — every showcased stack keeps its example CLAUDE.md
+# ---------------------------------------------------------------------------
+# SYS-05 only validates examples that already exist, so a committed example
+# could be removed or renamed without any structural failure. This gate
+# locks in the example->stack mapping (per ADR-016 examples are
+# agent-generated, regenerated on material change): each required example
+# MUST have a non-empty CLAUDE.md, and the stack it demonstrates MUST exist
+# in the manifest. Adding a new example registers it here; two examples may
+# map to the same stack (e.g. astro-portfolio and hybrid-astro).
+
+REQUIRED_EXAMPLES = {
+    "astro-portfolio": "stack-astro",
+    "hybrid-astro": "stack-astro",
+    "fastapi-service": "stack-fastapi",
+    "order-service": "stack-fastapi",
+    "flask-api": "stack-flask",
+    "go-service": "stack-go-service",
+    "metricshub": "stack-go-echo",
+}
+
+
+def check_sys_08():
+    if not HAS_YAML:
+        return ["  PyYAML not installed — run: pip install pyyaml"]
+
+    _, entries, _ = _load_manifest()
+    failures = []
+
+    for example, stack_id in sorted(REQUIRED_EXAMPLES.items()):
+        cm = os.path.join(ROOT, "examples", example, "CLAUDE.md")
+        if not os.path.isfile(cm):
+            failures.append(
+                f"  examples/{example}/CLAUDE.md missing — required "
+                f"example for stack '{stack_id}' (ADR-016: regenerate, "
+                f"do not delete)"
+            )
+        elif os.path.getsize(cm) == 0:
+            failures.append(f"  examples/{example}/CLAUDE.md is empty")
+        if stack_id not in entries:
+            failures.append(
+                f"  {example}: mapped stack '{stack_id}' not in manifest"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Test registry
 # ---------------------------------------------------------------------------
 
@@ -1256,6 +1303,8 @@ CHECKS = [
      "title": "Every usable stack's chain carries the MUST sections", "fn": check_sys_06},
     {"id": "SYS-07", "spec": "SAIT-SMK-SYS-07-001A",
      "title": "360 audit reports live only under docs/audits/", "fn": check_sys_07},
+    {"id": "SYS-08", "spec": "SAIT-SMK-SYS-08-001A",
+     "title": "Every showcased stack keeps its example CLAUDE.md", "fn": check_sys_08},
     {"id": "TPL-08", "spec": "SAIT-SMK-TPL-08-001A",
      "title": "Every base template has at least one [ID:] tag", "fn": check_tpl_08},
     {"id": "TPL-09", "spec": "SAIT-SMK-TPL-09-001A",

--- a/tests/specs/SAIT-SMK-SYS-08-001A.md
+++ b/tests/specs/SAIT-SMK-SYS-08-001A.md
@@ -1,0 +1,68 @@
+---
+id: SAIT-SMK-SYS-08-001A
+title: Every showcased stack keeps its example CLAUDE.md
+product: sait
+type: smoke
+area: SYS
+priority: p2
+status: ready
+environment: [local, ci]
+automatable: yes
+created: 2026-06-26
+author: Branimir Georgiev
+product-version: "2.x"
+tags: [examples, adr-016, convention]
+---
+
+## Short description
+
+> **Given** the committed example->stack mapping (`REQUIRED_EXAMPLES`)
+> **When** each required example directory is checked
+> **Then** every example has a non-empty `CLAUDE.md` and the stack it
+> demonstrates exists in the manifest — a showcased example cannot be
+> silently removed, emptied, or pointed at a deleted stack
+
+## Results
+
+| Result | Condition |
+|--------|-----------|
+| PASSED | Every required example has a non-empty CLAUDE.md and maps to a stack present in the manifest |
+| FAILED | A required example's CLAUDE.md is missing or empty, or its mapped stack is not in the manifest |
+| SKIPPED | PyYAML is not installed |
+| BLOCKED | — |
+| ERROR | File system is inaccessible |
+
+## Steps
+
+### Prerequisites
+
+- Repository cloned locally
+- Python 3 with PyYAML installed
+
+### Setup
+
+1. Change to the repository root
+
+### Execution
+
+1. Load `manifest.yaml` and collect the declared stack IDs
+2. For each `REQUIRED_EXAMPLES` entry (example directory -> stack ID),
+   resolve `examples/<dir>/CLAUDE.md`
+3. Record missing/empty files and mapped stacks absent from the manifest
+
+### Assertions
+
+1. Assert every required `examples/<dir>/CLAUDE.md` exists and is non-empty
+2. Assert every mapped stack ID is present in the manifest
+
+### Teardown
+
+— (read-only check, no teardown required)
+
+## Related
+
+- ADR-016 — examples are agent-generated, regenerated on material change
+  (the rule this check guards)
+- `SAIT-SMK-SYS-05-001A` — validates the audit rendering of examples
+  that exist; this check guards their existence
+- `quality-gates-pair-check` — pair-the-check convention


### PR DESCRIPTION
## Problem

No smoke check asserts that a showcased stack keeps its
`examples/*/CLAUDE.md`. SYS-05 only validates examples that already
exist, so one could be removed, emptied, or pointed at a deleted stack
without a structural failure. 7 examples exist for 17 stacks.

## Change

Added smoke check **SYS-08** (`SAIT-SMK-SYS-08-001A`). A
`REQUIRED_EXAMPLES` map locks in the 7 committed example→stack pairs
(per the decision to lock in the existing set, not require every concrete
stack). Two examples map to `stack-astro` and two to `stack-fastapi`, so
the gate is keyed by example dir. Each required example MUST have a
non-empty `CLAUDE.md`, and its mapped stack MUST exist in the manifest.

Per ADR-016, the fix on failure is to **regenerate** the example, not
delete it. A new example registers itself by adding a line to
`REQUIRED_EXAMPLES`.

## Verification

- SYS-08 **fails** when an example is removed (verified by temp-rename)
  and passes when present ✓
- `py tests/run_smoke.py` → 23/23 ✓
- Spec registered in INDEX; SYS-08 component group added to CODIFICATION;
  INDEX fully reconciled (no phantom rows, none missing) ✓

Closes #662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)