### PR TITLE
feat(templates): require full-history secret scanning (#759)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2892,6 +2892,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3140,6 +3140,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2892,6 +2892,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2892,6 +2892,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3678,6 +3678,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3678,6 +3678,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3328,6 +3328,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3364,6 +3364,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3140,6 +3140,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2892,6 +2892,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -46,6 +46,12 @@ not after deployment.
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,
   or API keys MUST be rejected automatically
+- The scan MUST cover the full git history, not just the current tip: a
+  secret committed and later deleted still lives in old commits, so a
+  shallow checkout gives a false sense of safety. Check out full-depth
+  before the scan (`actions/checkout` with `fetch-depth: 0`)
+- Run the scanner both in CI (full history) and as a pre-commit hook
+  (catch it before it is ever committed) — defense in depth
 - Sensitive values MUST NOT appear in any artefact that enters source control —
   this includes commit messages, issue comments, and documentation files
 - Runtime secrets MUST be fetched from a dedicated vault at startup — MUST NOT

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -134,6 +134,10 @@ gate categories to GitHub Actions workflows and GitHub-native features.
   workflow authoring rules) to avoid the paywall.
 - Both SHOULD be enabled — push protection catches on push, gitleaks
   catches in PR validation
+- The gitleaks job MUST check out full history (`actions/checkout` with
+  `fetch-depth: 0`) — the default shallow checkout scans only the tip,
+  missing a secret that was committed and later deleted but still lives
+  in old commits
 
 ---
 


### PR DESCRIPTION
Closes #759.

## What
Pairs the "run a secret scanner" rule with its enforcement detail in both `devsecops.md` (Secret detection) and `platform/github.md` (gitleaks job): full-depth checkout (`actions/checkout` with `fetch-depth: 0`) before the scan, plus a CI + pre-commit defense-in-depth recommendation.

## Why
A secret committed and later deleted persists in old commits; a shallow-checkout scan of only the tip misses it — the mandate can be satisfied by an ineffective scan. Same pair-check discipline as #751: a security MUST must name its enforcement mechanism.

Smoke: 23/23. `generated/` regenerated (devsecops.md is in-chain; platform/github.md is orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)