### PR TITLE
feat(templates): add in-process config model to config.md (#754)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -2389,6 +2389,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1698,6 +1698,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1698,6 +1698,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1646,6 +1646,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -2389,6 +2389,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base

--- a/templates/base/core/config.md
+++ b/templates/base/core/config.md
@@ -41,6 +41,29 @@ Sources override in this order (highest wins):
 - Never let a lower-priority source silently override a
   higher-priority one
 
+## In-process config model
+
+For a library or CLI whose run configuration is an in-process object
+with named presets — build profiles, dataset variants, run modes — not
+an environment, model it explicitly instead of re-declaring the same
+inputs inside each command. This composes with 12-factor: env vars wire
+deployment and secrets; the in-process object holds one run's inputs.
+
+- **Frozen object** — bundle all inputs for one run in an immutable
+  record (frozen dataclass, readonly struct); each default carries its
+  rationale in place, so a preset's diff reads as intent
+- **Registry** — map names (and aliases) to instances; look up
+  case-insensitively and raise on a miss, listing the known keys
+- **Unset-means-default resolution** — CLI flags default to a
+  null/sentinel, and a shared resolver backfills each unset field from
+  the selected preset while an explicit value always wins. This
+  separates "user said nothing" from "user said this" — never default a
+  flag to the preset value directly, or the two become indistinguishable
+- **Derive layout from the object** — compute paths as properties
+  (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
+  accessor hands callers a mutable copy so they cannot mutate the shared
+  frozen object
+
 ## Build-time vs runtime config
 
 - **Build-time** — values baked into the artifact at build (API base


### PR DESCRIPTION
Closes #754.

## What
Adds an "In-process config model" section to `config.md`: a frozen config object bundling one run's inputs, a name→instance registry with case-insensitive lookup, unset-means-default resolution (flags default to a sentinel; a shared resolver backfills from the selected preset; explicit values win), and deriving layout from the object.

## Why
`config.md` treated config exclusively as 12-factor env vars. Every CLI with run profiles/modes reinvents the in-process shape, usually by re-declaring the same inputs in each command. This composes with the env-var guidance — env wires deployment/secrets, the object holds a run's inputs — it does not replace it.

Smoke: 23/23. `generated/` regenerated (15 stacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)