### PR TITLE
fix(templates): README owns the directory map — ADR-020 (#716)

### DIFF
--- a/docs/decisions/020-structure-section-ownership.md
+++ b/docs/decisions/020-structure-section-ownership.md
@@ -1,0 +1,72 @@
+---
+id: "020"
+status: Accepted
+date: 2026-07-05
+category: templates
+supersedes: []
+superseded_by: []
+---
+
+# ADR-020: README owns the directory map
+
+## Context
+
+Two rules were in tension over who owns the "Project structure"
+section. The documentation standard declares `README.md` the single
+source of truth for project structure and forbids duplicating it in
+other documents. The canonical section structure for generated agent
+context files requires a Project structure section in every
+`CLAUDE.md` / `AGENTS.md`.
+
+A generated context file that satisfies the second rule with a
+directory tree violates the first, and the two copies drift. Observed
+downstream (demo-sensor-app): README and CLAUDE.md both carried a
+tree; the CLAUDE.md copy went stale — it labelled generated files
+"(to generate)" and missed later-added directories — while the README
+stayed current.
+
+## Decision
+
+1. **README owns the directory map** — the README "Project structure"
+   section is the only rendered directory map in a project. No other
+   document carries a second one.
+2. **The generated section is a pointer plus rules** — the Project
+   structure section of a generated `CLAUDE.md` / `AGENTS.md` MUST
+   reference the README "Project structure" section and MAY add
+   agent-facing placement rules (what belongs where, per-file content
+   requirements). It MUST NOT contain a second directory tree.
+3. **Stack templates keep their layout sections** — a stack template's
+   Project structure section describes the recommended layout for a
+   new project. It is generation-time input (it seeds the README and
+   scaffolding), not live project state, so it does not violate the
+   single-source-of-truth rule.
+
+## Alternatives considered
+
+- **Drop the Project-structure requirement from generated files** —
+  rejected; agents lose placement guidance and the section role
+  numbering stays fixed regardless.
+- **Keep both trees, add a non-drift rule (CLAUDE.md tree generated
+  from README)** — rejected; requires tooling no consumer project
+  has, and drift returns between regenerations.
+- **Placement rules only, without the README pointer** — rejected;
+  the agent is left without the location of the authoritative map.
+
+## Consequences
+
+- `templates/base/core/docs.md` "Single source of truth" names the
+  pointer-plus-rules pattern for agent context files.
+- `templates/base/core/agents.md` skeleton placeholders for section
+  1.2 are updated in all three models; the hybrid "what to inline"
+  entry scopes Project structure to placement rules.
+- Existing `examples/*/CLAUDE.md` still show inline trees. They are
+  standalone previews with no adjacent README to point at; they get
+  realigned at the next pipeline regeneration.
+- Downstream projects reduce their context-file structure sections to
+  a pointer plus placement rules.
+
+## Related
+
+- `templates/base/core/docs.md` — single source of truth section
+- `templates/base/core/agents.md` — output skeletons
+- ADR-017 — canonical stack-template section structure (context only)

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -645,6 +645,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents

--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -66,7 +66,9 @@ them*.
 ### 1.1 Overview
 [Stack template — Stack section]
 ### 1.2 Project structure
-[Stack template — architecture/structure sections]
+[Pointer to README "Project structure" + agent-specific placement
+rules — never a second directory tree (see docs.md, single source
+of truth)]
 ### 1.3 Commands
 [Stack template — Commands section]
 
@@ -146,7 +148,9 @@ Project-specific overrides and additions follow below.
 ### 1.1 Overview
 [Stack template — Stack section]
 ### 1.2 Project structure
-[Planned or actual directory tree]
+[Pointer to README "Project structure" + agent-specific placement
+rules — never a second directory tree (see docs.md, single source
+of truth)]
 ### 1.3 Commands
 [Stack template — Commands section]
 
@@ -201,8 +205,9 @@ than inline but safer than pure reference.
 
 - **Git conventions** — wrong branch names or commit formats pollute
   history and are hard to fix retroactively
-- **Project structure** — wrong file placement breaks builds and
-  confuses navigation
+- **Project structure placement rules** — wrong file placement breaks
+  builds and confuses navigation; the directory map itself stays in
+  README (see docs.md, single source of truth)
 - **Language-specific safety rules** — e.g. no `set:html`, no `any`,
   no raw SQL — violations introduce security or correctness bugs
 - **Content rules** — formatting, writing style, and structure that
@@ -243,7 +248,9 @@ Project-specific overrides and additions follow below.
 - Model: hybrid
 [IDENTITY answers: owner, repo URL, stack, hosting]
 ### 1.2 Project structure
-[Planned or actual directory tree]
+[Pointer to README "Project structure" + agent-specific placement
+rules — never a second directory tree (see docs.md, single source
+of truth)]
 ### 1.3 Commands
 [Stack template — Commands section]
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -19,6 +19,9 @@ levels. Every rule MUST use one of these words:
 
 - `README.md` is the single source of truth for project structure
 - Do not duplicate structure in other documents — reference `README.md` instead
+- Agent context files (`CLAUDE.md` / `AGENTS.md`) keep their Project
+  structure section as a pointer to the README section plus
+  agent-specific placement rules — never a second directory tree
 - No references to non-existent files, components, or services
 
 ## Standard documents


### PR DESCRIPTION
## Summary

Resolves the tension between two rules:

- `docs.md` §Single source of truth: README owns project structure; do not duplicate it elsewhere.
- Canonical section structure: every generated `CLAUDE.md` / `AGENTS.md` MUST contain a Project structure section.

A generated file satisfying the second with a directory tree violated the first, and the copies drifted (observed in demo-sensor-app: the CLAUDE.md tree went stale while README stayed current).

## Decision (ADR-020)

1. **README owns the directory map** — the only rendered tree/map in a project.
2. **The generated section is a pointer plus rules** — it MUST reference README's section, MAY add agent-facing placement rules, MUST NOT carry a second tree. (Issue options 1+2 combined, per its recommendation.)
3. **Stack templates keep their layout sections** — recommended layout is generation-time input that seeds the README; not live project state.

## Changes

- `docs/decisions/020-structure-section-ownership.md` — new ADR (schema-checked via `ADR-01`)
- `templates/base/core/docs.md` — SSOT section names the pointer-plus-rules pattern
- `templates/base/core/agents.md` — §1.2 placeholders updated in all three model skeletons; hybrid "what to inline" scopes structure to placement rules
- `generated/` — all 17 chains regenerated (docs.md is core)

**Examples**: left as-is deliberately — they are standalone previews with no adjacent README to point at; they realign at the next pipeline regeneration (#709, v3.0).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — clean after regeneration
- `py tools/audit_redundancy.py --check` — no new duplicates

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)