### PR TITLE
chore(wiki): strip vestigial template tags and excess dividers

### DIFF
--- a/docs/wiki/cicd.md
+++ b/docs/wiki/cicd.md
@@ -1,8 +1,5 @@
 # CI/CD — Wiki
 
-[ID: cicd-wiki]
-[DEPENDS ON: base/cicd.md]
-
 Wiki notes on reusable CI/CD pipeline structures. Each entry
 describes a problem, solution structure, when to use it, and
 platform examples.
@@ -14,8 +11,6 @@ configuration.
 ---
 
 ## 1. Gate job
-
-[ID: cicd-wiki-gate]
 
 **Problem:** Required status checks block merges when conditional
 jobs are skipped. Docs-only PRs wait for a full build that will
@@ -73,11 +68,7 @@ gate:
     - when: always
 ```
 
----
-
 ## 2. Path filtering
-
-[ID: cicd-wiki-path-filter]
 
 **Problem:** Every PR runs the full pipeline regardless of what
 changed. Docs and config changes wait minutes for irrelevant
@@ -136,11 +127,7 @@ build:
     - when: never
 ```
 
----
-
 ## 3. Fan-out / fan-in
-
-[ID: cicd-wiki-fan-out]
 
 **Problem:** Running lint, test, security scan, and type check
 sequentially wastes time. A lint failure at minute 5 means tests
@@ -185,11 +172,7 @@ gate:
         done
 ```
 
----
-
 ## 4. Artifact promotion
-
-[ID: cicd-wiki-artifact-promotion]
 
 **Problem:** Rebuilding the application for each environment
 introduces the risk that staging and production run different
@@ -217,11 +200,7 @@ build → push :sha → staging (sha) → promote → production (sha)
 - The artifact that passed tests in staging is the artifact that
   runs in production
 
----
-
 ## 5. Dependency caching
-
-[ID: cicd-wiki-caching]
 
 **Problem:** Installing dependencies on every CI run adds minutes
 to every pipeline. Package registries are external — network
@@ -267,11 +246,7 @@ cache:
   policy: pull-push
 ```
 
----
-
 ## 6. Matrix build
-
-[ID: cicd-wiki-matrix]
 
 **Problem:** The project must work across multiple runtime versions,
 operating systems, or configurations. Testing them sequentially
@@ -311,11 +286,7 @@ test:
 - Use matrix `include`/`exclude` to cover only realistic
   combinations
 
----
-
 ## 7. Auto-merge for bot PRs
-
-[ID: cicd-wiki-auto-merge]
 
 **Problem:** Dependabot and Renovate create PRs for dependency
 updates. Each requires manual review and merge — hundreds per
@@ -357,11 +328,7 @@ auto-merge:
 - CI MUST pass before auto-merge triggers — never bypass checks
 - Review the changelog of auto-merged updates periodically
 
----
-
 ## 8. Deploy preview
-
-[ID: cicd-wiki-deploy-preview]
 
 **Problem:** Reviewing code changes without seeing the result
 requires the reviewer to check out the branch and build locally.

--- a/docs/wiki/devsecops.md
+++ b/docs/wiki/devsecops.md
@@ -1,8 +1,5 @@
 # DevSecOps Pipeline — Wiki
 
-[ID: devsecops-wiki]
-[DEPENDS ON: base/devsecops.md, base/cicd.md]
-
 Wiki notes on reusable security structures for CI/CD pipelines.
 Each entry describes a problem, solution structure, when to
 use it, and examples.
@@ -15,8 +12,6 @@ patterns (input validation, encoding, CSRF, headers).
 ---
 
 ## 1. Break-the-build gate
-
-[ID: devsecops-wiki-break-build]
 
 **Problem:** Security scans run in CI but findings are advisory.
 Developers see warnings, ignore them, and merge. Vulnerabilities
@@ -57,11 +52,7 @@ security:
   in code — not silenced in CI configuration
 - Never add `continue-on-error: true` to security scan steps
 
----
-
 ## 2. Vulnerability triage workflow
-
-[ID: devsecops-wiki-triage]
 
 **Problem:** SCA tools report dozens of vulnerabilities across
 transitive dependencies. The team has no process for deciding
@@ -95,11 +86,7 @@ SCA report → triage
 - Re-triage accepted risks quarterly — the threat landscape
   changes
 
----
-
 ## 3. SBOM generation
-
-[ID: devsecops-wiki-sbom]
 
 **Problem:** A vulnerability is disclosed in a widely-used library.
 The team cannot determine which services use the affected version.
