### PR TITLE
feat(templates): least-privilege workflow permissions (#770)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -15,6 +15,25 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 - Pipeline definitions: `.github/workflows/*.yml`
 - Trigger: `on: pull_request` for validation, `on: push` for main branch
 - Actions marketplace for reusable steps
+- **Least-privilege token scope.** Set the workflow-level `permissions:`
+  to `contents: read` by default and grant a write scope ONLY on the
+  specific job that needs it (release creation, artifact/asset attach),
+  at job level. A single compromised step in a blanket-write workflow
+  can do real damage; a read-only default contains it. Keep a scan that
+  needs an elevated scope in its OWN workflow — SAST that writes
+  findings needs `security-events: write`, and isolating it means that
+  scope never rides along with the main CI jobs. Prefer pipeline-as-code
+  (a committed workflow file) over a platform default-setup toggle, so
+  the scoped permission is reviewed and version-controlled.
+
+  ```yaml
+  permissions:
+    contents: read          # workflow-level default
+  jobs:
+    release:
+      permissions:
+        contents: write     # only where needed
+  ```
 - **Authenticate GitHub API calls**, even for public-data reads. Any
   `api.github.com` call in a workflow MUST send
   `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}`. Unauthenticated


### PR DESCRIPTION
Closes #770.

## What
Adds a least-privilege permissions rule to the CI section of `platform/github.md`: workflow-level `permissions: contents: read` by default, write granted only on the specific job that needs it (release/asset attach), and an elevated-scope scan (SAST needing `security-events: write`) isolated in its own workflow. Includes the `permissions:` block snippet and prefers pipeline-as-code over the platform default-setup toggle.

## Why
`360.md` lists "permissions scoped to minimum required" as a checkbox but gives no mechanism. Default CI tokens are broad; a single compromised step in a blanket-write workflow can do real damage. Isolating the elevated-permission job keeps that scope off the main CI jobs.

Smoke: 23/23. No `generated/` change (platform layer is orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)