### PR TITLE
feat(templates): audit path-based excludes on src/ adoption (#719)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3699,6 +3699,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3699,6 +3699,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3699,6 +3699,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3003,6 +3003,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2247,6 +2247,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3699,6 +3699,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -37,6 +37,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- When adopting `src/` or adding a sub-package, audit every path-based
+  exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
+  ruff `extend-exclude`) for patterns that now match new package
+  directories, and anchor them (`"./name"`). Verify by comparing
+  scanned-file counts before and after — a colliding pattern silently
+  drops a whole sub-package from the scan while CI stays green
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 


### PR DESCRIPTION
## Summary

`python-lib.md` recommends the `src/` layout but didn't warn about the exclude-pattern collision: after the move (or when adding a sub-package), an unanchored path-based exclude in a tool config can match a new package directory and silently drop it from scanning.

Concrete downstream case (corrosim src/ migration, braboj/corrosim#78 / PR #81): `[tool.bandit] exclude_dirs = [..., "report"]` meant the root-level report bundle; after the migration created `src/corrosim/report/`, bandit silently excluded the whole sub-package from SAST — **2357 vs 4312 LOC scanned, CI green**. Fix was anchoring (`"./report"`).

New bullet under `python-lib-structure`: audit every path-based exclude (bandit `exclude_dirs`, coverage `omit`, ruff `extend-exclude`) for collisions, anchor them (`"./name"`), and verify by comparing scanned-file counts before/after.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — no new duplicates

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)