### PR TITLE
docs(wiki): rename patterns/ to wiki/ and drop dead Resolution mode

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -259,14 +259,14 @@ a mismatch exists between a file header and the manifest, the manifest
 wins and the file header MUST be updated. Smoke check SYS-04 validates
 this contract.
 
-### Pattern files
+### Wiki
 
-Pattern files (`docs/patterns/`) are human reference documentation
-for *projects that use the templates*. They are NOT part of the
-dependency graph or agent context. Parent rules files list which
-patterns to use as one-line conventions.
+The wiki (`docs/wiki/`) gathers human reference documentation
+for *projects that use the templates*. It is NOT part of the
+dependency graph or agent context. Parent rules files reference
+the relevant wiki pages as one-line conventions.
 
-Current pattern files: `cicd.md`, `devsecops.md`, `frontend.md`,
+Current wiki pages: `cicd.md`, `devsecops.md`, `frontend.md`,
 `security.md`, `testing.md`.
 
 ### Meta documents
@@ -443,8 +443,8 @@ a declarative header that the agent resolves at startup.
 │     templates/manifest.yaml → resolves dependency chain   │
 ├─────────────────────────────────────────────────┤
 │  3. DEVELOPMENT (during session)                │
-│     Full context loaded — agent applies rules   │
-│     and patterns without prompting              │
+│     Full context loaded — agent applies the     │
+│     resolved rules without prompting            │
 ├─────────────────────────────────────────────────┤
 │  4. UPDATE (on upstream change)                 │
 │     git submodule update --remote               │
@@ -462,7 +462,6 @@ a hand-curated file list:
 Stack: static-site-astro
 Extras: data-quality, 360, issues, scope, review, readme
 Platform: github
