### PR TITLE
fix(templates): add base-review to the core tier (#708)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -208,7 +208,7 @@ See ADR-004 for the full rationale.
 
 ### Core tier
 
-Five base templates apply to every project. They are declared in
+Six base templates apply to every project. They are declared in
 `templates/manifest.yaml` under `core:` and included during
 resolution — stacks do not need to list them in `depends_on`:
 
@@ -217,6 +217,7 @@ resolution — stacks do not need to list them in `depends_on`:
 - `templates/base/core/docs.md`
 - `templates/base/core/readme.md`
 - `templates/base/core/testing.md`
+- `templates/base/core/review.md`
 
 ### Orthogonal templates
 
@@ -226,7 +227,7 @@ opt in via the `Extras` field in the declaration block or during the
 interview.
 
 Orthogonal templates include platform choices (github, gitlab),
-workflow preferences (360, ai-workflow, review, release, deployment),
+workflow preferences (360, ai-workflow, release, deployment),
 and the advanced data templates (data-governance, data-migration) —
 opt-in extras no stack pulls automatically (`data-quality` is the only
 data module reached by a chain, via python-service).

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/stack/c-embedded.md -->
 # Stack -- Embedded C
 [DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript
 [ID: base-typescript]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript
 [ID: base-typescript]

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/language/typescript.md -->
 # Base — TypeScript
 [ID: base-typescript]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/core/config.md -->
 # Base — Configuration
 [ID: base-config]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1457,6 +1457,129 @@ two.
   collision itself is the bug worth flagging
 
 
+<!-- templates/base/core/review.md -->
+# Base — Peer Review
+
+[ID: base-review]
+
+## Principle
+
+- All code MUST undergo a peer review before merging
+- The reviewer is accountable for what gets merged
+- The developer is responsible for the code they write
+- Reviews have priority over your own development — a blocked reviewer
+  blocks the team
+
+## Priority order
+
+Apply the following order when reviewing, from most to least critical.
+Use `templates/base/core/quality.md` (and any language-specific quality template
+such as
+`templates/base/language/typescript.md`) as the standard for items 2–4.
+
+1. **Security exposure** — anything that could be exploited, any credential
+   or license problem
+2. **Functional correctness** — paths that produce wrong results, unhandled
+   failures, or race conditions
+3. **Clarity** — obscure names, deep nesting, high cognitive complexity,
+   boolean flag parameters
+4. **Convention compliance** — code that deviates from agreed project patterns
+
+## MUST checklist
+
+- [ ] No credentials, tokens, or sensitive values appear anywhere in the
+      committed files
+- [ ] Every failure path is explicitly handled — no silent catches, no
+      swallowed exceptions
+- [ ] Any new dependency carries a license compatible with the project policy
+- [ ] Significant logic or architectural decisions are captured in documentation
+- [ ] Existing documentation reflects the state of the code after this change
+
+## MUST checklist — state and boundaries
+
+- [ ] If the change touches shared browser or framework state (history,
+      URL, localStorage, global context), verify what else depends on that
+      state — review the change in the context of the framework contract,
+      not in isolation
+- [ ] URL parameters and query strings are treated as untrusted external
+      input — validate before destructuring, indexing, or using as keys
+- [ ] Refactoring preserves behavior for ALL code paths — if a function
+      handles N cases, verify N × directions/modes; extracting a helper
+      must not silently change edge-case behavior (null handling, sort
+      direction, boundary values)
+
+## CI signals
+
+- [ ] When CI fails, separate **infra failures** (the action could not
+      run — network, missing release, broken pinning, runner OOM) from
+      **diff failures** (the check ran and produced a negative signal on
+      the diff). An infra failure is a signal about the workflow, not
+      the PR — surface it honestly in the merge decision rather than
+      retrying or ignoring it
+
+Practical guidance:
+
+- On a red check, read the log before calling the PR green or red
+- If the failure is infra (`curl 404`, `docker pull` timeout, package
+  not found), file a separate task to fix the workflow and note it in
+  the merge call
+- Do NOT retry-until-green silently — that masks the infra problem
+- Do NOT push past it with `--no-verify` or an admin merge unless the
+  maintainer explicitly accepts the risk
+
+## SHOULD checklist
+
+- [ ] Non-trivial functions have a unit test for each relevant variant
+- [ ] Code coverage does not decrease
+- [ ] Lint errors/warnings do not increase
+- [ ] Third-party dependencies are necessary, understood, and well-maintained
+- [ ] Code is simple — no new abstraction without two or more call sites,
+      no new dependency without a documented reason
+- [ ] Numerical comparison gates (render-match scoring, calibration
+      tolerances, visual-regression diffs) lock the values they sample,
+      not the shape between samples — on render-producing pipelines
+      (charts, diagrams, illustrations) pair them with manual visual
+      review; a passing numerical gate is necessary, not sufficient
+
+## Structure audit
+
+A code review checks changed files. A structure audit checks project
+completeness. Run a structure audit after:
+
+- New project setup
+- Framework or stack migration
+- Adding a major layer (backend, CI/CD, infrastructure)
+- Before a release milestone
+
+Verify every MUST from:
+
+- `templates/base/core/docs.md` — standard documents (README, ONBOARDING,
+  PLAYBOOK, ADRs)
+- `templates/base/core/readme.md` — README has all 8 required sections
+- `templates/base/core/git.md` — .gitignore, README exist
+- The relevant frontend or backend layer template — required assets,
+  config files, SEO files
+- The relevant stack template — framework-specific files and conventions
+
+When a section contains multiple MUST sub-clauses, verify each sub-clause
+independently — do not pass the section as a whole. For example,
+`templates/base/core/readme.md` Usage requires both usage examples AND expected
+output
+per example — these are two separate checks.
+
+SHOULD also check:
+
+- No substantial duplication across sibling components — if two or more
+  components share the same code, extract a shared module
+
+## Deviations
+
+- Deviating from a SHOULD rule requires a written explanation in the pull
+  request
+- Deviating from a MUST rule requires explicit sign-off from a designated
+  approver before the change can land
+
+
 <!-- templates/base/security/security.md -->
 # Base — Application Security
 

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -13,7 +13,7 @@
 
 version: "1.0"
 
-core: [base-quality, base-git, base-docs, base-readme, base-testing]
+core: [base-quality, base-git, base-docs, base-readme, base-testing, base-review]
 
 base:
   - id: base-git


### PR DESCRIPTION
## Summary

`base-review` was registered in `manifest.yaml` but not in the `core:` tier and referenced by no stack's `depends_on` — yet the `agents.md` §5 skeleton universally hardcodes *"Follow templates/base/core/review.md priority order."* Any chain-resolved generation never loaded the review process while the generated §5 still pointed at it.

Resolution: **promote `base-review` into the core tier** (option 1 from the issue). §5 Review process is a mandatory section of every generated context file in all three models, so the review process is core by definition — same rationale as the other five core templates.

## Changes

- `templates/manifest.yaml` — `core:` tier is now six templates (+`base-review`)
- `docs/SPEC.md` — core-tier list updated (five → six); `review` removed from the orthogonal workflow set
- `generated/` — all 17 pre-resolved chains regenerated via `py tools/sync.py`

The issue's secondary question (whether `base-oop` belongs in library/service chains) is split out to a follow-up issue to keep one concern per PR.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new exact in-chain duplicates
- `py tools/sync.py --check` clean (chains regenerated in this PR)

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)