### PR TITLE
feat(templates): derive test tier from directory, default fast (#774)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1615,6 +1615,26 @@ instead of the Docker CLI:
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
 
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it
+
 
 <!-- templates/base/core/review.md -->
 # Base — Peer Review

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -459,3 +459,23 @@ instead of the Docker CLI:
 
 This is programmatic single-image e2e from the test suite; local
 multi-service dev composition lives in `containers.md`.
+
+---
+
+## Derive the test tier from the directory, default to fast
+[ID: testing-tier-by-directory]
+
+The taxonomy classifies test types and the regression table names smoke
+/ quick / full triggers, but nothing ties them together: how a tier is
+DERIVED and how the default run excludes the heavy tier. Hand-marking
+every test file drifts from where the test actually lives.
+
+- **Derive the tier from the directory** with a single collection hook
+  (pytest `pytest_collection_modifyitems`, or the runner's equivalent):
+  `tests/*` → unit, `tests/integration/` → integration, `tests/e2e/` →
+  e2e. The tier follows from location, so a marker cannot drift from
+  where the test sits
+- **Make the default run the fast tier** (unit + integration) and gate
+  the heavy tier (container, browser) behind an opt-in marker PLUS an
+  optional-dependency extra, so the common path stays fast and the
+  expensive dependencies are not installed for it


### PR DESCRIPTION
Closes #774.

## What
Adds a "Derive the test tier from the directory, default to fast" section to `testing.md`: one collection hook (pytest `pytest_collection_modifyitems` or equivalent) maps `tests/*`→unit, `tests/integration/`→integration, `tests/e2e/`→e2e; the default run is the fast tier (unit + integration), with the heavy tier gated behind an opt-in marker plus an optional-dependency extra.

## Why
The taxonomy and the smoke/quick/full trigger table existed separately with nothing tying them together — how a tier is derived and how the default excludes the heavy tier. Deriving the tier from location stops a marker from drifting from where the test sits; language-neutral apart from the hook API. Complements the coverage-denominator rule (#756).

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)