### PR TITLE
feat(templates): allow README project structure as a table (#713)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1074,8 +1074,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup
@@ -1132,6 +1135,7 @@ Every README MUST contain the following sections, in this order:
   README MUST be updated in the same PR
 - Sections that have not been updated in over six months SHOULD be reviewed
   for accuracy
+
 
 <!-- templates/base/core/testing.md -->
 # Base — Testing

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -51,8 +51,11 @@ Every README MUST contain the following sections, in this order:
 - If the project has multiple usage modes, each MUST have its own example
 
 ### 4. Project structure
-- MUST include a directory tree covering the top two levels
+- MUST map the directory structure covering the top two levels
 - Each entry MUST have a one-line description of its purpose
+- MAY be rendered as an indented directory tree or as a two-column
+  table (`Path` | `Purpose`) — a table renders consistently on GitHub
+  and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 
 ### 5. Development setup


### PR DESCRIPTION
## Summary

`base-readme` §4 *Project structure* read as prescribing an indented ASCII tree in a code block. This PR keeps the substantive rules (top two levels, one-line description per entry, omit generated directories) and permits either representation:

> MAY be rendered as an indented directory tree or as a two-column table (`Path` | `Purpose`)

The table renders consistently on GitHub, avoids alignment drift, and structurally enforces the one-line-description rule (one cell per entry). Went with the issue's primary proposal (MAY either) rather than the SHOULD-table variant — no reason to push existing tree READMEs to churn.

Builds on ADR-020 (#716): README is the only place the map lives, so the representation choice belongs here.

Also: fixed the missing trailing newline in `readme.md` (MD047).

## Changes

- `templates/base/core/readme.md` §4 — reworded first MUST, added the MAY bullet
- `generated/` — 17 chains regenerated (readme.md is core)

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)