### PR TITLE
feat(templates): add class-restraint guidance to oop.md (#739)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2099,6 +2099,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2615,6 +2615,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2099,6 +2099,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2099,6 +2099,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2801,6 +2801,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2801,6 +2801,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2615,6 +2615,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2099,6 +2099,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —

--- a/templates/base/core/oop.md
+++ b/templates/base/core/oop.md
@@ -35,6 +35,27 @@ Apply SOLID at the class, module, and service level:
   forces clarifying asides; when the layering and the name disagree, rename
   to match the layer
 
+## When not to reach for a class
+[ID: base-oop-restraint]
+
+SOLID and the patterns above bias toward classes; this is the
+counterweight. Reach for a class to encapsulate state, not to house
+stateless logic.
+
+- **Prefer a free function for stateless logic** — introduce a class
+  only to encapsulate state or attach behaviour to state it owns. A pure
+  transform (inputs → output, no retained state) stays a function; a
+  class only couples it to state it does not use
+- **A class whose only public method is `run()` / `execute()` is usually
+  a function in disguise** — keep the free function unless the retained
+  state genuinely warrants an object
+- **Put state-mutating behaviour on the object that owns the state** —
+  avoid the anemic model where an external function mutates a data bag;
+  this is the active-voice complement of "encapsulate state, expose
+  behaviour" above
+- **Construct through factory classmethods or named constructors** rather
+  than free `build_*` / `init_*` functions that return the type
+
 ## Design patterns
 
 - Apply established **GoF design patterns** where they fit the problem —


### PR DESCRIPTION
Closes #739.

## What
Adds a "When not to reach for a class" section to `oop.md`: prefer free functions for stateless logic, treat a `run()`/`execute()`-only class as a function in disguise, put state-mutating behaviour on the object that owns the state (cure the anemic model), and construct via factory classmethods.

## Why
`oop.md` was entirely pro-OOP (apply SOLID, prefer composition, name the pattern) with no counterweight — biasing an agent toward over-abstraction. This gives the balance a good reviewer applies. Language-agnostic design judgement; surfaced refactoring a numerical pipeline downstream (corrosim).

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)