### PR TITLE
fix(templates): keep role-fixed §4 Identity placeholder, never omit (#710)

### DIFF
--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -111,8 +111,12 @@ checklist into a short bullet list: that silently drops steps and the
 "print and execute sequentially" enforcement, producing a thin wrap-up.]
 ```
 
-Omit sections that are not applicable to the project (e.g. omit section 4
-for a backend service, omit 3.2+ if only testing applies).
+Top-level sections 1–6 are role-fixed (§4 is always Identity, §5 is
+always Review) — never renumber and never omit them. A top-level
+section that does not apply keeps its numbered heading with a one-line
+`Not applicable — <reason>` body (e.g. §4 Identity for a backend
+service). Omit only non-applicable subsections (e.g. 3.2+ if only
+testing applies). This applies to all three models.
 
 ---
 


### PR DESCRIPTION
## Summary

`agents.md` said *"omit section 4 for a backend service"*, but all four service examples keep `## 4. Identity` with a `Not applicable` body. Since top-level section numbers are role-fixed (§5 is always Review), omitting §4 yields a `1, 2, 3, 5, 6` sequence that reads as a numbering bug.

Per the issue's recommendation, the convention now matches the examples: **keep the numbered heading with a one-line `Not applicable — <reason>` body; omit only non-applicable subsections.** Stated once, applying to all three models. No example changes needed — they already comply.

## Verification

- `py tests/run_smoke.py` — 23/23 pass

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)