### PR TITLE
feat(templates): add code-surface probe to ai-workflow (#698)

### DIFF
--- a/templates/base/workflow/ai-workflow.md
+++ b/templates/base/workflow/ai-workflow.md
@@ -553,6 +553,17 @@ cohort-wide one. The probe costs seconds; the misframing costs a wasted spike.
 The mechanism generalizes to any cohort with byte-identifiable artifacts —
 scraped assets, generated files, captured fixtures, computed reports.
 
+Probe the code surface, not just the data. When the hypothesis is that an
+assumption is wired everywhere — "this generalization needs a schema lift,"
+"every caller hard-codes the old shape" — the cheapest probe greps the
+load-bearing constant or type across the codebase and reads each call site.
+The assumption often turns out to be locked in one function while the rest of
+the pipeline already iterates polymorphically; sizing that in ten minutes
+keeps a one-function change from being scoped as a multi-session rewrite. A
+data probe and a code-surface probe answer different questions — one measures
+what the bytes are, the other locates where an assumption is encoded — and
+both are cheap.
+
 Probe the artifact, not your reading of it. When the claim rests on a dense
 source-of-truth artifact — an overlay image, a generated SVG, a log, a chart, a
 database row — dump its raw representation (pixel scan, JSON dump, AST walk,


### PR DESCRIPTION
Closes #698.

## What

Extends the **Probe before acting on a hypothesis** section in `templates/base/workflow/ai-workflow.md` with a sibling to the existing "Probe the breadth / Probe the artifact" paragraphs:

> Probe the code surface, not just the data. When the hypothesis is that an assumption is wired everywhere — "this generalization needs a schema lift," "every caller hard-codes the old shape" — the cheapest probe greps the load-bearing constant or type across the codebase and reads each call site. The assumption often turns out to be locked in one function while the rest of the pipeline already iterates polymorphically; sizing that in ten minutes keeps a one-function change from being scoped as a multi-session rewrite. A data probe and a code-surface probe answer different questions — one measures what the bytes are, the other locates where an assumption is encoded — and both are cheap.

## Why

The existing probe guidance is data-shaped (dump bytes, run a query, measure an intermediate). The sibling pattern — *where is this assumption locked?* — answers a different question and prevents architectural over-scoping when an apparent multi-session lift is one function deep. Placed after the breadth paragraph (both are grep-across-codebase probes), before the artifact paragraph.

## Housekeeping

Also added the missing `task` + `P3` labels to #698 (it was created unlabeled).

## Checks

- `py tools/sync.py --check` — in sync
- `py tests/run_smoke.py` — 23/23 pass
- `ai-workflow.md` is reference-only (zero chains) — no resolved-chain or redundancy impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)