### PR TITLE
feat(templates): runtime-agnostic health-gated container e2e (#765)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1587,6 +1587,34 @@ is the in-process tier the E2E policy names.
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
 
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -431,3 +431,31 @@ is the in-process tier the E2E policy names.
   Go `httptest.Server` (the standard library blessing the pattern).
   Use the in-process thread when you need only the app; reserve a
   container when you need the built image or sidecar services
+
+---
+
+## Container e2e: runtime-agnostic and health-gated
+[ID: testing-container-e2e]
+
+When an e2e test needs the real built image, hardcoding Docker and a
+fixed `sleep` breaks on rootless Podman, in CI without Docker, and when
+the container is slow to start. Drive the image through the Docker API
+instead of the Docker CLI:
+
+- **Runtime-agnostic via a Docker-compatible API** — drive containers
+  through a library that speaks the Docker API (Testcontainers and
+  equivalents) so the SAME test runs on Docker or rootless Podman by
+  pointing at whichever socket is present (`DOCKER_HOST`); no test
+  change per runtime
+- **Poll until healthy, never sleep** — gate readiness with a poll loop
+  against the container's health endpoint plus a deadline, so a slow
+  start waits and a dead start fails fast
+- **Import-guard the optional dependency** (`pytest.importorskip` or
+  equivalent) so the module still collects, and skips cleanly, in jobs
+  that do not install the heavy e2e extra
+- **Disable the resource reaper on rootless runtimes** — Ryuk and its
+  kin assume a privileged Docker; a meta-assertion MAY also verify the
+  image runs as a non-root user
+
+This is programmatic single-image e2e from the test suite; local
+multi-service dev composition lives in `containers.md`.


### PR DESCRIPTION
Closes #765.

## What
Adds a "Container e2e: runtime-agnostic and health-gated" section to `testing.md`: drive the real built image through a Docker-API-compatible library (Testcontainers et al.) via `DOCKER_HOST`, poll a health endpoint instead of sleeping, import-guard the optional e2e dependency, and disable the resource reaper on rootless runtimes.

## Why
E2E tests that hardcode Docker + a fixed `sleep` break on rootless Podman, in CI without Docker, and flake on slow starts. The runtime-agnostic-via-standard-API, poll-not-sleep, and import-guard ideas are language-neutral. Programmatic single-image e2e from the suite; multi-service dev composition stays in `containers.md`.

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)