@@ -147,11 +134,7 @@ CVE disclosed → search SBOMs → list affected services → patch
   retrievable per version
 - Automate SBOM generation in CI — never generate manually
 
----
-
 ## 4. Secret rotation
-
-[ID: devsecops-wiki-secret-rotation]
 
 **Problem:** Secrets (API keys, database passwords, tokens) are
 created once and never rotated. A leaked secret from months ago
@@ -187,11 +170,7 @@ Timeline: [---v1 valid---][--overlap--][---v2 valid---]
 - Alert on rotation failure — a failed rotation is worse than
   no rotation (the secret is stuck)
 
----
-
 ## 5. Dependency update workflow
-
-[ID: devsecops-wiki-dep-update]
 
 **Problem:** Dependencies are updated reactively — only when a
 vulnerability is reported. By then, the update may span multiple
@@ -219,8 +198,8 @@ Monthly:
 
 **Rules:**
 
-- Patch and minor updates: auto-merge if CI passes (see
-  `cicd-wiki-auto-merge`)
+- Patch and minor updates: auto-merge if CI passes (see the
+  auto-merge section in `cicd.md`)
 - Major updates: require human review of changelog and breaking
   changes
 - Group related updates (e.g. all `@typescript-eslint/*` packages)
@@ -230,11 +209,7 @@ Monthly:
 - Track update frequency — if a dependency has not been updated
   in 12 months, investigate whether it is abandoned
 
----
-
 ## 6. Security smoke test
-
-[ID: devsecops-wiki-security-smoke]
 
 **Problem:** Security headers, CSP, CORS, and TLS configuration
 are set once and forgotten. A deployment change or proxy update
@@ -288,11 +263,7 @@ exit $FAIL
 - Alert immediately on failure — a missing security header in
   production is an incident
 
----
-
 ## 7. Pre-merge security gate
-
-[ID: devsecops-wiki-pre-merge-gate]
 
 **Problem:** SAST and SCA run on every PR, but DAST only runs
 after merge to staging. A vulnerability that SAST misses is not
@@ -332,11 +303,7 @@ Post-merge to staging:
 - Track which layer catches each finding — if DAST consistently
   catches issues SAST misses, improve SAST rules
 
----
-
 ## 8. Incident-to-hardening loop
-
-[ID: devsecops-wiki-hardening-loop]
 
 **Problem:** A security incident is resolved. The immediate fix
 is deployed. But the root cause is never addressed. The same

--- a/docs/wiki/frontend.md
+++ b/docs/wiki/frontend.md
@@ -1,8 +1,5 @@
 # Frontend UI — Wiki
 
-[ID: frontend-wiki]
-[DEPENDS ON: frontend/quality.md, frontend/ux.md]
-
 Wiki notes on reusable frontend application structures. Each
 entry describes a problem, solution structure, when to use it,
 and examples.
@@ -13,8 +10,6 @@ See `frontend/ux.md` for accessibility and responsive design.
 ---
 
 ## 1. Error boundary
-
-[ID: frontend-wiki-error-boundary]
 
 **Problem:** A runtime error in one component crashes the entire
 application. Users see a blank screen with no way to recover.
@@ -70,11 +65,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 - Place boundaries at natural isolation points — not around
   every component
 
----
-
 ## 2. Skeleton loading
-
-[ID: frontend-wiki-skeleton]
 
 **Problem:** Content loads asynchronously. The page shows a blank
 area or a spinner until data arrives. Layout shifts when content
@@ -107,11 +98,7 @@ Loaded:   John Smith  Admin   john@example.com
 - Prefer skeletons over spinners for structured content; use
   spinners only for actions (form submit, navigation)
 
----
-
 ## 3. Optimistic update
-
-[ID: frontend-wiki-optimistic]
 
 **Problem:** After a user action (like, save, delete), the UI
 waits for the server response before updating. The delay makes
@@ -145,11 +132,7 @@ User clicks "Like" → UI shows liked (instant)
 - Do not use optimistic updates for operations that affect other
   users' data in real time
 
----
-
 ## 4. Infinite scroll with virtualization
-
-[ID: frontend-wiki-virtual-scroll]
 
 **Problem:** Rendering thousands of DOM elements for a long list
 freezes the browser. Pagination breaks the browsing flow. Loading
