### PR TITLE
feat(templates): gate cognitive complexity with a ratchet (#722)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2580,6 +2580,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2875,8 +2897,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3289,6 +3289,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -3584,8 +3606,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3289,6 +3289,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -3584,8 +3606,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3289,6 +3289,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -3584,8 +3606,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1837,6 +1837,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2132,8 +2154,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1837,6 +1837,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2132,8 +2154,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1837,6 +1837,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2132,8 +2154,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1837,6 +1837,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2132,8 +2154,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2593,6 +2593,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2888,8 +2910,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1837,6 +1837,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2132,8 +2154,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3289,6 +3289,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -3584,8 +3606,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2580,6 +2580,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -2875,8 +2897,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -124,6 +124,28 @@ Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 
 ---
 
+## Complexity gates
+
+[ID: quality-gates-complexity]
+
+- Complexity gates SHOULD measure cognitive complexity (nesting plus
+  control-flow interruptions) rather than only McCabe branch counts.
+  The two metrics genuinely disagree in practice: McCabe flags flat,
+  linear section emitters while passing deeply nested logic — the
+  opposite of what a readability standard is after
+- Tools: `complexipy` for Python (ruff has no cognitive-complexity
+  rule); `eslint-plugin-sonarjs` for TypeScript/JavaScript (see
+  Recommended lint plugins)
+- Retrofit onto an existing codebase via a ratchet: commit a baseline
+  that freezes current offenders at their recorded values; CI fails
+  only when an over-threshold function is new or has increased. The
+  gate turns on from day one with zero up-front refactoring, and the
+  baseline doubles as a measured refactor priority list
+- Pin the tool version when the baseline file format is
+  version-sensitive
+
+---
+
 ## Skip noisy gates when input is unchanged
 
 [ID: quality-gates-skip-equivalent]
@@ -419,8 +441,9 @@ records and asserts Y-equality across them.
 
 - **Docstring coverage for non-public functions** — enforcing docs on
   internal helpers creates busywork
-- **Cyclomatic complexity thresholds** — too many false positives on
-  legitimate complex logic; rely on lint warnings instead
+- **Cyclomatic (McCabe) complexity as a hard gate** — too many false
+  positives on legitimate complex logic; gate cognitive complexity
+  with a ratchet instead (see `quality-gates-complexity`)
 - **100% test coverage** — incentivizes meaningless tests; 80% is the
   practical sweet spot
 - **Commit message format** — enforce in PR title via repository settings,


### PR DESCRIPTION
## Summary

Adds a `quality-gates-complexity` section: complexity gates SHOULD measure **cognitive complexity** (nesting + control-flow interruptions), not only McCabe branch counts — the two metrics genuinely disagree (corrosim ADR 0013: worst cognitive offender at 47 was C901-clean; a C901-noqa'd 'linear' function measured cognitive 26).

Rules added:
- Tool guidance: `complexipy` for Python (ruff has no cognitive rule), `eslint-plugin-sonarjs` for TS/JS (already the recommended lint plugin)
- **Ratchet adoption** for existing codebases: committed baseline freezes current offenders; CI fails only on new/increased — gate turns on day one, baseline doubles as a refactor priority list
- Pin the tool version when the baseline format is version-sensitive

The "What NOT to gate" bullet is reworded from a blanket complexity-threshold exclusion to specifically McCabe-as-hard-gate, pointing at the new section.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)