### PR TITLE
feat(templates): pair the LF rule with a .gitattributes mechanism (#751)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -325,6 +325,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -319,6 +319,13 @@ maintainer time on phantom fixes.
 - Commit an `.editorconfig` file at the project root — enforces indent
   style, indent size, line endings, charset, and trailing whitespace
   across all editors without tool-specific config
+- Commit a `.gitattributes` at the project root with `* text=auto`
+  (add `eol=lf` where the project wants hard LF) — the git-side
+  guarantee that no CRLF is committed, covering files written by any
+  tool, editor, or contributor without an EditorConfig plugin.
+  EditorConfig normalizes editor-side only; `.gitattributes` enforces
+  the LF rule at commit and checkout. Verify with `git ls-files --eol`
+  — no committed file reports `i/crlf`
 - Prefer self-documenting code — if a comment feels necessary, treat it as a
   signal that the code needs restructuring before the comment is added
 - Add comments only where the intent cannot be expressed in code


### PR DESCRIPTION
Closes #751.

## What
`quality.md` mandated `Line endings MUST be LF` but named only EditorConfig — which normalizes editor-side and does nothing for files written by tools or contributors without the plugin. This adds `.gitattributes` (`* text=auto`, `eol=lf`) as the git-side commit/checkout guarantee.

## Why
Satisfies the file's own `quality-gates-pair-check` discipline: a mechanically checkable constraint must name its enforcement mechanism. Observed downstream (corrosim CRLF/LF churn on Windows), fixed only by a `.gitattributes` the templates never prescribed.

## Check
Names `git ls-files --eol` as the verification (no committed file reports `i/crlf`).

Smoke: 23/23. `generated/` regenerated (quality.md is core-tier → all 17 chains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)