### PR TITLE
feat(templates): AST meta-test for the public-API contract (#758)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1478,6 +1478,34 @@ two.
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
 
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -322,3 +322,31 @@ two.
 - File as one issue, not two — a fix on the shared code resolves both
 - If the inputs are genuinely independent with no shared upstream, the
   collision itself is the bug worth flagging
+
+---
+
+## Enforce the public-API contract with an AST meta-test
+[ID: testing-ast-contract]
+
+A blanket annotation linter rule (e.g. ruff `ANN`) forces `Any` and
+noise onto private helpers that legitimately take un-stubbed third-party
+objects, so teams either over-lint or let the "every public function
+carries full type hints and a documented docstring" contract drift.
+Split the rule: the linter owns format and complexity; a test owns the
+*presence* of annotations and docstring sections on the public surface
+only.
+
+- Parse each module with the language's AST (Python `ast`, TypeScript
+  via the compiler API, Go `go/ast`) and filter the public defs:
+  top-level non-underscore functions plus public methods of public
+  classes
+- Assert every parameter (except `self`/`cls`) and the return is
+  annotated, that param'd defs carry an `Args:` section, and that
+  value-returning defs carry `Returns:`. Emit failures as
+  `file:line name(param)` so each is self-documenting
+- Roll out behind an allowlist inside the test: sweep module by module
+  and flip the global gate last, so no PR is a big-bang unreviewable
+  sweep
+- The same AST/token pass cheaply enforces adjacent rules a linter has
+  no rule for — a comment trailing code on the right, a ticket/PR/ADR
+  number embedded in a comment — reusing one traversal


### PR DESCRIPTION
Closes #758.

## What
Adds an "Enforce the public-API contract with an AST meta-test" section to `testing.md`: parse each module with the language's AST (Python `ast`, TS compiler API, Go `go/ast`), filter the public defs, and assert annotations + `Args:`/`Returns:` presence — with a module-by-module allowlist rollout.

## Why
A blanket annotation linter rule forces `Any` and noise onto private helpers taking un-stubbed third-party objects, so teams over-lint or let the contract drift. Splitting format/complexity (linter) from presence-on-the-public-surface (test) is the strongest "enforce what the linter can't" technique; the same traversal cheaply enforces adjacent comment-hygiene rules.

Smoke: 23/23. `generated/` regenerated (testing.md is core-tier → all chains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)