### PR TITLE
feat(templates): state the nosniff Content-Type authority principle (#766)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1928,10 +1928,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2422,10 +2422,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2487,10 +2487,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2422,10 +2422,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2422,10 +2422,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3124,10 +3124,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3124,10 +3124,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2780,10 +2780,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2166,10 +2166,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2487,10 +2487,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2422,10 +2422,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1928,10 +1928,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —

--- a/templates/base/security/security.md
+++ b/templates/base/security/security.md
@@ -129,10 +129,13 @@ every project regardless of language or framework.
   - `Strict-Transport-Security` (see Transport security)
   - `Referrer-Policy: strict-origin-when-cross-origin`
   - `Permissions-Policy` — disable unused browser APIs
-- When enabling `nosniff`, pin static asset MIME types in code — the
-  OS registry resolves `.js` to `text/plain` on some platforms, so the
-  browser refuses to run the script and CI on Linux will not catch it;
-  verify script/style execution in a real browser, not just status codes
+- When enabling `nosniff`, pin static asset MIME types in code — with
+  `nosniff` the browser will not correct a wrong `Content-Type`, so the
+  server is the sole authority on it and MIME resolution MUST NOT depend
+  on the host. The OS registry resolves `.js` to `text/plain` on some
+  platforms, so the browser refuses to run the script and CI on Linux
+  will not catch it; verify script/style execution in a real browser,
+  not just status codes
 - Never use `unsafe-inline` or `unsafe-eval` in CSP without a
   written justification
 - Do not expose server version or technology stack in headers —


### PR DESCRIPTION
Closes #766.

## What
`security.md` already had the practical rule (pin static-asset MIME types in code when `nosniff` is set, with the `.js`→`text/plain` trigger). This adds the **principle** the issue emphasizes: with `nosniff` the browser will not correct a wrong `Content-Type`, so the server is the sole authority on it and MIME resolution MUST NOT depend on the host.

## Note
The bulk of this issue was already covered by an earlier pass (`security.md:132`); this is a minimal principle-framing addition, not a new rule — avoiding a redundant bullet.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)