### PR TITLE
feat(templates): scope coverage denominator to CI-runnable surface (#756)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2590,6 +2590,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3299,6 +3299,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3299,6 +3299,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3299,6 +3299,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1847,6 +1847,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1847,6 +1847,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1847,6 +1847,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1847,6 +1847,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2603,6 +2603,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1847,6 +1847,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3299,6 +3299,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2590,6 +2590,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -119,6 +119,18 @@ When a dependency bump adds a lint rule that flags existing source:
 - **Legacy projects** — coverage reported as warning only; CI shows the
   number but never blocks; flip to error when the team has the mandate
   to invest in testing
+- **Un-runnable code** — omit modules that genuinely cannot execute in
+  CI (native extensions, GPU paths, container-only code with no wheels
+  on the runner) from the coverage denominator, and validate them
+  out-of-band (a separate suite, integration environment, or tracked
+  artifacts). Scoping the denominator keeps the gate honest at 80%
+  instead of dropping the bar to a meaningless number that lets
+  permanently-un-runnable code drag the percentage down as dead weight
+- **Omit-list is a contract** — a new pure module is in scope by
+  default and MUST be tested; adding a module to the omit-list is a
+  reviewable decision, never a silent escape. This is the coverage
+  analogue of the complexity ratchet (see `quality-gates-complexity`):
+  make a partial codebase's gate honest without lowering the bar
 
 Stack templates MAY add additional thresholds (e.g. Lighthouse scores).
 


### PR DESCRIPTION
Closes #756.

## What
Adds two bullets to the Coverage policy in `quality-gates.md`: omit genuinely un-runnable modules (native extensions, GPU, container-only) from the coverage denominator and validate them out-of-band; treat the omit-list as a reviewable contract.

## Why
A flat 80% over the whole package becomes meaningless the moment part of the code physically cannot run in CI — forcing either a lowered global bar or dead-weight drag. Observed downstream (python-lib chain, Docker-only engine layer sat at ~48% global vs 90–100% on pure modules). Framed as the coverage analogue of the existing complexity ratchet.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)