### PR TITLE
feat(templates): bidirectional-artifact caveat for regeneration (#718)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -432,6 +432,14 @@ maintainer time on phantom fixes.
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -37,6 +37,14 @@
     >100 files), the PR MUST open a tracked follow-up issue AND state
     the STALE accounting explicitly (N files affected, named or
     globbed) — silent staleness is the failure mode
+  - This rule applies to one-directional (source → artifact)
+    derivations only. An artifact that also serves as, or feeds, the
+    source of truth is bidirectional — the tell is an `--apply` or
+    ingest step that reads the artifact back into the source. Do NOT
+    auto-regenerate a bidirectional artifact from the pipeline it
+    feeds: regeneration overwrites human-verified values. Refresh it
+    only through the human-in-the-loop step that owns it, and flag
+    the staleness explicitly instead
 - **Before merging**, review the diff against the base branch. Follow
   `templates/base/core/review.md` priority order: security → correctness →
   clarity →


### PR DESCRIPTION
## Summary

The git.md rule *"Regenerate derived artifacts in the same PR"* assumes a one-directional source → artifact pipeline. It breaks on **bidirectional artifacts** — generated from a source AND themselves the human-authored ground truth that feeds back into it.

Caveat added as a sub-bullet under the existing rule:
- Scopes the regenerate rule to one-directional derivations
- Gives the one-line tell: an `--apply`/ingest step reads the artifact back into the source
- Do NOT auto-regenerate from the pipeline the artifact feeds — regeneration overwrites human-verified values; refresh only through the human-in-the-loop step that owns it, and flag staleness explicitly

Source incident: wuseria S201 / #1359 review — an extractor bug fix would have flipped a maintainer-accepted `eye-read.md` cell and desynced applied ground truth in `charts.py`; the correct move was to not regenerate.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates
- `generated/` chains regenerated (git.md is core)

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)