-Resolution: full
 ```
 
 | Field | Required | Description |
@@ -470,7 +469,6 @@ Resolution: full
 | `Stack` | MUST | Stack ID from `manifest.yaml` |
 | `Extras` | MAY | Comma-separated base template IDs not in the stack's dependency chain |
 | `Platform` | MAY | Platform ID (`github`, `gitlab`) |
-| `Resolution` | MAY | `full` (rules + patterns) or `rules` (rules only); default: `rules` |
 
 ### Resolution algorithm
 
@@ -483,12 +481,8 @@ Output: ordered list of template files to load.
    transitive dependencies (depth-first, deduplicated)
 3. Append Extras (skip if already in the resolved set)
 4. Append Platform template (if declared)
-5. If Resolution = full → for each resolved rules file,
-   include its companion *-patterns.md (if it exists
-   in manifest.yaml with a depends_on pointing to
-   the rules file)
-6. Append templates/base/core/agents.md
-7. Return the ordered file list
+5. Append templates/base/core/agents.md
+6. Return the ordered file list
 ```
 
 Ordering: base → backend/frontend → stack (topological sort of

--- a/docs/wiki/cicd.md
+++ b/docs/wiki/cicd.md
@@ -1,9 +1,9 @@
-# Base — CI/CD Patterns
+# CI/CD — Wiki
 
-[ID: base-cicd-patterns]
+[ID: cicd-wiki]
 [DEPENDS ON: base/cicd.md]
 
-Reusable structural patterns for CI/CD pipelines. Each pattern
+Wiki notes on reusable CI/CD pipeline structures. Each entry
 describes a problem, solution structure, when to use it, and
 platform examples.
 
@@ -15,7 +15,7 @@ configuration.
 
 ## 1. Gate job
 
-[ID: cicd-pattern-gate]
+[ID: cicd-wiki-gate]
 
 **Problem:** Required status checks block merges when conditional
 jobs are skipped. Docs-only PRs wait for a full build that will
@@ -77,7 +77,7 @@ gate:
 
 ## 2. Path filtering
 
-[ID: cicd-pattern-path-filter]
+[ID: cicd-wiki-path-filter]
 
 **Problem:** Every PR runs the full pipeline regardless of what
 changed. Docs and config changes wait minutes for irrelevant
@@ -140,7 +140,7 @@ build:
 
 ## 3. Fan-out / fan-in
 
-[ID: cicd-pattern-fan-out]
+[ID: cicd-wiki-fan-out]
 
 **Problem:** Running lint, test, security scan, and type check
 sequentially wastes time. A lint failure at minute 5 means tests
@@ -189,7 +189,7 @@ gate:
 
 ## 4. Artifact promotion
 
-[ID: cicd-pattern-artifact-promotion]
+[ID: cicd-wiki-artifact-promotion]
 
 **Problem:** Rebuilding the application for each environment
 introduces the risk that staging and production run different
@@ -221,7 +221,7 @@ build → push :sha → staging (sha) → promote → production (sha)
 
 ## 5. Dependency caching
 
-[ID: cicd-pattern-caching]
+[ID: cicd-wiki-caching]
 
 **Problem:** Installing dependencies on every CI run adds minutes
 to every pipeline. Package registries are external — network
@@ -271,7 +271,7 @@ cache:
 
 ## 6. Matrix build
 
-[ID: cicd-pattern-matrix]
+[ID: cicd-wiki-matrix]
 
 **Problem:** The project must work across multiple runtime versions,
 operating systems, or configurations. Testing them sequentially
@@ -315,7 +315,7 @@ test:
 
 ## 7. Auto-merge for bot PRs
 
-[ID: cicd-pattern-auto-merge]
+[ID: cicd-wiki-auto-merge]
 
 **Problem:** Dependabot and Renovate create PRs for dependency
 updates. Each requires manual review and merge — hundreds per
@@ -361,7 +361,7 @@ auto-merge:
 
 ## 8. Deploy preview
 
-[ID: cicd-pattern-deploy-preview]
+[ID: cicd-wiki-deploy-preview]
 
 **Problem:** Reviewing code changes without seeing the result
 requires the reviewer to check out the branch and build locally.

--- a/docs/wiki/devsecops.md
+++ b/docs/wiki/devsecops.md
@@ -1,22 +1,22 @@
-# Base — DevSecOps Pipeline Patterns
+# DevSecOps Pipeline — Wiki
 
-[ID: base-devsecops-patterns]
+[ID: devsecops-wiki]
 [DEPENDS ON: base/devsecops.md, base/cicd.md]
 
-Reusable structural patterns for security in CI/CD pipelines.
-Each pattern describes a problem, solution structure, when to
+Wiki notes on reusable security structures for CI/CD pipelines.
+Each entry describes a problem, solution structure, when to
 use it, and examples.
 
 See `base/devsecops.md` for SAST, SCA, secret detection, and
 compliance rules.
-See `base/security-patterns.md` for application-level security
+See `security.md` for application-level security
 patterns (input validation, encoding, CSRF, headers).
 
 ---
 
 ## 1. Break-the-build gate
 
-[ID: devsecops-pattern-break-build]
+[ID: devsecops-wiki-break-build]
 
 **Problem:** Security scans run in CI but findings are advisory.
 Developers see warnings, ignore them, and merge. Vulnerabilities
@@ -61,7 +61,7 @@ security:
 
 ## 2. Vulnerability triage workflow
 
-[ID: devsecops-pattern-triage]
+[ID: devsecops-wiki-triage]
 
 **Problem:** SCA tools report dozens of vulnerabilities across
 transitive dependencies. The team has no process for deciding
@@ -99,7 +99,7 @@ SCA report → triage
 
 ## 3. SBOM generation
 
-[ID: devsecops-pattern-sbom]
+[ID: devsecops-wiki-sbom]
 
 **Problem:** A vulnerability is disclosed in a widely-used library.
 The team cannot determine which services use the affected version.
@@ -151,7 +151,7 @@ CVE disclosed → search SBOMs → list affected services → patch
 
 ## 4. Secret rotation
 
-[ID: devsecops-pattern-secret-rotation]
+[ID: devsecops-wiki-secret-rotation]
 
 **Problem:** Secrets (API keys, database passwords, tokens) are
 created once and never rotated. A leaked secret from months ago
@@ -191,7 +191,7 @@ Timeline: [---v1 valid---][--overlap--][---v2 valid---]
 
 ## 5. Dependency update workflow
 
-[ID: devsecops-pattern-dep-update]
+[ID: devsecops-wiki-dep-update]
 
 **Problem:** Dependencies are updated reactively — only when a
 vulnerability is reported. By then, the update may span multiple
@@ -215,12 +215,12 @@ Monthly:
 **When to use:**
 
 - Every project with external dependencies
-- Combine with the auto-merge pattern from `base/cicd-patterns.md`
+- Combine with the auto-merge pattern from `cicd.md`
 
 **Rules:**
 
 - Patch and minor updates: auto-merge if CI passes (see
-  `cicd-pattern-auto-merge`)
+  `cicd-wiki-auto-merge`)
 - Major updates: require human review of changelog and breaking
   changes
 - Group related updates (e.g. all `@typescript-eslint/*` packages)