@@ -184,11 +167,7 @@ DOM. Fetch more data when approaching the end of the loaded set.
 - Use established libraries: `react-window`, `@tanstack/virtual`,
   `vue-virtual-scroller`
 
----
-
 ## 5. Debounced search
-
-[ID: frontend-wiki-debounced-search]
 
 **Problem:** A search input fires an API call on every keystroke.
 Typing "camera" sends 6 requests, 5 of which are immediately
@@ -221,11 +200,7 @@ Requests:  ............→ "camera" (one request after 300ms pause)
 - Provide immediate local filtering when possible, defer API
   calls for server-side search
 
----
-
 ## 6. Form validation pattern
-
-[ID: frontend-wiki-form-validation]
 
 **Problem:** Validation logic is scattered across event handlers,
 submit functions, and inline checks. Error messages appear
@@ -259,11 +234,7 @@ Form submit → validate all   → show all errors, focus first
 - Never rely on client-side validation alone — always validate
   on the server
 
----
-
 ## 7. Responsive layout switch
-
-[ID: frontend-wiki-responsive-switch]
 
 **Problem:** A data table works on desktop but is unusable on
 mobile. Hiding columns loses information. Horizontal scrolling
@@ -299,11 +270,7 @@ Mobile  (≤ 640px): card stack with key fields
 - Test both layouts — queries like `getAllByText` verify content
   exists in both views
 
----
-
 ## 8. URL state synchronization
-
-[ID: frontend-wiki-url-state]
 
 **Problem:** Users apply filters, sort a table, and select a tab.
 When they share the URL or refresh the page, all state is lost.

--- a/docs/wiki/security.md
+++ b/docs/wiki/security.md
@@ -1,8 +1,5 @@
 # Application Security — Wiki
 
-[ID: security-wiki]
-[DEPENDS ON: base/security.md]
-
 Wiki notes on reusable structures for secure application code.
 Each entry describes a problem, solution structure, when to use
 it, and examples.
@@ -14,8 +11,6 @@ See `base/devsecops.md` for pipeline security rules and
 ---
 
 ## 1. Validate-at-boundary
-
-[ID: security-wiki-input-validation]
 
 **Problem:** User input flows through multiple layers with
 validation scattered across each. Some paths skip validation
@@ -52,11 +47,7 @@ app.post("/users", (req, res) => {
 });
 ```
 
----
-
 ## 2. Encode-on-output
-
-[ID: security-wiki-output-encoding]
 
 **Problem:** Data stored raw is rendered in HTML without encoding.
 Stored XSS executes in every user's browser.
@@ -74,11 +65,7 @@ Render: &lt;script&gt;alert(1)&lt;/script&gt;  (HTML-encoded in page)
 - Every point where dynamic data is rendered in HTML, URLs,
   JSON, SQL, or shell commands
 
----
-
 ## 3. Runtime secret injection
-
-[ID: security-wiki-secret-injection]
 
 **Problem:** Secrets are hardcoded in source, baked into images,
 or passed as build-time variables. They leak into version control,
@@ -116,11 +103,7 @@ services:
       - DATABASE_URL # read from host env or .env file
 ```
 
----
-
 ## 4. CSRF double-submit
-
-[ID: security-wiki-csrf]
 
 **Problem:** A malicious site submits a form using the user's
 session. The server cannot distinguish legitimate from forged
@@ -142,11 +125,7 @@ Mismatch               → 403 Forbidden
 - NOT needed for API-only backends using Bearer tokens
 - NOT needed for SameSite=Strict cookies
 
----
-
 ## 5. Rate limiter placement
-
-[ID: security-wiki-rate-limit]
 
 **Problem:** Endpoints are brute-forced or scraped. The server
 is overwhelmed with requests.
@@ -170,11 +149,7 @@ Client → [rate limiter] → allowed (under limit)
 - API: 100/min
 - Static: 1000/min
 
----
-
 ## 6. Lock file as supply chain guard
-
-[ID: security-wiki-dependency-pinning]
 
 **Problem:** A version range pulls a compromised patch release
 automatically. Supply chain attack succeeds silently.
@@ -191,11 +166,7 @@ package-lock.json: "lodash": "4.17.21"  (pinned — safe)
 
 - Every project with external dependencies
 
----
-
 ## 7. Least-privilege scoping
-
-[ID: security-wiki-least-privilege]
 
 **Problem:** A compromised component has admin access. The blast
 radius is the entire system.
@@ -215,11 +186,7 @@ Container → non-root, read-only filesystem
 - Every service account, CI token, API key, IAM role, container,
   and database user
 
