### PR TITLE
feat(templates): preserve-or-fail-loud for round-trip files (#742)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1030,6 +1030,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -389,6 +389,14 @@ it as stale.
   lacks, and silently omits fields it has — and the omission hides
   exactly the records the artifact exists to surface. The dead columns
   are the visible tell; treat them as a defect, not cosmetics
+- A round-trip generated file — one the generator scaffolds and then
+  refreshes in place while preserving human-owned edits (annotation
+  files, mark-up review tables, scaffolded configs with user sections)
+  — MUST on refresh either preserve human-entered content or fail loud
+  naming what it would discard. Silently reverting an edit that does not
+  match the preservation convention (an unmarked cell) is data loss even
+  when documented. Two compliant behaviours: treat divergent unmarked
+  content as a correction to keep, or refuse the refresh naming the cell
 
 ## Output file by agent
 


### PR DESCRIPTION
Closes #742.

## What
Adds a round-trip rule to `docs.md` §Generated files: a file the generator scaffolds and then refreshes in place while preserving human-owned edits (annotation files, mark-up review tables, scaffolded configs with user sections) MUST on refresh either preserve human-entered content or fail loud naming what it would discard. Names the failure mode (silent discard of non-conforming edits) and the two compliant behaviours.

## Why
§Generated files covered banners, `--check` staleness, and formatter exclusion — all for files humans must NOT edit — with no rule for the hybrid class. Observed downstream (wuseria S207): a correction entered without the preservation mark was silently reverted on the next refresh; "working as documented" still lost part of a 132-cell human read, and the highest-value corrections are exactly where the marking convention slips.

Smoke: 23/23. `generated/` regenerated (docs.md is core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)