@@ -234,7 +234,7 @@ Monthly:
 
 ## 6. Security smoke test
 
-[ID: devsecops-pattern-security-smoke]
+[ID: devsecops-wiki-security-smoke]
 
 **Problem:** Security headers, CSP, CORS, and TLS configuration
 are set once and forgotten. A deployment change or proxy update
@@ -292,7 +292,7 @@ exit $FAIL
 
 ## 7. Pre-merge security gate
 
-[ID: devsecops-pattern-pre-merge-gate]
+[ID: devsecops-wiki-pre-merge-gate]
 
 **Problem:** SAST and SCA run on every PR, but DAST only runs
 after merge to staging. A vulnerability that SAST misses is not
@@ -325,7 +325,7 @@ Post-merge to staging:
 
 - Each layer runs independently — failure in one does not skip
   others
-- Combine with the fan-out pattern from `base/cicd-patterns.md`
+- Combine with the fan-out pattern from `cicd.md`
   for parallel execution
 - DAST runs post-merge because it needs a running environment —
   but DAST findings MUST still block production deployment
@@ -336,7 +336,7 @@ Post-merge to staging:
 
 ## 8. Incident-to-hardening loop
 
-[ID: devsecops-pattern-hardening-loop]
+[ID: devsecops-wiki-hardening-loop]
 
 **Problem:** A security incident is resolved. The immediate fix
 is deployed. But the root cause is never addressed. The same

--- a/docs/wiki/frontend.md
+++ b/docs/wiki/frontend.md
@@ -1,10 +1,10 @@
-# Frontend — UI Patterns
+# Frontend UI — Wiki
 
-[ID: frontend-patterns]
+[ID: frontend-wiki]
 [DEPENDS ON: frontend/quality.md, frontend/ux.md]
 
-Reusable structural patterns for frontend applications. Each
-pattern describes a problem, solution structure, when to use it,
+Wiki notes on reusable frontend application structures. Each
+entry describes a problem, solution structure, when to use it,
 and examples.
 
 See `frontend/quality.md` for design patterns and state management.
@@ -14,7 +14,7 @@ See `frontend/ux.md` for accessibility and responsive design.
 
 ## 1. Error boundary
 
-[ID: frontend-pattern-error-boundary]
+[ID: frontend-wiki-error-boundary]
 
 **Problem:** A runtime error in one component crashes the entire
 application. Users see a blank screen with no way to recover.
@@ -74,7 +74,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 
 ## 2. Skeleton loading
 
-[ID: frontend-pattern-skeleton]
+[ID: frontend-wiki-skeleton]
 
 **Problem:** Content loads asynchronously. The page shows a blank
 area or a spinner until data arrives. Layout shifts when content
@@ -111,7 +111,7 @@ Loaded:   John Smith  Admin   john@example.com
 
 ## 3. Optimistic update
 
-[ID: frontend-pattern-optimistic]
+[ID: frontend-wiki-optimistic]
 
 **Problem:** After a user action (like, save, delete), the UI
 waits for the server response before updating. The delay makes
@@ -149,7 +149,7 @@ User clicks "Like" → UI shows liked (instant)
 
 ## 4. Infinite scroll with virtualization
 
-[ID: frontend-pattern-virtual-scroll]
+[ID: frontend-wiki-virtual-scroll]
 
 **Problem:** Rendering thousands of DOM elements for a long list
 freezes the browser. Pagination breaks the browsing flow. Loading
@@ -188,7 +188,7 @@ DOM. Fetch more data when approaching the end of the loaded set.
 
 ## 5. Debounced search
 
-[ID: frontend-pattern-debounced-search]
+[ID: frontend-wiki-debounced-search]
 
 **Problem:** A search input fires an API call on every keystroke.
 Typing "camera" sends 6 requests, 5 of which are immediately
