### PR TITLE
feat(templates): in-process ephemeral-port server technique (#764)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1559,6 +1559,34 @@ output:
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
 
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -403,3 +403,31 @@ output:
   hash goes CI-flaky across machines and toolchains; commit invariant
   property tests instead. The fingerprint proves the refactor, the
   invariants guard the future
+
+---
+
+## Serve the real app in-process on an ephemeral port
+[ID: testing-in-process-server]
+
+Between the framework's in-process test client (bypasses the real
+WSGI/ASGI/HTTP server, its response headers, and static-file MIME
+resolution) and a full container (slow, needs a runtime) sits a
+lightweight middle option: start the real application on an
+OS-assigned port in a daemon thread and drive it over real HTTP. This
+is the in-process tier the E2E policy names.
+
+- **Bind to port 0** so the OS assigns a free port; derive the base URL
+  from the assigned port and tear the server down in a `finally`. A
+  fixed port collides across parallel tests and repeated runs; port 0
+  never does
+- **It exercises the real server stack** — routing, serialization,
+  response headers, static-file content types — that an in-process test
+  client silently bypasses
+- **One recipe, two consumers** — a driver / screenshot script and a
+  browser-based UI test fixture share the same "serve the real app
+  ephemerally" helper, so UI tests need no container
+- Every server exposes this primitive: Python
+  `werkzeug.serving.make_server(..., 0, ...)`, Node `server.listen(0)`,
+  Go `httptest.Server` (the standard library blessing the pattern).
+  Use the in-process thread when you need only the app; reserve a
+  container when you need the built image or sidecar services


### PR DESCRIPTION
Closes #764.

## What
Adds a "Serve the real app in-process on an ephemeral port" section to `testing.md`: start the real app on an OS-assigned port (bind to port 0) in a daemon thread, derive the base URL, tear down in `finally`, and drive it over real HTTP. Elaborates the technique behind the E2E section's in-process-server policy bullet.

## Why
The framework's in-process test client bypasses the real WSGI/ASGI/HTTP server (headers, static-file MIME); a container is slow and needs a runtime. Port 0 is the lightweight middle — parallel-safe, exercises the real stack, and one helper serves both driver scripts and browser UI tests. Language-neutral (`werkzeug make_server(…,0,…)`, `server.listen(0)`, Go `httptest.Server`).

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)