### PR TITLE
feat(templates): API contract version is a separate axis (#772)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4301,6 +4301,12 @@ Overridden by each framework stack. The common principle:
 - Contract-test the running API against the spec — generate cases from
   the spec and run them against a live instance (e.g. Schemathesis) so
   the implementation provably conforms to the published contract
+- The spec document's own version field (OpenAPI `info.version`) is a
+  separate axis from the package / release version — maintain it on its
+  own cadence and do NOT bump it on a routine package release that does
+  not change the contract. Where a drift test guards it, assert the
+  field is PRESENT (the spec requires it), not that it equals the
+  package version
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2134,6 +2134,12 @@ DEBUG=false
 - Contract-test the running API against the spec — generate cases from
   the spec and run them against a live instance (e.g. Schemathesis) so
   the implementation provably conforms to the published contract
+- The spec document's own version field (OpenAPI `info.version`) is a
+  separate axis from the package / release version — maintain it on its
+  own cadence and do NOT bump it on a routine package release that does
+  not change the contract. Where a drift test guards it, assert the
+  field is PRESENT (the spec requires it), not that it equals the
+  package version
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2134,6 +2134,12 @@ DEBUG=false
 - Contract-test the running API against the spec — generate cases from
   the spec and run them against a live instance (e.g. Schemathesis) so
   the implementation provably conforms to the published contract
+- The spec document's own version field (OpenAPI `info.version`) is a
+  separate axis from the package / release version — maintain it on its
+  own cadence and do NOT bump it on a routine package release that does
+  not change the contract. Where a drift test guards it, assert the
+  field is PRESENT (the spec requires it), not that it equals the
+  package version
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility

--- a/templates/backend/api.md
+++ b/templates/backend/api.md
@@ -45,6 +45,12 @@
 - Contract-test the running API against the spec — generate cases from
   the spec and run them against a live instance (e.g. Schemathesis) so
   the implementation provably conforms to the published contract
+- The spec document's own version field (OpenAPI `info.version`) is a
+  separate axis from the package / release version — maintain it on its
+  own cadence and do NOT bump it on a routine package release that does
+  not change the contract. Where a drift test guards it, assert the
+  field is PRESENT (the spec requires it), not that it equals the
+  package version
 
 ## Versioning
 - APIs in a given version MUST maintain backward compatibility


### PR DESCRIPTION
Closes #772.

## What
Adds a rule to `api.md` §OpenAPI: the spec document's own version field (OpenAPI `info.version`) is a separate axis from the package/release version — maintain it on its own cadence, don't bump it on a routine package release that doesn't change the contract, and where a drift test guards it, assert the field is *present*, not equal to the package version.

## Why
The section taught up-to-date specs and drift-pinning but not the version-axis distinction. Teams that inject the package version into the contract then churn the contract version on every unrelated package patch. Any project shipping both a versioned package and a machine-readable contract (OpenAPI/protobuf/JSON Schema) has two axes; conflating them is the common mistake. The "assert present, not equal" check is one instance of the drift-guard family.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)