### PR TITLE
feat(templates): periodic whole-tree audit for dup/dead-code (#723)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2907,6 +2907,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3616,6 +3616,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3616,6 +3616,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3616,6 +3616,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2164,6 +2164,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2164,6 +2164,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2164,6 +2164,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2164,6 +2164,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2920,6 +2920,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2164,6 +2164,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3616,6 +3616,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2907,6 +2907,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -451,6 +451,29 @@ records and asserts Y-equality across them.
 
 ---
 
+## Periodic whole-tree audits
+
+[ID: quality-gates-tree-audit]
+
+Duplication and dead code are review-time rules, but a reviewer sees
+the diff — and the twin of a pasted block usually lives outside the
+diff. A rule whose violations are invisible in a diff needs a
+scheduled whole-tree sweep, not a per-change gate.
+
+- Duplication and dead-code detectors (pylint duplicate-code, jscpd,
+  vulture) MUST NOT run as per-PR CI gates when the tree measures
+  clean — both tool classes false-positive on legitimate patterns
+  (look-alike scientific/CLI boilerplate for duplication,
+  intentionally unused API parameters for dead code), so a per-PR
+  gate means maintaining suppression lists forever to guard nothing
+- Run them as a documented periodic whole-tree audit instead: record
+  the exact commands and the last-run result in `docs/PLAYBOOK.md`,
+  and run at epic boundaries and release points
+- File audit findings as tickets rather than fixing on the spot —
+  the audit is a discovery pass, not a change PR
+
+---
+
 ## Tool constraints
 
 [ID: quality-gates-constraints]


### PR DESCRIPTION
## Summary

Adds a `quality-gates-tree-audit` section answering WHERE duplication/dead-code tooling runs (quality.md already owns the rules themselves):

- **Not a per-PR CI gate** when the tree measures clean — pylint duplicate-code / jscpd / vulture false-positive on legitimate patterns, so a gate means maintaining suppression lists forever to guard nothing
- **Names the review blind spot** — diff-scoped review cannot enforce DRY across files; the twin of a pasted block lives outside the diff
- **Documented periodic whole-tree audit** — exact commands + last-run result recorded in `docs/PLAYBOOK.md`, run at epic boundaries and release points, findings filed as tickets (discovery pass, not a change PR)

Reusable principle stated: rules whose violations are invisible in a diff need a scheduled whole-tree sweep, not a per-change gate.

Downstream instance: corrosim PLAYBOOK §3.8 (braboj/corrosim#98).

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)