----
-
 ## 8. Security header baseline
-
-[ID: security-wiki-headers]
 
 **Problem:** Default browser behavior is permissive. Every missing
 header is an attack surface.

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,8 +1,5 @@
 # Testing — Wiki
 
-[ID: testing-wiki]
-[DEPENDS ON: base/testing.md]
-
 Wiki notes on reusable structures for test code. Each entry
 describes a problem, solution structure, when to use it, and
 examples.
@@ -13,8 +10,6 @@ See `base/quality.md` for testability as a design concern.
 ---
 
 ## 1. Test factory
-
-[ID: testing-wiki-factory]
 
 **Problem:** Tests create domain objects inline with verbose
 literal syntax. When a field is added to the type, every test
@@ -62,11 +57,7 @@ export function makeLens(overrides: Partial<Lens> = {}): Lens {
   make failures reproducible
 - Use factory composition for nested types: `makeOrder({ items: [makeItem()] })`
 
----
-
 ## 2. Arrange-Act-Assert
-
-[ID: testing-wiki-aaa]
 
 **Problem:** Tests mix setup, execution, and verification into an
 unstructured block. Readers cannot tell what is being tested or
@@ -110,11 +101,7 @@ it("scores weather-sealed lenses higher for landscape", () => {
 - Assert should test one logical concept — multiple `expect`
   calls are fine if they verify the same outcome
 
----
-
 ## 3. Builder pattern for test data
-
-[ID: testing-wiki-builder]
 
 **Problem:** Factory functions work for simple objects but become
 unwieldy when the object has many optional fields, nested
@@ -164,11 +151,7 @@ export const aLens = () => new LensBuilder();
   over-engineer simple test data
 - Name builder entry points as articles: `aUser()`, `anOrder()`
 
----
-
 ## 4. Parameterized tests
-
-[ID: testing-wiki-parameterized]
 
 **Problem:** Multiple tests verify the same logic with different
 inputs. Each test is a copy of the others with one value changed.
@@ -216,11 +199,7 @@ def test_score_aperture(aperture, expected):
   separate file unless it exceeds 20 entries
 - Each row MUST be independent — no row depends on a previous row
 
----
-
 ## 5. Fixture hierarchy
-
-[ID: testing-wiki-fixtures]
 
 **Problem:** Tests duplicate expensive setup (database seeding,
 API mocking, DOM rendering). Extracting setup into `beforeEach`
@@ -279,11 +258,7 @@ def user(db):
 - Name fixtures after what they provide, not what they do:
   `user` not `createUser`
 
----
-
 ## 6. Mock boundary
-
-[ID: testing-wiki-mock-boundary]
 
 **Problem:** Tests mock internal implementation details. When the
 code is refactored, tests break even though behavior is unchanged.
@@ -313,11 +288,7 @@ functions without mocks.
   module, the design needs improvement
 - Mock the dependency, not the function under test
 
----
-
 ## 7. Snapshot testing
-
-[ID: testing-wiki-snapshot]
 
 **Problem:** Verifying complex output (rendered HTML, serialized
 objects, API responses) requires verbose assertions that are hard
@@ -342,11 +313,7 @@ Review snapshot changes in code review like any other diff.
 - Never snapshot non-deterministic output (timestamps, random IDs)
   — stabilize the output first (mock clocks, seed randomness)
 
----
-
 ## 8. Contract testing
-
-[ID: testing-wiki-contract]
 
 **Problem:** Service A depends on Service B's API. Integration
 tests that call Service B are slow, flaky, and require both


### PR DESCRIPTION
## What

Two cleanups to the `docs/wiki/` pages (follow-on to #696):

1. **Strip template machinery** — removed all `[ID: …]` and `[DEPENDS ON: …]` tag lines (50 lines). These were leftovers from when the pages were `base/*-patterns.md` templates; they are not in the manifest, never resolved into any chain, and never scanned by smoke. Reworded the one internal section-ID cross-ref to a plain prose reference.
2. **Trim dividers** — reduced the per-section `---` rules from 8 → 1 per page. The numbered `##` headings separate sections; one rule remains to divide each page's intro from its body.

## Why

These are human reference docs, not composable templates — the template tags misleadingly implied they were part of the dependency graph, and a divider before every heading was redundant noise.

## Impact

Zero functional impact (verified: no external references to the IDs; smoke never reads `docs/wiki/`). Gates green: smoke 23/23, `sync.py --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)