### PR TITLE
feat(templates): add reverse-proxy / edge backend template (#702)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -107,6 +107,7 @@ backend/
 ├── concurrency.md  # Threads vs. processes vs. async, shared state, structured concurrency
 ├── messaging.md    # Brokers, producers, consumers, schema, DLQ, observability
 ├── webhooks.md     # Inbound webhook intake, edge signature verification, fast-ack, retry amplification
+├── edge.md         # Reverse proxy / edge — TLS termination, forwarded headers, upstream routing, timeouts, edge security
 ├── grpc.md         # Proto design, status codes, interceptors, health check
 ├── microservices.md # Service boundaries, inter-service comms, saga, contract testing
 ├── errors.md       # Classification, propagation, recovery, external failures

--- a/docs/wiki/backend.md
+++ b/docs/wiki/backend.md
@@ -5,11 +5,12 @@ building blocks you assemble it from, and how to combine those blocks
 to meet requirements such as resilience, availability, and security.
 
 This page is concept-first and maps each topic to the authoritative
-rules. See `backend/http.md`, `backend/api.md`, `backend/auth.md`,
-`backend/database.md`, `backend/caching.md`, `backend/jobs.md`,
-`backend/messaging.md`, `backend/grpc.md`, `backend/microservices.md`,
-`backend/errors.md`, `backend/observability.md`, and
-`backend/monitoring.md` for the specifics.
+rules. See `backend/edge.md`, `backend/http.md`, `backend/api.md`,
+`backend/auth.md`, `backend/database.md`, `backend/caching.md`,
+`backend/jobs.md`, `backend/messaging.md`, `backend/grpc.md`,
+`backend/microservices.md`, `backend/errors.md`,
+`backend/observability.md`, and `backend/monitoring.md` for the
+specifics.
 
 ---
 
@@ -82,7 +83,7 @@ them together.
 
 | Block | Role | Stateful? | Rules |
 |-------|------|-----------|-------|
-| **Edge / gateway** | TLS, routing, load balancing, CDN, rate limit, authn, WAF | No | `backend/http.md` |
+| **Edge / gateway** | TLS, routing, load balancing, CDN, rate limit, authn, WAF | No | `backend/edge.md` |
 | **API / application layer** | Validate, authorize, run business logic | No (keep it so) | `backend/quality.md` |
 | **Auth provider** | Identity, tokens, sessions, keys | Yes | `backend/auth.md` |
 | **Config / secrets** | Env vars, secrets, runtime config | Yes | `base/config.md` |
@@ -149,6 +150,7 @@ docs straight from the contract. See `backend/api.md`, `backend/http.md`.
 Make the backend reachable where users are: front it with an
 edge/gateway and CDN; terminate TLS; use stable DNS; place capacity in
 the regions you serve; keep a documented status page and fallback path.
+See `backend/edge.md`.
 
 ### Scalability & performance — handle more load
 

--- a/templates/backend/edge.md
+++ b/templates/backend/edge.md
@@ -1,0 +1,84 @@
+# Backend — Edge / Reverse Proxy
+[ID: backend-edge]
+[DEPENDS ON: templates/backend/http.md, templates/base/security/security.md, templates/backend/observability.md]
+
+Rules for the edge tier — the reverse proxy, load balancer, or gateway
+that sits in front of the application (nginx, Envoy, Caddy, HAProxy, a
+cloud ALB, or a CDN). Compose this template on demand for a service
+exposed to untrusted networks — it is not part of any stack chain by
+default.
+
+The edge is infrastructure, not a service: it terminates TLS, routes,
+and shields the application tier. Keep business logic out of it — that
+belongs in the application layer. API-gateway routing inside a service
+mesh is covered by `microservices.md`.
+
+---
+
+## TLS termination
+
+- Terminate TLS at the edge and redirect all plain HTTP to HTTPS — the
+  application MUST NOT be reachable over cleartext
+- Serve only TLS 1.2+; disable legacy protocol and cipher versions
+- Set HSTS (`Strict-Transport-Security`) at the edge so browsers refuse
+  to downgrade
+- Re-encrypt to upstreams (mTLS or TLS) when traffic crosses an
+  untrusted segment; plaintext to upstreams is acceptable only on a
+  trusted private network
+
+## Forwarded headers and client identity
+
+- Forward the originating client over `Forwarded` (RFC 7239) or the
+  de-facto `X-Forwarded-For` / `X-Forwarded-Proto` / `X-Forwarded-Host`
+- Strip inbound forwarded headers from external callers before
+  appending your own — never trust a client-supplied `X-Forwarded-For`
+- Configure the application's trusted-proxy list so it reads the real
+  client IP only from hops you control — an over-broad trust list lets
+  callers spoof their address and defeat IP rate limits
+- Propagate or originate a correlation/request ID at the edge so a
+  request is traceable end to end (see `observability.md`)
+
+## Routing and upstreams
+
+- Route by host and path to upstream pools; keep routing declarative,
+  not code
+- Gate traffic on upstream health checks — remove failing instances
+  from rotation and add them back only after they pass readiness
+- Balance across instances (round-robin or least-connections) and
+  spread upstreams across availability zones
+- Drain connections on deploy — stop sending new requests to an
+  instance before it shuts down so in-flight work completes
+
+## Limits, timeouts, and buffering
+
+- Set explicit connect, read, and write timeouts to every upstream —
+  an unbounded proxy timeout turns one slow upstream into edge
+  exhaustion
+- Cap request body size at the edge to reject oversized payloads before
+  they reach the application
+- Bound concurrent connections and enforce per-client rate limits at
+  the edge; return `429` with `Retry-After` when a client exceeds them
+- Set keep-alive and idle timeouts so abandoned connections free their
+  slots
+
+## Edge security
+
+- Enforce rate limiting, IP/geo allow-or-deny, and WAF rules at the
+  edge — shed abusive traffic before it reaches the application
+- Do not leak upstream identity: strip `Server`, `X-Powered-By`, and
+  internal hostnames from responses
+- Restrict admin, metrics, and health endpoints to internal networks —
+  never expose them through the public edge
+
+---
+
+## Testing
+[EXTEND: base-testing]
+
+- Test that plain HTTP redirects to HTTPS and that HSTS is present
+- Test that a client-supplied `X-Forwarded-For` is overwritten, not
+  trusted, for callers outside the trusted-proxy list
+- Test that an oversized body and an over-rate client are rejected at
+  the edge (`413` / `429`) without reaching the application
+- Test that a failing upstream is removed from rotation by the health
+  check and that deploys drain in-flight connections

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -156,6 +156,10 @@ backend:
     file: templates/backend/webhooks.md
     description: Inbound webhook intake, edge signature verification, fast-ack, retry amplification
     depends_on: [backend-http, backend-messaging, base-security, backend-observability]
+  - id: backend-edge
+    file: templates/backend/edge.md
+    description: Reverse proxy / edge — TLS termination, forwarded headers, upstream routing, timeouts, edge security
+    depends_on: [backend-http, base-security, backend-observability]
   - id: backend-grpc
     file: templates/backend/grpc.md
     description: Proto design, status codes, interceptors, health check


### PR DESCRIPTION
Closes #702.

## What

Adds a register-only `templates/backend/edge.md` for the edge / reverse-proxy tier (nginx, Envoy, Caddy, ALB, CDN) — a genuine gap: the orchestrator listed the responsibilities but pointed at `http.md`, which carries none of them.

Compose-on-demand, like `webhooks.md` — not part of any stack chain by default.

## Sections

- **TLS termination** — terminate at edge, HTTP→HTTPS, TLS 1.2+, HSTS, re-encrypt to upstreams
- **Forwarded headers / client identity** — `Forwarded` (RFC 7239) vs `X-Forwarded-*`, strip inbound, trusted-proxy list, correlation IDs
- **Routing and upstreams** — declarative routing, health-gated rotation, AZ spread, connection draining on deploy
- **Limits, timeouts, buffering** — explicit upstream timeouts, body-size caps, `429`+`Retry-After`
- **Edge security** — rate/WAF/geo at the edge, strip `Server`/`X-Powered-By`, internal-only admin/metrics
- **Testing** (`[EXTEND: base-testing]`)

## Wiring

- `manifest.yaml` — `backend-edge` (`depends_on: [backend-http, base-security, backend-observability]`)
- `docs/wiki/backend.md` — orchestrator §3 block + §4 reachability now point at `backend/edge.md`
- `docs/SPEC.md` — directory listing (via `sync.py`)

## Non-redundancy

Defers the HTTP surface to `http.md` and service-mesh gateway routing to `microservices.md`.

## Checks

- `py tools/sync.py --check` — in sync
- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 new duplicates (register-only ⇒ not in any chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)