### PR TITLE
fix(templates): dedup quality.md rules owned by base-testing (#683)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -169,14 +169,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -397,10 +389,7 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention
 
 
 <!-- templates/base/core/git.md -->

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -163,14 +163,6 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
-## Testability
-
-- Testability is a first-class design concern, not an afterthought
-- Code MUST be designed for testability from the start — do not write
-  code first and struggle to test later
-- If code is hard to test, treat it as a design problem, not a
-  testing problem
-
 ## Calibration discipline
 
 [ID: quality-calibration]
@@ -391,7 +383,4 @@ maintainer time on phantom fixes.
 
 ## Testing
 
-- Write tests for business logic and edge cases
-- Do not test implementation details — test behaviour
 - Tests must pass before merging to `main`
-- Tests MUST be runnable from CI without human intervention


### PR DESCRIPTION
## What

`base-quality` restated testability/testing rules already owned by
`base-testing`. Both are core-tier, so **every one of the 17 resolved
chains** loaded the duplicate. Found via a redundancy audit across the
resolved chains (the content-overlap check `template-content-quality.md`
notes smoke does not perform).

## Change

Trim `templates/base/core/quality.md`: remove the `## Testability`
section and the duplicated bullets in `## Testing`. Every removed rule
still resolves through `base-testing` (always co-loaded):

| Removed from quality.md | Survives at |
|---|---|
| Testability: "first-class design concern" | testing.md:152 |
| Testability: "designed for testability from the start" | testing.md:202 |
| Testability: "hard to test → design problem" | testing.md:204 |
| Testing: "test behaviour, not implementation" | testing.md:206 |
| Testing: "business logic and edge cases" | testing.md:31,33 |
| Testing: "runnable from CI" | testing.md:39 |

Kept `Tests must pass before merging to main` (no verbatim owner
elsewhere). Regenerated the 17 pre-resolved chains (`sync.py`).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync
- Net: 198 deletions, 0 additions

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)
