### PR TITLE
fix(templates): clear the two baselined frontend duplicate restatements (#693)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2130,7 +2130,6 @@ to change.
   should I click this?"
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
-- Privacy-friendly analytics only (no consent banner required)
 - `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
   ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
 - Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
@@ -2963,8 +2962,6 @@ files into `src/content/`.
   and Astro content collection types)
 - `eslint-plugin-unicorn` SHOULD be added for rules not covered by sonarjs
   (e.g. `no-zero-fractions`, `prefer-number-properties`)
-- **Prettier** owns all formatting — commit `.prettierrc`; no style debates
-  in code review
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2130,7 +2130,6 @@ to change.
   should I click this?"
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
-- Privacy-friendly analytics only (no consent banner required)
 - `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
   ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
 - Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl
@@ -2963,8 +2962,6 @@ files into `src/content/`.
   and Astro content collection types)
 - `eslint-plugin-unicorn` SHOULD be added for rules not covered by sonarjs
   (e.g. `no-zero-fractions`, `prefer-number-properties`)
-- **Prettier** owns all formatting — commit `.prettierrc`; no style debates
-  in code review
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead

--- a/templates/frontend/static-site.md
+++ b/templates/frontend/static-site.md
@@ -155,7 +155,6 @@ to change.
   should I click this?"
 - JSON-LD structured data SHOULD be present on content pages (Article,
   Course, or appropriate schema type)
-- Privacy-friendly analytics only (no consent banner required)
 - `robots.txt` MUST allow answer-engine crawlers (OAI-SearchBot,
   ChatGPT-User, PerplexityBot, Claude-SearchBot/Claude-User, Applebot)
 - Behind Cloudflare, AI-crawler access MUST be verified in AI Crawl

--- a/templates/stack/static-site-astro.md
+++ b/templates/stack/static-site-astro.md
@@ -227,8 +227,6 @@ files into `src/content/`.
   and Astro content collection types)
 - `eslint-plugin-unicorn` SHOULD be added for rules not covered by sonarjs
   (e.g. `no-zero-fractions`, `prefer-number-properties`)
-- **Prettier** owns all formatting — commit `.prettierrc`; no style debates
-  in code review
 - `.astro` files formatted with the official Prettier Astro plugin
 - MUST NOT use `set:html` — it is Astro's equivalent of `innerHTML` and
   bypasses escaping; use `{expression}` for text content instead

--- a/tools/audit_redundancy.py
+++ b/tools/audit_redundancy.py
@@ -49,16 +49,8 @@ NEAR_THRESHOLD = 0.87
 # these and fails only on NEW duplicates. Each key is
 # (fingerprint, (fileA, fileB)) with files sorted; the value is the
 # reason / owning issue. Remove an entry once its duplicate is resolved.
-BASELINE = {
-    ("privacy friendly analytics only no consent banner required",
-     ("templates/frontend/quality.md",
-      "templates/frontend/static-site.md")):
-        "frontend SEO consolidation (#624)",
-    ("prettier owns all formatting commit no style debates",
-     ("templates/frontend/static-site.md",
-      "templates/stack/static-site-astro.md")):
-        "frontend SEO consolidation (#624)",
-}
+# Currently empty — `--check` enforces a true zero.
+BASELINE = {}
 
 
 def normalize(text):


### PR DESCRIPTION
## What

Clears the two frontend in-chain duplicates that were baselined behind
#624, taking the redundancy `BASELINE` to **empty** so `--check`
enforces a true zero.

## Change

Both are plain inherited restatements, removed from the child that
already inherits them:

- `static-site.md §SEO` dropped "Privacy-friendly analytics only" —
  inherited via `[EXTEND: frontend-quality]`.
- `static-site-astro.md §Code conventions` dropped "Prettier owns all
  formatting" — inherited from `static-site-code` (and not actually SEO).

Verified each rule still resolves **once** per chain (astro, tutorial)
via its owner. Emptied `BASELINE` in `tools/audit_redundancy.py`.

This is orthogonal to where the canonical SEO rule lives, so it does
**not** pre-empt the `frontend/seo.md` extraction — that stays deferred
to the #492 frontend restructure, and **#624 remains open** for it.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync
- `py tools/audit_redundancy.py --check` — OK, **0 baselined**, exit 0
- `py tools/audit_redundancy.py` — **0** exact in-chain duplicates

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)
