### PR TITLE
fix(templates): clear in-chain dups via python override + go-lib (#689)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3596,6 +3596,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Stack
 [ID: python-service-stack]
+[OVERRIDE: python-lib-stack]
 
 - Language: Python 3.11+
 - Framework: [Flask / FastAPI / Django]
@@ -3927,6 +3928,7 @@ and deployment.
 
 ## Stack
 [ID: django-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: Django 4.2 LTS / 5.x

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3596,6 +3596,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Stack
 [ID: python-service-stack]
+[OVERRIDE: python-lib-stack]
 
 - Language: Python 3.11+
 - Framework: [Flask / FastAPI / Django]
@@ -3814,7 +3815,7 @@ deployment.
 ---
 
 ## Stack
-[OVERRIDE: python-lib-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: FastAPI

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3596,6 +3596,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Stack
 [ID: python-service-stack]
+[OVERRIDE: python-lib-stack]
 
 - Language: Python 3.11+
 - Framework: [Flask / FastAPI / Django]
@@ -3730,7 +3731,7 @@ extensions, and deployment.
 ---
 
 ## Stack
-[OVERRIDE: python-lib-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: Flask

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2031,7 +2031,6 @@ no HTTP layer.
 - Use `errors.Is()` and `errors.As()` for inspection — never string matching
 - Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
   that owns the concept
-- Log errors once — at the top of the call stack, not at every level
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2031,7 +2031,6 @@ no HTTP layer.
 - Use `errors.Is()` and `errors.As()` for inspection — never string matching
 - Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
   that owns the concept
-- Log errors once — at the top of the call stack, not at every level
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2031,7 +2031,6 @@ no HTTP layer.
 - Use `errors.Is()` and `errors.As()` for inspection — never string matching
 - Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
   that owns the concept
-- Log errors once — at the top of the call stack, not at every level
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2031,7 +2031,6 @@ no HTTP layer.
 - Use `errors.Is()` and `errors.As()` for inspection — never string matching
 - Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
   that owns the concept
-- Log errors once — at the top of the call stack, not at every level
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3596,6 +3596,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Stack
 [ID: python-service-stack]
+[OVERRIDE: python-lib-stack]
 
 - Language: Python 3.11+
 - Framework: [Flask / FastAPI / Django]

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -39,7 +39,6 @@ no HTTP layer.
 - Use `errors.Is()` and `errors.As()` for inspection — never string matching
 - Define sentinel errors (`var ErrNotFound = errors.New(...)`) in the package
   that owns the concept
-- Log errors once — at the top of the call stack, not at every level
 
 ---
 

--- a/templates/stack/python-django.md
+++ b/templates/stack/python-django.md
@@ -9,6 +9,7 @@ and deployment.
 
 ## Stack
 [ID: django-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: Django 4.2 LTS / 5.x

--- a/templates/stack/python-fastapi.md
+++ b/templates/stack/python-fastapi.md
@@ -8,7 +8,7 @@ deployment.
 ---
 
 ## Stack
-[OVERRIDE: python-lib-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: FastAPI

--- a/templates/stack/python-flask.md
+++ b/templates/stack/python-flask.md
@@ -8,7 +8,7 @@ extensions, and deployment.
 ---
 
 ## Stack
-[OVERRIDE: python-lib-stack]
+[OVERRIDE: python-service-stack]
 
 - Language: Python 3.11+
 - Framework: Flask

--- a/templates/stack/python-service.md
+++ b/templates/stack/python-service.md
@@ -9,6 +9,7 @@ Covers conventions that are shared regardless of framework choice.
 
 ## Stack
 [ID: python-service-stack]
+[OVERRIDE: python-lib-stack]
 
 - Language: Python 3.11+
 - Framework: [Flask / FastAPI / Django]


### PR DESCRIPTION
## What

Clears 4 of the 6 known in-chain duplicates surfaced by the redundancy
audit (#687), leaving only the 2 frontend dups (queued on #624).

## Changes

**1. python-service-stack override-graph fix (clears 3).** The framework
Stack sections `[OVERRIDE: python-lib-stack]`, skipping the closer
`python-service-stack`, so the abstract service Stack leaked into every
framework chain unsuperseded — duplicating `Distribution:` and other
lines. Corrected the graph:

- `python-service` Stack: add `[OVERRIDE: python-lib-stack]`
- `python-flask` / `python-fastapi` Stack: `[OVERRIDE: python-service-stack]`
- `python-django` Stack: add `[OVERRIDE: python-service-stack]`

Now `flask/fastapi/django → python-service → python-lib`, a clean
override chain; the audit excludes the duplicate as a legitimate
override.

**2. go-lib app-logging rule (clears 1).** "Log errors once — at the top
of the call stack" is an application concern, not a library one;
`backend/observability` owns it for services. Removed from `go-lib`.
Verified: standalone `go-lib` drops it (0 occurrences); service chains
(`go-service`, `go-echo`, `grpc-go`) keep it via observability (1 each).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync
- `py tools/audit_redundancy.py` — 6 → **2** exact in-chain dups (both
  frontend)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
