### PR TITLE
feat(templates): split security scanning by actionability (#762)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2432,8 +2432,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -2887,6 +2888,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2680,8 +2680,9 @@ Apply SOLID at the class, module, and service level:
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -3135,6 +3136,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2432,8 +2432,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -2887,6 +2888,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2432,8 +2432,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -2887,6 +2888,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3134,8 +3134,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -3673,6 +3674,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3134,8 +3134,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -3673,6 +3674,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3324,6 +3324,29 @@ not after deployment.
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
+
 ## Secret detection
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3360,6 +3360,29 @@ not after deployment.
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
+
 ## Secret detection
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2680,8 +2680,9 @@ Apply SOLID at the class, module, and service level:
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -3135,6 +3136,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2432,8 +2432,9 @@ every project regardless of language or framework.
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly
@@ -2887,6 +2888,29 @@ not after deployment.
   erases the release — the scan job reaches forward to the release,
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
+
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
 
 ## Secret detection
 

--- a/templates/base/infra/containers.md
+++ b/templates/base/infra/containers.md
@@ -30,8 +30,9 @@
 
 ## Image hygiene
 - Scan all images for vulnerabilities in CI before pushing to a registry
-- Never push an image with critical or high vulnerabilities to staging or
-  production
+- Never push an image with **fixable** critical or high vulnerabilities
+  to staging or production — an unfixable upstream or base-layer CVE is
+  advisory (publish it with an SBOM), not a release blocker
 - Tag images with the git commit SHA or release version — never rely on
   mutable tags in staging or production
 - Remove unused images from the registry regularly

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -42,6 +42,29 @@ not after deployment.
   never the reverse. Needs `contents: write` at job scope
 - Dependencies with unacceptable licenses MUST NOT be merged
 
+## Scan by actionability
+
+The block-vs-inform decision turns on one question: can I fix this
+before release? A finding you own has a fix you can apply; a finding in
+a base layer you do not control does not.
+
+- **Gate (blocking) on findings you own** — SCA over your own
+  dependencies (`pip-audit`, `npm audit`, `govulncheck`). A vulnerable
+  dependency has a fix you can apply, so it MUST block the merge
+- **Inform (advisory) on findings you cannot fix at will** — image and
+  base-layer scans (Trivy, Grype). Run them and publish the report plus
+  an SBOM, but do not fail the build on an unfixable upstream CVE
+  (`continue-on-error` plus a non-failing exit code)
+- **Advisory by construction for release-gated scans** — a scan that
+  runs only on a tag or release job cannot be dry-run on a PR, so a
+  hard fail first surfaces mid-release. Keep such scans advisory and
+  OFF the deploy dependency path, so an image hiccup cannot block the
+  deploy or erase the release record
+- **Make the fixable-base case a PR, not a standing advisory** — track
+  the base image with a dependency bot (docker ecosystem) so an
+  available base bump arrives as a reviewable PR, not a perpetual
+  scan finding
+
 ## Secret detection
 
 - Secret detection MUST run in CI — any commit containing credentials, tokens,


### PR DESCRIPTION
Closes #762.

## What
- `devsecops.md`: new "Scan by actionability" section — gate (blocking) on findings you own (SCA over your deps), inform (advisory) on findings you can't fix at will (image/base-layer scans), advisory-by-construction for release-gated scans, and route the fixable-base case through a dependency-bot PR.
- `containers.md`: reconcile "never push with high/critical" → "no **fixable** high/critical"; unfixable upstream CVEs are advisory.

## Why
The old blanket rules block every release for a base-layer CVE the project can't patch and contradict each other for the unfixable case. The single question "can I fix this before release?" decides block vs inform.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)