### PR TITLE
feat(templates): name the allow_nan=false serializer flag (#775)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2002,9 +2002,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2054,9 +2054,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2002,9 +2002,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2002,9 +2002,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2616,9 +2616,11 @@ staticcheck ./...     # additional static analysis
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2616,9 +2616,11 @@ staticcheck ./...     # additional static analysis
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2616,9 +2616,11 @@ staticcheck ./...     # additional static analysis
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2002,9 +2002,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2054,9 +2054,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2002,9 +2002,11 @@ DEBUG=false
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 

--- a/templates/backend/http.md
+++ b/templates/backend/http.md
@@ -57,9 +57,11 @@
   as a string — JavaScript cannot represent larger integers precisely
 - Endpoints that serialise computed floats MUST reject non-finite values:
   `NaN`/`Infinity` are not valid RFC 8259 JSON. Configure the encoder to
-  fail loud (a 500 at the serialisation boundary) instead of emitting a
-  bare `NaN` token that strict parsers reject; represent an undefined
-  value as `null` and document the field as nullable in the contract
+  reject them (e.g. `allow_nan=false`) so it fails loud at the
+  serialisation boundary (a 500) instead of emitting a bare `NaN` token
+  that strict parsers reject; represent an undefined value as `null`
+  (normalised before serialisation) and document the field as nullable
+  in the contract
 - Responses MUST contain only the fields needed by the caller — do not pad
   payloads with fields that are not consumed
 


### PR DESCRIPTION
Closes #775.

## What
`http.md` already required rejecting non-finite floats (`NaN`/`Infinity`) at the serialisation boundary and failing loud. This adds the concrete encoder flag (`allow_nan=false`) and the "normalised before serialisation" framing so the rule is directly actionable.

## Note
The rule was already substantially present (`http.md:58`, added in an earlier pass — it's the sibling of the 2^53-integer rule). This is a minimal example/framing enhancement, not a new rule.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)