### PR TITLE
feat(templates): warn that close #N auto-closes even when negated (#746)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -443,6 +443,12 @@ maintainer time on phantom fixes.
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -25,6 +25,12 @@
   closes more than one issue: `Closes #a, closes #b, closes #c` closes
   all three. `Closes #a, #b, #c` closes only `#a` — a bare `#b`/`#c` is
   a plain reference, not a closing one, and stays open after merge.
+- **A closing keyword auto-closes even when negated** — GitHub matches
+  the bare `close/fix/resolve #N` substring regardless of surrounding
+  words, so "does not close #N" in a PR body or commit still closes #N
+  on merge. To reference an issue without closing it, write "part of #N"
+  or `#N` alone — never a closing keyword next to the number unless the
+  change truly resolves it
 - **Regenerate derived artifacts in the same PR** — when a change
   affects generated or derived files committed to the repo (extractor
   outputs, snapshot fixtures, generated docs), regenerate them in the


### PR DESCRIPTION
Closes #746.

## What
Adds a warning to `git.md` §Pull requests, next to the existing closing-keyword rule: GitHub matches the bare `close/fix/resolve #N` substring **regardless of surrounding words**, so "does not close #N" in a PR body or commit still auto-closes #N on merge. Gives the safe alternative — "part of #N" or a bare `#N`.

## Why
Small, high-value: the failure is silent (you only notice the issue vanished after merge) and easy to hit exactly when you're trying to *clarify* that a PR does NOT close something. Observed downstream (corrosim): a PR body saying "does not close #53" auto-closed #53 on merge.

Smoke: 23/23. `generated/` regenerated (git.md is core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)