### PR TITLE
fix(templates): dedup migration rule restated by python framework stacks (#685)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4074,7 +4074,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `*.pyc`, `__pycache__/`, `.mypy_cache/`, `db.sqlite3`
-- Migrations are committed — never regenerate a migration already merged
 - `staticfiles/` is gitignored — collect on deploy, not in the repo
 
 ---

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3974,7 +3974,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`
-- Alembic migrations are committed — never regenerate a migration already merged
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3859,7 +3859,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `instance/`, `*.db`, `__pycache__/`, `.mypy_cache/`
-- Migrations are committed — never regenerate a migration that is already merged
 
 ---
 

--- a/templates/stack/python-django.md
+++ b/templates/stack/python-django.md
@@ -156,7 +156,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `*.pyc`, `__pycache__/`, `.mypy_cache/`, `db.sqlite3`
-- Migrations are committed — never regenerate a migration already merged
 - `staticfiles/` is gitignored — collect on deploy, not in the repo
 
 ---

--- a/templates/stack/python-fastapi.md
+++ b/templates/stack/python-fastapi.md
@@ -168,7 +168,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `*.db`, `__pycache__/`, `.mypy_cache/`
-- Alembic migrations are committed — never regenerate a migration already merged
 
 ---
 

--- a/templates/stack/python-flask.md
+++ b/templates/stack/python-flask.md
@@ -137,7 +137,6 @@ CLAUDE.md
 [EXTEND: base-git]
 
 - Do not commit `.env`, `instance/`, `*.db`, `__pycache__/`, `.mypy_cache/`
-- Migrations are committed — never regenerate a migration that is already merged
 
 ---
 


### PR DESCRIPTION
## What

`python-flask`, `python-fastapi`, and `python-django` each restated the
migration-commit rule in their own `## Git conventions` section. All
three `DEPEND ON python-service`, whose `python-service-git` section
(always in the resolved chain) already owns the rule — so it appeared
**twice** in each resolved chain.

Found via a redundancy audit across the 17 resolved chains (the
content-overlap check `template-content-quality.md` notes smoke does
not perform).

## Change

Remove the duplicated line from the three children:

| File | Removed |
|---|---|
| `stack/python-flask.md` | "Migrations are committed — never regenerate a migration that is already merged" |
| `stack/python-fastapi.md` | "Alembic migrations are committed — never regenerate a migration already merged" |
| `stack/python-django.md` | "Migrations are committed — never regenerate a migration already merged" |

Each rule still resolves **once** per chain via `python-service`
(verified: 1 occurrence in each regenerated chain). Regenerated the
three affected chains.

Note: only the migration rule was a genuine fix. The other redundancy
findings are by-design (`[OVERRIDE]` Stack sections), needed for
standalone use (`go-lib`), or deferred to #624 (frontend SEO).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync
- Net: 6 deletions, 0 additions

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
