### PR TITLE
feat(templates): generators derive enumerations from schema (#741)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1023,6 +1023,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -382,6 +382,13 @@ it as stale.
   not just the file path. "19 of 19 entries stale" tells the maintainer
   the extractor itself drifted; a bare filename reads like a one-line
   edit and hides the scale
+- A generator that renders per-field output (report columns, table
+  sections, config stanzas) MUST derive the field enumeration from the
+  data schema it renders, never from a hardcoded list. A fixed list
+  fails both ways at once: it renders dead columns for fields the data
+  lacks, and silently omits fields it has — and the omission hides
+  exactly the records the artifact exists to surface. The dead columns
+  are the visible tell; treat them as a defect, not cosmetics
 
 ## Output file by agent
 


### PR DESCRIPTION
Closes #741.

## What
Adds a rule to `docs.md` §Generated files: a generator rendering per-field output (report columns, table sections, config stanzas) MUST derive the field enumeration from the data schema it renders, never a hardcoded list — and names the visible tell (dead columns) as the review trigger.

## Why
A fixed list fails in both directions at once: dead columns for fields the data lacks, and silent omission of fields it has — the omission hides exactly the records the artifact exists to surface, while dead-but-plausible columns read as style. Observed downstream (wuseria S206): a hardcoded column tuple rendered dead columns and dropped the exact failing curves a calibration issue needed documented; the defect survived five chart-family additions.

Smoke: 23/23. `generated/` regenerated (docs.md is core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)