### PR TITLE
feat(templates): prove statelessness with disjoint inputs (#767)

### DIFF
--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4334,6 +4334,13 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3491,6 +3491,13 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3491,6 +3491,13 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3312,6 +3312,13 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2698,6 +2698,13 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources
 

--- a/templates/backend/concurrency.md
+++ b/templates/backend/concurrency.md
@@ -78,5 +78,12 @@ CPU-bound work cannot be offloaded to a background job or worker process.
   code review alone to catch data races
 - Write stress tests for any code that shares state: run N goroutines /
   threads concurrently and assert invariants hold
+- Prove statelessness with disjoint inputs, not just shared-state
+  stress: fire many requests in parallel, each with a distinct,
+  non-overlapping expected-output set, and assert every response falls
+  only within its own request's set. A value that could only have come
+  from another request exposes shared-state bleed — an accidental
+  module-level mutable shared across requests or workers. A same-input
+  concurrency test cannot catch this, because every request looks alike
 - Test cancellation paths: assert that cancelling a context or token
   terminates the operation promptly and cleans up resources


### PR DESCRIPTION
Closes #767.

## What
Adds a rule to `concurrency.md` §Testing: to prove a handler is stateless, fire many requests in parallel each with a distinct, non-overlapping expected-output set, and assert every response falls only within its own request's set.

## Why
The section already stress-tests code that *shares* state, but has no positive proof for a service that *claims* to be stateless. A cross-request value exposes shared-state bleed (an accidental module-level mutable shared across requests/workers) — and a same-input concurrency test can't detect it because every request looks alike. Turns "stateless" from an assertion into an executable proof. Language-neutral (HTTP, RPC, queue consumer).

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)