### PR TITLE
feat(templates): harden quality-gates scope agreement (#704, #720)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2693,6 +2693,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -2716,6 +2733,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3402,6 +3402,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -3425,6 +3442,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3402,6 +3402,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -3425,6 +3442,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3402,6 +3402,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -3425,6 +3442,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1950,6 +1950,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -1973,6 +1990,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1950,6 +1950,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -1973,6 +1990,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1950,6 +1950,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -1973,6 +1990,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1950,6 +1950,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -1973,6 +1990,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2706,6 +2706,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -2729,6 +2746,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1950,6 +1950,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -1973,6 +1990,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3402,6 +3402,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -3425,6 +3442,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2693,6 +2693,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -2716,6 +2733,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -237,6 +237,23 @@ below close those gaps.
   byte sequences) MUST be excluded from the formatter — they must
   stay byte-for-byte, and reformatting them changes the test input
 
+### Formatter-vs-generator escalation
+
+When a generator (script, codegen, scaffolder) emits a file into a
+directory that a commit-time formatter (prettier, black, gofmt) walks,
+three things MUST hold together:
+
+- The emitted path MUST appear in the formatter's ignore list
+  (`.prettierignore`, black `force-exclude`, or equivalent)
+- A CI staleness gate (`<generator> --check`) MUST run on the same
+  paths (see `quality-gates-staleness`)
+- Both MUST land in the same PR — the ignore line without the gate,
+  or the gate without the ignore line, leaves silent drift
+
+Without all three, the formatter mutates generator output between
+commits and the generator's `--check` fails on a clean checkout — so
+the staleness gate cannot even be wired into CI.
+
 ### Skipped is not passed
 
 - When a code-touching change would skip the build job via a
@@ -260,6 +277,23 @@ below close those gaps.
 - When the deploy workflow runs `validate` (or equivalent) on every
   push to main, the PR workflow MUST run the same `validate` on
   every PR, regardless of which paths changed
+
+### Mirror cross-cutting checks with an always-run job
+
+When the deploy gate runs a deterministic check over a broader file
+set than any PR job's path-filter (a formatter or linter over all
+tracked files), mirror it on PRs with a dedicated always-run job —
+not by widening an existing filter:
+
+- A path-filter must enumerate every input the check reads; the next
+  omitted path silently reopens the mirror gap. An always-run job is
+  enumeration-free
+- Keep output-measuring and language-scoped jobs (build, e2e, perf,
+  per-language tests) path-filtered — promote only the cross-cutting
+  deterministic step to always-run
+- This complements `quality-gates-skip-equivalent`: skip noisy output
+  gates on PRs that provably cannot affect them; always run
+  deterministic cross-cutting gates
 
 ### Green CI does not prove environment independence
 


### PR DESCRIPTION
## Summary

Two refinements to `quality-gates-scope-agreement`, both from downstream incidents where the abstract rule was right but didn't steer the reader to the robust fix.

**Formatter-vs-generator escalation (#704)** — new subsection under the ignore-lists rule. When a generator emits a file into a directory a commit-time formatter walks, three things MUST hold together: the emitted path in the formatter's ignore list, a `--check` staleness gate on the same paths, and both landing in the same PR. Source: wuseria#1336 (prettier reformatted `scaffold_anchor_helpers` output; `--check` then failed on a clean checkout; 6 files affected before caught).

**Always-run job over a wider filter (#720)** — new subsection after "PR gate MUST mirror the deploy gate". A deterministic deploy-side check over all tracked files is mirrored on PRs with a dedicated always-run job; a path-filter must enumerate every input and the next omitted path silently reopens the gap. States the distinction from `quality-gates-skip-equivalent` (skip noisy output gates; always run deterministic cross-cutting ones). Source: docs-only PR skipped the `build` job, merged green, broke the main deploy at `prettier --check` (downstream ADR-076).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates
- `generated/` chains regenerated

Closes #704, closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)