### PR TITLE
feat(templates): fan-in gate mechanism for platform/github.md (#769)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -79,6 +79,30 @@ gate categories to GitHub Actions workflows and GitHub-native features.
   - An in-run retry with short backoff covers a single-hit flake,
     not a sustained backend outage — for a multi-minute incident the
     right response is wait-and-rerun, not more attempts
+- **Fan out one gate per job, fan in a single required check.** Run
+  each quality gate as its own job (lint, type-check, test, build, e2e,
+  scan) so each fails fast and reports independently, then make ONE
+  `gate` job the sole required branch-protection context. The `gate`
+  job runs `if: always()` and fails unless EVERY upstream result is
+  exactly `success` — treating `skipped` and `cancelled` as failure,
+  not just `failure`. This is the concrete encoding the "skipped is not
+  passed" rule demands: a fan-in that checks only for `failure` lets a
+  skipped required gate slip through as a pass.
+
+  ```yaml
+  gate:
+    needs: [lint, type-check, test, build, e2e, scan]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          for r in ${{ join(needs.*.result, ' ') }}; do
+            if [ "$r" != "success" ]; then
+              echo "a required gate did not succeed" >&2
+              exit 1
+            fi
+          done
+  ```
 
 ---
 


### PR DESCRIPTION
Closes #769.

## What
Adds the concrete fan-out/fan-in wiring to the CI section of `platform/github.md`: one quality gate per job, then a single `gate` job (`if: always()`, loops `needs.*.result`) as the sole required branch-protection context that fails unless every upstream result is exactly `success` — treating `skipped` and `cancelled` as failure, not just `failure`.

## Why
`quality-gates.md` names the "skipped is not passed" anti-pattern and `cicd.md` mentions fan-in, but neither gives the wiring. Teams left to implement it write a fan-in that checks only for `failure`, letting a skipped required gate slip through as a pass. This is the GitHub-Actions encoding the rule demands (platform layer is the home).

Smoke: 23/23. No `generated/` change (platform layer is orthogonal to stack chains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)