@@ -225,7 +225,7 @@ Requests:  ............→ "camera" (one request after 300ms pause)
 
 ## 6. Form validation pattern
 
-[ID: frontend-pattern-form-validation]
+[ID: frontend-wiki-form-validation]
 
 **Problem:** Validation logic is scattered across event handlers,
 submit functions, and inline checks. Error messages appear
@@ -263,7 +263,7 @@ Form submit → validate all   → show all errors, focus first
 
 ## 7. Responsive layout switch
 
-[ID: frontend-pattern-responsive-switch]
+[ID: frontend-wiki-responsive-switch]
 
 **Problem:** A data table works on desktop but is unusable on
 mobile. Hiding columns loses information. Horizontal scrolling
@@ -303,7 +303,7 @@ Mobile  (≤ 640px): card stack with key fields
 
 ## 8. URL state synchronization
 
-[ID: frontend-pattern-url-state]
+[ID: frontend-wiki-url-state]
 
 **Problem:** Users apply filters, sort a table, and select a tab.
 When they share the URL or refresh the page, all state is lost.

--- a/docs/wiki/security.md
+++ b/docs/wiki/security.md
@@ -1,21 +1,21 @@
-# Base — Application Security Patterns
+# Application Security — Wiki
 
-[ID: base-security-patterns]
+[ID: security-wiki]
 [DEPENDS ON: base/security.md]
 
-Reusable structural patterns for secure application code. Each
-pattern describes a problem, solution structure, when to use it,
-and examples.
+Wiki notes on reusable structures for secure application code.
+Each entry describes a problem, solution structure, when to use
+it, and examples.
 
 See `base/security.md` for application security rules.
 See `base/devsecops.md` for pipeline security rules and
-`base/devsecops-patterns.md` for pipeline security patterns.
+`devsecops.md` for pipeline security patterns.
 
 ---
 
 ## 1. Validate-at-boundary
 
-[ID: security-pattern-input-validation]
+[ID: security-wiki-input-validation]
 
 **Problem:** User input flows through multiple layers with
 validation scattered across each. Some paths skip validation
