### PR TITLE
feat(ci): gate new redundancy via audit --check with a baseline (#691)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,6 +25,8 @@ jobs:
         run: python tools/sync.py --check
       - name: Check generated/ files are up to date
         run: python tools/resolve.py --check
+      - name: Check for new redundant rules
+        run: python tools/audit_redundancy.py --check
       - name: Install gitleaks
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ py tools/resolve.py --generate               # regenerate all cached files
 # Audit redundant rules across resolved chains
 py tools/audit_redundancy.py                 # exact in-chain duplicates
 py tools/audit_redundancy.py --near          # include near-duplicates
+py tools/audit_redundancy.py --check          # CI gate — fail on new dups
 
 # To generate a context file for a project:
 # 1. Open your agent

--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -231,9 +231,12 @@ finding is not automatically a defect — a duplicate may be intentional
 against the single-source principle, then either trim the restatement
 (prefer the parent/owner template) or accept it with a reason.
 
-`--check` is not yet wired into CI: the library still carries known
-duplicates queued behind their owning issues. Once those clear, the
-gate can ratchet the count to zero.
+`--check` runs in CI as a ratchet: it fails on any exact duplicate not
+in the tool's `BASELINE` allowlist, so new redundancy is blocked while
+the known duplicates clear through their owning issues (currently the
+frontend pair, #624). When you resolve a baselined duplicate, remove
+its `BASELINE` entry in `tools/audit_redundancy.py` — `--check` reports
+any entry that no longer applies.
 
 ---
 

--- a/tools/audit_redundancy.py
+++ b/tools/audit_redundancy.py
@@ -15,10 +15,15 @@ wording diverges only after a line wrap may slip past exact matching;
 use `--near` for paraphrases. Judgment still required — a duplicate is
 not always wrong (see docs/meta/template-content-quality.md).
 
+`--check` is a CI ratchet: it fails only on exact duplicates NOT in the
+BASELINE below, so new redundancy is blocked while known dups are worked
+off through their owning issues. Remove a BASELINE entry once its dup is
+resolved; `--check` reports any baseline entry that no longer applies.
+
 Usage:
     py tools/audit_redundancy.py            # exact in-chain duplicates
     py tools/audit_redundancy.py --near     # also show near-duplicates
-    py tools/audit_redundancy.py --check    # exit 1 if any exact dup found
+    py tools/audit_redundancy.py --check    # exit 1 on NEW exact dups
 """
 
 import io
@@ -39,6 +44,21 @@ TAG = re.compile(r"^\[(ID|OVERRIDE|EXTEND):\s*([^\]]+)\]\s*$")
 BULLET = re.compile(r"^\s*(?:[-*]|\d+\.)\s+(.*)$")
 MIN_LEN = 30
 NEAR_THRESHOLD = 0.87
+
+# Known in-chain exact duplicates accepted for now. `--check` ignores
+# these and fails only on NEW duplicates. Each key is
+# (fingerprint, (fileA, fileB)) with files sorted; the value is the
+# reason / owning issue. Remove an entry once its duplicate is resolved.
+BASELINE = {
+    ("privacy friendly analytics only no consent banner required",
+     ("templates/frontend/quality.md",
+      "templates/frontend/static-site.md")):
+        "frontend SEO consolidation (#624)",
+    ("prettier owns all formatting commit no style debates",
+     ("templates/frontend/static-site.md",
+      "templates/stack/static-site-astro.md")):
+        "frontend SEO consolidation (#624)",
+}
 
 
 def normalize(text):
@@ -211,13 +231,18 @@ def collect(core_ids, entries, stacks, want_near=False):
         sections, supersedes = chain_sections(sid, core_ids, entries)
 
         for fp, original, ia, ib in find_exact(sections, supersedes):
+            files = tuple(sorted(
+                [sections[ia]["file"], sections[ib]["file"]]
+            ))
             sites = tuple(sorted([
                 f"{sections[ia]['file']} §{sections[ia]['heading']}",
                 f"{sections[ib]['file']} §{sections[ib]['heading']}",
             ]))
             key = (fp, sites)
             rec = exact.setdefault(
-                key, {"original": original, "sites": sites, "chains": set()}
+                key,
+                {"original": original, "sites": sites, "fp": fp,
+                 "files": files, "chains": set()},
             )
             rec["chains"].add(sid)
 
@@ -253,11 +278,16 @@ def main():
     print("=" * 70)
     for rec in sorted(exact.values(), key=lambda r: -len(r["chains"])):
         chains = sorted(rec["chains"])
-        print(f"\n* {len(chains)} chain(s): {', '.join(chains)}")
+        reason = BASELINE.get((rec["fp"], rec["files"]))
+        tag = f"  [baselined: {reason}]" if reason else ""
+        print(f"\n* {len(chains)} chain(s): {', '.join(chains)}{tag}")
         for site in rec["sites"]:
             print(f"    {site}")
         print(f"    rule: {rec['original'][:84]}")
-    print(f"\n>>> {len(exact)} exact in-chain duplicate(s)")
+    n_base = sum(1 for r in exact.values()
+                 if (r["fp"], r["files"]) in BASELINE)
+    print(f"\n>>> {len(exact)} exact in-chain duplicate(s) "
+          f"({n_base} baselined)")
 
     if "--near" in args:
         print("\n" + "=" * 70)
@@ -275,10 +305,35 @@ def main():
         print(f"\n>>> {len(near)} near in-chain duplicate(s)")
 
     if "--check" in args:
-        if exact:
-            print(f"\nFAIL: {len(exact)} exact in-chain duplicate(s) found.")
+        present = set()
+        new_dups = []
+        for rec in exact.values():
+            bkey = (rec["fp"], rec["files"])
+            if bkey in BASELINE:
+                present.add(bkey)
+            else:
+                new_dups.append(rec)
+
+        resolved = set(BASELINE) - present
+        if resolved:
+            print("\nBaseline entries no longer present "
+                  "(remove from BASELINE):")
+            for fp, files in sorted(resolved):
+                print(f"  {fp[:56]}  {files}")
+
+        if new_dups:
+            print(f"\nFAIL: {len(new_dups)} new exact in-chain "
+                  f"duplicate(s) beyond the baseline:")
+            for rec in new_dups:
+                print(f"  rule: {rec['original'][:70]}")
+                for site in rec["sites"]:
+                    print(f"      {site}")
+            print("\nFix the duplicate, or add it to BASELINE in "
+                  "tools/audit_redundancy.py with its owning issue.")
             sys.exit(1)
-        print("\nOK: no exact in-chain duplicates.")
+
+        print(f"\nOK: no new exact in-chain duplicates "
+              f"({len(present)} baselined).")
         sys.exit(0)
 
 


### PR DESCRIPTION
## What

Wires `tools/audit_redundancy.py --check` into CI as a redundancy
ratchet — the phase-2 follow-up to the audit tool (#687) once the
clearable dups were removed (#689).

## How

- **BASELINE allowlist** in the tool holds the 2 known frontend
  duplicates (analytics, prettier), each keyed to its owning issue
  (#624). `--check` fails only on exact in-chain duplicates **not** in
  the baseline, so new redundancy is blocked while the known ones clear.
- `--check` also reports any baseline entry that no longer applies, so
  the allowlist shrinks as dups are fixed (and won't silently rot).
- The default report annotates baselined findings (`[baselined: ...]`).
- New CI step in `smoke.yml`: `python tools/audit_redundancy.py --check`.

## Behaviour

- Introduce a new in-chain duplicate -> CI fails with the rule + sites,
  and a hint to fix it or baseline it with its issue.
- Resolve a baselined duplicate -> `--check` flags the stale baseline
  entry to remove.

Verified the failure path fires (empty baseline -> 2 new dups -> exit 1)
and the pass path (current state -> exit 0, 2 baselined).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` / `resolve.py --check` — in sync
- `py tools/audit_redundancy.py --check` — OK, 2 baselined, exit 0

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
