### PR TITLE
feat(templates): characterization-fingerprint refactor proof (#740)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1534,6 +1534,31 @@ the expected value.
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
 
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -378,3 +378,28 @@ the expected value.
   guard one-directional: assert the derived copy matches the source of
   truth, not the reverse. Complements the AST contract test
   (`testing-ast-contract`) in the "enforce what the linter can't" family
+
+---
+
+## Prove a behaviour-preserving refactor with a fingerprint
+[ID: testing-characterization-fingerprint]
+
+When a refactor changes structure but is meant to leave output
+unchanged, "I didn't mean to change it" is not proof — a reordered dict,
+a 1-ULP float shift, or a changed RNG draw order silently perturbs a
+large output that unit tests check only in the small. Extend the
+ground-truth comparison (`testing-shared-path-breadth`) to the whole
+output:
+
+- **Fingerprint the full output before, reproduce and diff after** —
+  reduce the entire output (not a rounded or sampled view) to one exact
+  fingerprint, a hash of the full-precision bytes; capture it before the
+  refactor and regenerate after. Identical output is provably behaviour-
+  preserving; any diff is a real change to investigate
+- **Seed everything nondeterministic** (RNG, clock, iteration order) so
+  the fingerprint is stable and a diff means a regression, not noise
+- **Keep the fingerprint disposable** — it is a private scaffold for the
+  duration of the refactor, not a fixture. A committed platform-dependent
+  hash goes CI-flaky across machines and toolchains; commit invariant
+  property tests instead. The fingerprint proves the refactor, the
+  invariants guard the future


### PR DESCRIPTION
Closes #740.

## What
Adds a "Prove a behaviour-preserving refactor with a fingerprint" section to `testing.md`: reduce the full-precision output to one exact hash before the refactor, regenerate and diff after; seed all nondeterminism; keep the fingerprint disposable (never commit a platform-dependent hash — commit invariants instead).

## Why
`testing.md` names golden/ground-truth tests but not the *workflow* for proving a restructure changed nothing. Unit tests miss a subtle reorder/1-ULP shift in a large output; "I didn't mean to change it" isn't proof. Extends `testing-shared-path-breadth`'s ground-truth comparison to a whole-output refactor. Complements #739 (that advises simpler structure; this is how to get there safely).

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)