### PR TITLE
feat(tools): add redundancy audit for resolved chains (#687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ templates/          # All template source files
 docs/               # Onboarding, playbook, decision logs, SPEC.md
 examples/           # Complete generated context files (reference)
 tests/              # Smoke and e2e test runners, specs, reports
-tools/              # sync.py, resolve.py — sync and resolution scripts
+tools/              # sync.py, resolve.py, audit_redundancy.py
 generated/          # Pre-resolved template chains (one file per stack)
 ```
 
@@ -49,6 +49,10 @@ py tools/resolve.py --list                    # list stack IDs
 py tools/resolve.py <stack-id>               # print resolved file list
 py tools/resolve.py <stack-id> --concat      # print concatenated content
 py tools/resolve.py --generate               # regenerate all cached files
+
+# Audit redundant rules across resolved chains
+py tools/audit_redundancy.py                 # exact in-chain duplicates
+py tools/audit_redundancy.py --near          # include near-duplicates
 
 # To generate a context file for a project:
 # 1. Open your agent

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -211,6 +211,32 @@ If the agent cannot run scripts, use the pre-resolved files in
 
 ---
 
+## Audit redundancy
+
+A rule stated in two active sections of the same resolved chain dilutes
+the agent's attention (see `docs/meta/template-content-quality.md`). The
+audit scans every chain and reports duplicates, excluding those the
+override model legitimately produces (one section `[OVERRIDE]`s the
+other):
+
+```bash
+py tools/audit_redundancy.py           # exact in-chain duplicates
+py tools/audit_redundancy.py --near    # also paraphrase near-duplicates
+py tools/audit_redundancy.py --check   # exit 1 if any exact duplicate
+```
+
+Run it before opening a template PR and when consolidating rules. A
+finding is not automatically a defect — a duplicate may be intentional
+(e.g. a rule a base template needs when used standalone). Judge each
+against the single-source principle, then either trim the restatement
+(prefer the parent/owner template) or accept it with a reason.
+
+`--check` is not yet wired into CI: the library still carries known
+duplicates queued behind their owning issues. Once those clear, the
+gate can ratchet the count to zero.
+
+---
+
 ## Run the test suite
 
 ```bash

--- a/tools/audit_redundancy.py
+++ b/tools/audit_redundancy.py
@@ -1,0 +1,286 @@
+"""Audit redundant rules across resolved template chains.
+
+Reports rule lines that appear in two or more active sections within a
+single resolved stack chain. Duplicates that the override model
+legitimately produces are excluded: when one section supersedes another
+via `[OVERRIDE: id]` (directly or transitively), a shared rule between
+them is the replacement working as designed, not redundancy.
+
+A sibling duplicate IS reported: two sections that both `[EXTEND: x]`
+the same parent, or two unrelated sections, that state the same rule —
+the agent loads it twice with neither marked as authoritative.
+
+Limitations: fingerprints the first line of each bullet, so a rule whose
+wording diverges only after a line wrap may slip past exact matching;
+use `--near` for paraphrases. Judgment still required — a duplicate is
+not always wrong (see docs/meta/template-content-quality.md).
+
+Usage:
+    py tools/audit_redundancy.py            # exact in-chain duplicates
+    py tools/audit_redundancy.py --near     # also show near-duplicates
+    py tools/audit_redundancy.py --check    # exit 1 if any exact dup found
+"""
+
+import io
+import re
+import sys
+from difflib import SequenceMatcher
+
+from resolve import load_manifest, resolve_chain, read_file
+
+# Ensure UTF-8 stdout on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(
+        sys.stdout.buffer, encoding="utf-8", errors="replace"
+    )
+
+HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+TAG = re.compile(r"^\[(ID|OVERRIDE|EXTEND):\s*([^\]]+)\]\s*$")
+BULLET = re.compile(r"^\s*(?:[-*]|\d+\.)\s+(.*)$")
+MIN_LEN = 30
+NEAR_THRESHOLD = 0.87
+
+
+def normalize(text):
+    """Reduce a rule line to a comparable fingerprint."""
+    t = re.sub(r"`[^`]*`", " ", text)
+    t = re.sub(r"\*\*([^*]*)\*\*", r"\1", t)
+    t = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", t)
+    t = re.sub(r"[^a-z0-9 ]", " ", t.lower())
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def parse_sections(rel_path):
+    """Split a template file into sections with their tags and rules.
+
+    Returns a list of dicts: {file, heading, ids, overrides, rules}
+    where rules is {fingerprint: original_line}.
+    """
+    sections = []
+    current = None
+    in_fence = False
+
+    for raw in read_file(rel_path).splitlines():
+        if raw.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        m = HEADING.match(raw)
+        if m:
+            current = {
+                "file": rel_path,
+                "heading": m.group(2).strip(),
+                "ids": [],
+                "overrides": [],
+                "rules": {},
+            }
+            sections.append(current)
+            continue
+
+        if current is None:
+            continue
+
+        m = TAG.match(raw.strip())
+        if m:
+            kind, value = m.group(1), m.group(2).strip()
+            if kind == "ID":
+                current["ids"].append(value)
+            elif kind == "OVERRIDE":
+                current["overrides"].append(value)
+            continue
+
+        if "|" in raw:  # skip table rows
+            continue
+        m = BULLET.match(raw)
+        if m:
+            fp = normalize(m.group(1))
+            if len(fp) >= MIN_LEN:
+                current["rules"].setdefault(fp, m.group(1).strip())
+
+    return sections
+
+
+def chain_sections(stack_id, core_ids, entries):
+    """All sections across a stack's resolved chain, plus a supersedes
+    relation derived from [OVERRIDE] tags (transitive closure)."""
+    files = resolve_chain(stack_id, core_ids, entries)
+    sections = []
+    for f in files:
+        sections.extend(parse_sections(f))
+
+    id_to_idx = {}
+    for i, s in enumerate(sections):
+        for sid in s["ids"]:
+            id_to_idx[sid] = i
+
+    # direct: idx -> set of section indices it overrides
+    direct = {i: set() for i in range(len(sections))}
+    for i, s in enumerate(sections):
+        for target in s["overrides"]:
+            if target in id_to_idx:
+                direct[i].add(id_to_idx[target])
+
+    # transitive closure
+    supersedes = {i: set() for i in range(len(sections))}
+    for i in range(len(sections)):
+        stack = list(direct[i])
+        while stack:
+            j = stack.pop()
+            if j not in supersedes[i]:
+                supersedes[i].add(j)
+                stack.extend(direct[j])
+
+    return sections, supersedes
+
+
+def related(a, b, supersedes):
+    """True if section a and b are in an override relationship."""
+    return b in supersedes[a] or a in supersedes[b]
+
+
+def find_exact(sections, supersedes):
+    """Yield (fingerprint, original, idx_a, idx_b) for exact in-chain
+    duplicates across non-override section pairs."""
+    by_fp = {}
+    for i, s in enumerate(sections):
+        for fp, original in s["rules"].items():
+            by_fp.setdefault(fp, []).append((i, original))
+    for fp, hits in by_fp.items():
+        for a in range(len(hits)):
+            for b in range(a + 1, len(hits)):
+                ia, original = hits[a]
+                ib, _ = hits[b]
+                if sections[ia]["file"] == sections[ib]["file"]:
+                    continue
+                if related(ia, ib, supersedes):
+                    continue
+                yield fp, original, ia, ib
+
+
+def find_near(sections, supersedes):
+    """Yield (ratio, fp_a, fp_b, idx_a, idx_b) for near-duplicate rules
+    across non-override section pairs in different files. Candidate pairs
+    are prefiltered to those sharing a token of length >= 6, keeping the
+    comparison count tractable on large chains."""
+    rules = []  # (fp, idx)
+    for i, s in enumerate(sections):
+        for fp in s["rules"]:
+            rules.append((fp, i))
+
+    token_index = {}
+    for idx, (fp, _) in enumerate(rules):
+        for tok in set(t for t in fp.split() if len(t) >= 6):
+            token_index.setdefault(tok, []).append(idx)
+
+    candidates = set()
+    for hits in token_index.values():
+        if len(hits) > 80:  # skip ubiquitous tokens
+            continue
+        for a in range(len(hits)):
+            for b in range(a + 1, len(hits)):
+                candidates.add((hits[a], hits[b]))
+
+    seen = set()
+    for ra, rb in candidates:
+        fa, ia = rules[ra]
+        fb, ib = rules[rb]
+        if ia == ib or fa == fb:
+            continue
+        if sections[ia]["file"] == sections[ib]["file"]:
+            continue
+        if abs(len(fa) - len(fb)) > 30 or related(ia, ib, supersedes):
+            continue
+        key = tuple(sorted([fa, fb]))
+        if key in seen:
+            continue
+        ratio = SequenceMatcher(None, fa, fb).ratio()
+        if ratio >= NEAR_THRESHOLD:
+            seen.add(key)
+            yield ratio, fa, fb, ia, ib
+
+
+def collect(core_ids, entries, stacks, want_near=False):
+    """Run exact (and optionally near) detection over every stack,
+    aggregating each unique finding to the set of chains it affects."""
+    exact = {}  # key -> {"original", "sites", "chains"}
+    near = {}
+    for stack in stacks:
+        sid = stack["id"]
+        sections, supersedes = chain_sections(sid, core_ids, entries)
+
+        for fp, original, ia, ib in find_exact(sections, supersedes):
+            sites = tuple(sorted([
+                f"{sections[ia]['file']} §{sections[ia]['heading']}",
+                f"{sections[ib]['file']} §{sections[ib]['heading']}",
+            ]))
+            key = (fp, sites)
+            rec = exact.setdefault(
+                key, {"original": original, "sites": sites, "chains": set()}
+            )
+            rec["chains"].add(sid)
+
+        if not want_near:
+            continue
+        for ratio, fa, fb, ia, ib in find_near(sections, supersedes):
+            sites = tuple(sorted([
+                f"{sections[ia]['file']} §{sections[ia]['heading']}",
+                f"{sections[ib]['file']} §{sections[ib]['heading']}",
+            ]))
+            key = tuple(sorted([fa, fb])) + (sites,)
+            rec = near.setdefault(
+                key,
+                {"ratio": ratio, "a": fa, "b": fb, "sites": sites,
+                 "chains": set()},
+            )
+            rec["chains"].add(sid)
+    return exact, near
+
+
+def main():
+    args = sys.argv[1:]
+    if "--help" in args:
+        print(__doc__)
+        sys.exit(0)
+
+    core_ids, entries, stacks = load_manifest()
+    exact, near = collect(core_ids, entries, stacks, want_near="--near" in args)
+
+    print("=" * 70)
+    print("EXACT in-chain rule duplicates")
+    print("(override-superseded pairs excluded)")
+    print("=" * 70)
+    for rec in sorted(exact.values(), key=lambda r: -len(r["chains"])):
+        chains = sorted(rec["chains"])
+        print(f"\n* {len(chains)} chain(s): {', '.join(chains)}")
+        for site in rec["sites"]:
+            print(f"    {site}")
+        print(f"    rule: {rec['original'][:84]}")
+    print(f"\n>>> {len(exact)} exact in-chain duplicate(s)")
+
+    if "--near" in args:
+        print("\n" + "=" * 70)
+        print(f"NEAR in-chain duplicates (>= {NEAR_THRESHOLD})")
+        print("=" * 70)
+        for rec in sorted(near.values(),
+                          key=lambda r: (-len(r["chains"]), -r["ratio"])):
+            chains = sorted(rec["chains"])
+            print(f"\n~{rec['ratio']:.2f} | {len(chains)} chain(s): "
+                  f"{', '.join(chains)}")
+            for site in rec["sites"]:
+                print(f"    {site}")
+            print(f"    A: {rec['a'][:80]}")
+            print(f"    B: {rec['b'][:80]}")
+        print(f"\n>>> {len(near)} near in-chain duplicate(s)")
+
+    if "--check" in args:
+        if exact:
+            print(f"\nFAIL: {len(exact)} exact in-chain duplicate(s) found.")
+            sys.exit(1)
+        print("\nOK: no exact in-chain duplicates.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Redundancy across resolved chains is the project's main quality lever
(`docs/meta/template-content-quality.md`), but smoke does not detect
content overlap — the doc itself flags this gap. The two recent dedup
PRs (#684, #686) were found with a throwaway probe; this productionizes
it as a first-class tool.

## Tool

`tools/audit_redundancy.py` reuses `resolve.py`'s chain resolution, then:

- parses each resolved chain into sections with their `[ID]`/`[OVERRIDE]`
  tags and builds a transitive supersedes graph;
- reports rule lines duplicated across two **active** sections in the
  same chain;
- **excludes** duplicates the override model legitimately produces (one
  section `[OVERRIDE]`s the other) — the false positives a naive
  raw-file scan produces, e.g. the Go Stack sections;
- `--near` adds paraphrase detection (token-prefiltered); `--check`
  exits 1 for future CI gating.

```bash
py tools/audit_redundancy.py           # exact in-chain duplicates
py tools/audit_redundancy.py --near    # also paraphrase near-duplicates
py tools/audit_redundancy.py --check   # exit 1 if any exact duplicate
```

## Current findings (audit-only)

Against the live library it surfaces 6 exact + 3 near in-chain dups, all
legitimate follow-ups: `go-lib` standalone logging, frontend SEO (→
#624), the `python-service-stack` Distribution leak, docs/readme present
tense. The Go Stack dups a raw scan flags are correctly excluded.

`--check` is **not** wired into CI yet: those known dups would fail it.
It stays audit-only until they clear (the phase-2 ratchet).

## Docs

- PLAYBOOK: new "Audit redundancy" section under validation.
- CLAUDE.md §1.3: added the commands to the catalogue.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
