### PR TITLE
docs(wiki): add missing backend building blocks to the primer

### DIFF
--- a/docs/wiki/backend.md
+++ b/docs/wiki/backend.md
@@ -82,13 +82,16 @@ them together.
 
 | Block | Role | Stateful? | Rules |
 |-------|------|-----------|-------|
-| **Edge / gateway** | TLS, routing, rate limit, authn, WAF | No | `backend/http.md` |
+| **Edge / gateway** | TLS, routing, load balancing, CDN, rate limit, authn, WAF | No | `backend/http.md` |
 | **API / application layer** | Validate, authorize, run business logic | No (keep it so) | `backend/quality.md` |
 | **Auth provider** | Identity, tokens, sessions, keys | Yes | `backend/auth.md` |
+| **Config / secrets** | Env vars, secrets, runtime config | Yes | `base/config.md` |
+| **Feature flags** | Toggles, gradual rollout, experiments | Yes | `backend/features.md` |
 | **Relational DB** | Source-of-truth records, transactions | Yes | `backend/database.md` |
 | **Cache / KV** | Hot reads, sessions, locks, counters | Yes (ephemeral) | `backend/caching.md` |
 | **Blob store** | Files, media, large payloads | Yes | — |
 | **Search index** | Full-text and faceted queries | Yes (derived) | — |
+| **Analytics / warehouse** | OLAP, time-series, reporting queries | Yes (derived) | — |
 | **Broker / queue** | Decouple, buffer, fan-out | Yes | `backend/messaging.md` |
 | **Workers / jobs** | Async and scheduled work | No | `backend/jobs.md` |
 | **Integrations** | External APIs, outbound webhooks | No | `backend/webhooks.md` |


### PR DESCRIPTION
## What

Fill gaps in backend.md's §3 building-blocks inventory:

- **Config / secrets** — env vars, secrets, runtime config (`base/config.md`). Had a rules template but no block; §4 Security already leaned on it.
- **Feature flags** — toggles, gradual rollout, experiments (`backend/features.md`). Had a rules template but no block.
- **Analytics / warehouse** — OLAP / time-series / reporting stores, distinct from the transactional stores listed.
- **Edge / gateway** widened to name **load balancing** and **CDN**, which §4 HA/reachability already reference but weren't inventoried.

§3 now lists 14 blocks, grouped (edge, app, foundation, data, async, integrations, observability).

## Impact

Human reference doc — no functional impact on generation. Gates green: smoke 23/23, `sync.py --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)