### PR TITLE
feat(templates): explicit query-param parse, absent vs invalid (#773)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1968,6 +1968,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2020,6 +2020,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1968,6 +1968,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1968,6 +1968,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2582,6 +2582,12 @@ staticcheck ./...     # additional static analysis
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2582,6 +2582,12 @@ staticcheck ./...     # additional static analysis
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2582,6 +2582,12 @@ staticcheck ./...     # additional static analysis
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1968,6 +1968,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2020,6 +2020,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1968,6 +1968,12 @@ DEBUG=false
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:

--- a/templates/backend/http.md
+++ b/templates/backend/http.md
@@ -23,6 +23,12 @@
   not for resource identity (use path segments for that)
 - The following names are reserved for framework-level use and MUST NOT
   be repurposed: `limit`, `skip`, `offset`, `expand`, `sortedBy`
+- Parse a typed query parameter explicitly so you can distinguish three
+  states: absent (use the default), present-and-valid (use it), and
+  present-but-invalid (raise 400). Do NOT rely on a framework's
+  type-coercing helper (e.g. Flask `request.args.get('n', type=int)`)
+  that returns the default on a malformed value — it silently turns a
+  client error into a successful default-valued 200
 
 ## Request headers
 - All HTTP headers MUST follow Hyphenated-Pascal-Case casing:


### PR DESCRIPTION
Closes #773.

## What
Adds a rule to `http.md` §Query parameters: parse a typed query parameter explicitly to distinguish three states — absent (default), present-and-valid (use it), present-but-invalid (raise 400) — rather than a framework's type-coercing helper (e.g. Flask `request.args.get('n', type=int)`) that returns the default on a malformed value.

## Why
Makes `security.md`'s general "do not silently coerce or strip fields" concrete for the query-string case. The coercing convenience API silently turns a client error into a successful default-valued 200; the absent-vs-invalid distinction exists in every framework's query-parsing API.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)