@@ -56,7 +56,7 @@ app.post("/users", (req, res) => {
 
 ## 2. Encode-on-output
 
-[ID: security-pattern-output-encoding]
+[ID: security-wiki-output-encoding]
 
 **Problem:** Data stored raw is rendered in HTML without encoding.
 Stored XSS executes in every user's browser.
@@ -78,7 +78,7 @@ Render: &lt;script&gt;alert(1)&lt;/script&gt;  (HTML-encoded in page)
 
 ## 3. Runtime secret injection
 
-[ID: security-pattern-secret-injection]
+[ID: security-wiki-secret-injection]
 
 **Problem:** Secrets are hardcoded in source, baked into images,
 or passed as build-time variables. They leak into version control,
@@ -120,7 +120,7 @@ services:
 
 ## 4. CSRF double-submit
 
-[ID: security-pattern-csrf]
+[ID: security-wiki-csrf]
 
 **Problem:** A malicious site submits a form using the user's
 session. The server cannot distinguish legitimate from forged
@@ -146,7 +146,7 @@ Mismatch               → 403 Forbidden
 
 ## 5. Rate limiter placement
 
-[ID: security-pattern-rate-limit]
+[ID: security-wiki-rate-limit]
 
 **Problem:** Endpoints are brute-forced or scraped. The server
 is overwhelmed with requests.
@@ -174,7 +174,7 @@ Client → [rate limiter] → allowed (under limit)
 
 ## 6. Lock file as supply chain guard
 
-[ID: security-pattern-dependency-pinning]
+[ID: security-wiki-dependency-pinning]
 
 **Problem:** A version range pulls a compromised patch release
 automatically. Supply chain attack succeeds silently.
@@ -195,7 +195,7 @@ package-lock.json: "lodash": "4.17.21"  (pinned — safe)
 
 ## 7. Least-privilege scoping
 
-[ID: security-pattern-least-privilege]
+[ID: security-wiki-least-privilege]
 
 **Problem:** A compromised component has admin access. The blast
 radius is the entire system.
@@ -219,7 +219,7 @@ Container → non-root, read-only filesystem
 
 ## 8. Security header baseline
 
-[ID: security-pattern-headers]
+[ID: security-wiki-headers]
 
 **Problem:** Default browser behavior is permissive. Every missing
 header is an attack surface.

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,10 +1,11 @@
-# Base — Testing Patterns
+# Testing — Wiki
 
-[ID: base-testing-patterns]
+[ID: testing-wiki]
 [DEPENDS ON: base/testing.md]
 
-Reusable structural patterns for test code. Each pattern describes
-a problem, solution structure, when to use it, and examples.
+Wiki notes on reusable structures for test code. Each entry
+describes a problem, solution structure, when to use it, and
+examples.
 
 See `base/testing.md` for test types, coverage targets, and naming.
 See `base/quality.md` for testability as a design concern.
@@ -13,7 +14,7 @@ See `base/quality.md` for testability as a design concern.
 
 ## 1. Test factory
 
-[ID: testing-pattern-factory]
+[ID: testing-wiki-factory]
 
 **Problem:** Tests create domain objects inline with verbose
 literal syntax. When a field is added to the type, every test
@@ -65,7 +66,7 @@ export function makeLens(overrides: Partial<Lens> = {}): Lens {
 
 ## 2. Arrange-Act-Assert
 
-[ID: testing-pattern-aaa]
+[ID: testing-wiki-aaa]
 
 **Problem:** Tests mix setup, execution, and verification into an
 unstructured block. Readers cannot tell what is being tested or
@@ -113,7 +114,7 @@ it("scores weather-sealed lenses higher for landscape", () => {
 
 ## 3. Builder pattern for test data
 
-[ID: testing-pattern-builder]
+[ID: testing-wiki-builder]
 
 **Problem:** Factory functions work for simple objects but become
 unwieldy when the object has many optional fields, nested
@@ -167,7 +168,7 @@ export const aLens = () => new LensBuilder();
 
 ## 4. Parameterized tests
 
-[ID: testing-pattern-parameterized]
+[ID: testing-wiki-parameterized]
 
 **Problem:** Multiple tests verify the same logic with different
 inputs. Each test is a copy of the others with one value changed.
@@ -219,7 +220,7 @@ def test_score_aperture(aperture, expected):
 
 ## 5. Fixture hierarchy
 
-[ID: testing-pattern-fixtures]
+[ID: testing-wiki-fixtures]
 
 **Problem:** Tests duplicate expensive setup (database seeding,
 API mocking, DOM rendering). Extracting setup into `beforeEach`
@@ -282,7 +283,7 @@ def user(db):
 
 ## 6. Mock boundary
 
-[ID: testing-pattern-mock-boundary]
+[ID: testing-wiki-mock-boundary]
 
 **Problem:** Tests mock internal implementation details. When the
 code is refactored, tests break even though behavior is unchanged.
@@ -316,7 +317,7 @@ functions without mocks.
 
 ## 7. Snapshot testing
 
-[ID: testing-pattern-snapshot]
+[ID: testing-wiki-snapshot]
 
 **Problem:** Verifying complex output (rendered HTML, serialized
 objects, API responses) requires verbose assertions that are hard
@@ -345,7 +346,7 @@ Review snapshot changes in code review like any other diff.
 
 ## 8. Contract testing
 
-[ID: testing-pattern-contract]
+[ID: testing-wiki-contract]
 
 **Problem:** Service A depends on Service B's API. Integration
 tests that call Service B are slow, flaky, and require both


### PR DESCRIPTION
## What

- Rename `docs/patterns/` → `docs/wiki/` to convey the folder gathers human-facing knowledge.
- Sweep the five pages: titles, lead text, and all `[ID: …]` section tags now read as wiki entries (`*-wiki` / `*-wiki-*`); fix stale `base/*-patterns.md` cross-links to point at wiki siblings.
- Align `docs/SPEC.md` with ADR-004: drop the never-implemented `Resolution: full (rules + patterns)` mode and the companion `*-patterns.md` resolution step.

## Why

The wiki files are **not** in `manifest.yaml` or any resolved chain — verified against `resolve.py`, the manifest, and `generated/`. They are reference docs for humans, never loaded into agent context. The SPEC's `Resolution: full` mode contradicted that (patterns can't be manifest companions once ADR-004 moved them out), so it was vacuous and is removed.

## Impact

Zero functional impact on generation. Gates green: smoke 23/23, `sync.py --check` clean, `audit_redundancy.py --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)