### PR TITLE
feat(templates): skip-not-fail on absent optional deploy secret (#771)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3003,6 +3003,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3257,6 +3257,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3003,6 +3003,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3003,6 +3003,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3796,6 +3796,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3796,6 +3796,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3405,6 +3405,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3441,6 +3441,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3257,6 +3257,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3003,6 +3003,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 

--- a/templates/base/infra/cicd.md
+++ b/templates/base/infra/cicd.md
@@ -72,6 +72,10 @@ Each stage MUST fail fast — a failed stage stops the pipeline immediately.
   target, never rebuilding in the deploy step. This guarantees the
   deployed artifact is the exact one that passed the gates (see
   "Promote the same artifact" under Environment separation)
+- A deploy step whose secret (a deploy-hook URL or token) is absent on
+  forks or contributor branches MUST skip and still succeed
+  (`if: ${{ secrets.DEPLOY_URL != '' }}`), keeping the workflow green
+  rather than hard-failing — forks do not receive repository secrets
 
 ## Release record
 


### PR DESCRIPTION
Closes #771.

## What
Adds one bullet to `cicd.md` §Deployment strategy: a deploy step whose secret (deploy-hook URL or token) is absent on forks or contributor branches MUST skip and still succeed (`if: ${{ secrets.X != '' }}`), keeping the workflow green rather than hard-failing.

## Note — 2 of 3 refinements already covered
The issue proposed three refinements; two were already present:
- "Deploy the published artifact, never rebuild in the deploy job" → already at `cicd.md:69-74` (added by #601 build-once CD).
- "Trigger production on a version tag, not every push to main" → already at `cicd.md:36,44` (main → staging, tag → production).

Only the skip-not-fail-on-absent-secret refinement was missing; that's what this ships.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)