### PR TITLE
feat(templates): require runtime version coherence (#768)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2439,6 +2439,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2687,6 +2687,25 @@ Apply SOLID at the class, module, and service level:
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2439,6 +2439,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2439,6 +2439,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3141,6 +3141,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3141,6 +3141,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2687,6 +2687,25 @@ Apply SOLID at the class, module, and service level:
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2439,6 +2439,25 @@ every project regardless of language or framework.
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/templates/base/infra/containers.md
+++ b/templates/base/infra/containers.md
@@ -37,6 +37,25 @@
   mutable tags in staging or production
 - Remove unused images from the registry regularly
 
+## Runtime version coherence
+
+Pinning the base image (above), the CI runtime, the type-checker target,
+and the packaging floor are four separate loci for the SAME runtime
+version. Pin them independently and a base-image-only bump — often a
+lone dependency-bot PR — ships an image on the new runtime while every
+gate still validates the old one: the gates go green and an untested
+runtime ships.
+
+- The language / runtime version MUST be identical across the container
+  base image tag or digest, every CI job that sets up the runtime, the
+  static type-checker's target version, and the packaging metadata floor
+  (`requires-python`, `engines`, equivalent)
+- Move it in one coordinated change; reject an isolated base-image bump
+  that leaves the gates behind — what is tested MUST be what ships
+- One exception, documented inline: a formatter or linter `target-version`
+  MAY trail one minor as a style floor when the newer target introduces
+  a confusing auto-rewrite
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production


### PR DESCRIPTION
Closes #768.

## What
Adds a "Runtime version coherence" section to `containers.md`: the language/runtime version MUST be identical across the container base image, every CI job, the type-checker target, and the packaging floor (`requires-python`/`engines`) — moved in one coordinated change. Documents the one allowed exception (a formatter/linter `target-version` may trail one minor as a style floor).

## Why
Each template pins ONE locus independently; none require them equal. A base-image-only bump then ships an image on the new runtime while the CI jobs, type-checker, and packaging metadata all still validate the old one — gates green, untested runtime shipped. "What is tested must be what ships."

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)