### PR TITLE
feat(templates): drift-guard meta-tests in testing.md (#763)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1506,6 +1506,34 @@ only.
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
 
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -350,3 +350,31 @@ only.
 - The same AST/token pass cheaply enforces adjacent rules a linter has
   no rule for — a comment trailing code on the right, a ticket/PR/ADR
   number embedded in a comment — reusing one traversal
+
+---
+
+## Drift-guard meta-tests pin a duplicated fact to its source
+[ID: testing-drift-guard]
+
+Single-source-of-truth is the goal, but some facts unavoidably live in
+two places: a hand-authored contract file and the code that implements
+it, a documented limit and the constant that enforces it, a version
+string reported at runtime and the package metadata. Without a guard the
+copies drift silently — the exact failure single-source is meant to
+prevent. Any fact represented twice gets a test that fails when the
+copies diverge, introspecting the live artifact rather than hardcoding
+the expected value.
+
+- **Constant vs contract** — assert the documented limit in the spec
+  file equals the code constant that enforces it
+- **Route coverage** — introspect the router (Flask `url_map`, Express
+  router stack, Go mux) and assert every live route appears in the
+  contract document, so a new or renamed endpoint left undocumented
+  fails CI with no human diff review
+- **Version parity** — assert the version reported at runtime equals the
+  installed package metadata, and that the contract's own version field
+  is present
+- Prefer introspection so the test cannot itself drift, and keep the
+  guard one-directional: assert the derived copy matches the source of
+  truth, not the reverse. Complements the AST contract test
+  (`testing-ast-contract`) in the "enforce what the linter can't" family


### PR DESCRIPTION
Closes #763.

## What
Adds a "Drift-guard meta-tests" section to `testing.md`: any fact represented in two places gets a test that fails when the copies diverge, by introspecting the live artifact rather than hardcoding the expected value. Instances: constant-vs-contract, route coverage (introspect the router), version parity.

## Why
`docs.md`/`agents.md` preach single-source-of-truth but say nothing about the unavoidable dual-copy case (contract + code, limit + constant, runtime version + metadata). Introspection keeps the test itself from drifting; one-directional guarding pins the derived copy to the source. Complements the AST contract test (#758) in the "enforce what the linter can't" family.

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)