### PR TITLE
feat(templates): forbid ticket/PR/ADR numbers in code comments (#745)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -356,6 +356,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -350,6 +350,15 @@ maintainer time on phantom fixes.
   audit the references in the same change — `rg "#<number>"` (or the tracker
   URL) over the repo lists them, and the audit is done when none point at the
   stale item
+- In code comments and docstrings, go further: never cite a ticket, PR,
+  or ADR *number* at all — code outlives the tracker, so state the
+  substance instead (name the descriptor, source, or derivation, not
+  "see #123" or "per ADR 0002"). Markdown docs (README, ADRs, the dev
+  journal) are the opposite: cross-referencing issues and ADRs by number
+  is their job. One exception in code: non-obvious or scientific logic
+  MAY name a *source* (author + year + method — "Rappé 1992"), which
+  ages gracefully where an issue number does not. Enforce with a test
+  that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
 
 ## Debug code
 


### PR DESCRIPTION
Closes #745.

## What
Strengthens the existing comment-citation rule in `quality.md` §Code style: in **code comments and docstrings**, never cite a ticket/PR/ADR *number* at all — state the substance instead. Scopes it (markdown docs may and should cross-reference by number — that's their job), keeps the scientific-source exception (author + year + method), and names the enforcement (a test that greps comments/docstrings for `#\d+` / `ADR\s*\d+`).

## Why
Where the prior rule says "keep citations fresh," this says "don't put numbers in code comments in the first place": those references rot as the code outlives the tracker/decision. Proven downstream (corrosim #151, enforced package-wide with `tests/test_docstrings.py`).

Smoke: 23/23. `generated/` regenerated (core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)