### PR TITLE
feat(templates): de-circularization sweep in calibration discipline (#744)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -192,6 +192,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -186,6 +186,13 @@ that runs the tool. The rules below address each.
   each entry
 - A small hand-built reference set from raw artifacts beats a large
   set carried over from a suspect pipeline
+- When a reference set flips from tool-seeded to independently verified
+  values (the de-circularization above), grep the codebase in the same
+  change for comments, guard conditions, and thresholds whose rationale
+  cites the OLD data, and re-verify each against the new ground truth —
+  or file an issue per survivor. The reasoning citing the stale values
+  keeps steering the code long after the data is corrected; the sweep is
+  one grep at a well-defined moment (the ground-truth-flip change)
 
 ### Honest absence beats a recovered wrong value
 


### PR DESCRIPTION
Closes #744.

## What
Adds a rule under `quality.md` §"Ground truth comes from raw artifacts, not suspect data": when a reference set flips from tool-seeded to independently verified values, grep the codebase in the same change for comments, guard conditions, and thresholds whose rationale cites the old data, and re-verify each against the new ground truth — or file an issue per survivor.

## Why
quality.md already had both halves separately (the load-bearing-comment re-verify rule in Code style; the suspect-data-as-ground-truth rule here) but no trigger connecting them. Downstream (wuseria S209/ADR-080): a dispatch guard's comment cited extractor-seeded (circular) GT; two eye-read GT flips proved it wrong but nothing re-audited the guard two files away — it steered the code into the wrong branch for two sessions, costing a P2 bug. The sweep is one grep at the GT-flip moment.

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)