### PR TITLE
feat(templates): cover Docker Compose in the container infra layer (#752)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2628,6 +2628,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2882,6 +2882,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2628,6 +2628,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2628,6 +2628,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3330,6 +3330,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3330,6 +3330,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2882,6 +2882,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2628,6 +2628,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production

--- a/templates/base/infra/containers.md
+++ b/templates/base/infra/containers.md
@@ -56,6 +56,25 @@ runtime ships.
   MAY trail one minor as a style floor when the newer target introduces
   a confusing auto-rewrite
 
+## Docker Compose (if applicable)
+
+Use a `docker-compose.yml` (Compose file) when a single image is not
+enough: more than one service (app plus datastore or cache), or an
+isolated build/run environment for a toolchain impractical to install
+on the host. Not every project needs Compose — keep it to those cases.
+
+- Define each service, its image or build context, ports, and
+  dependencies (`depends_on`) in the Compose file; keep it at the repo
+  root alongside the `Dockerfile`
+- Local dev: `docker compose build` then `docker compose run --rm
+  <service>` (or `up`) — `--rm` cleans up the one-off container so
+  repeated runs do not accumulate stopped containers
+- Bind-mount the source for local dev so edits are live without a
+  rebuild; do NOT bind-mount in CI or production — there the image is
+  the artifact, and a mount would shadow it with host files
+- Compose orchestrates local and single-host multi-service dev;
+  production multi-service orchestration is Kubernetes (below)
+
 ## Orchestration (Kubernetes)
 - Define all Kubernetes resources as code — no `kubectl apply` from a local
   machine in production


### PR DESCRIPTION
Closes #752.

## What
Adds a "Docker Compose (if applicable)" section to `containers.md`: when a `docker-compose.yml` is warranted (more than one service, or an isolated build/run toolchain), the `docker compose build` / `run --rm` workflow, and bind-mount-for-local-dev-only guidance (never in CI/prod, where the image is the artifact). Kept MAY/SHOULD.

## Why
The infra layer taught how to build one image but not how to orchestrate the common multi-service or isolated-toolchain case — Compose was absent from the entire template tree (0 hits for `docker-compose`/`compose.yml`). Service stacks (app + datastore) and toolchain-heavy libraries (e.g. corrosim's QM engine) realistically ship one. Compose orchestrates local/single-host dev; Kubernetes remains the production path.

Smoke: 23/23. `generated/` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)