### PR TITLE
feat(templates): strengthen the template-feedback audit item (#761)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3946,6 +3946,21 @@ summarize — visible sequential execution prevents missed steps.
     reusable, name the upstream template file and file an issue on the
     upstream repo (not a downstream note) — naming a candidate is not
     contributing it
+    - **Capture at decision time, not only here.** When an ADR or
+      decision records a generic convention, judge reusability then and
+      record the verdict on the record (an `Upstream:` line: candidate
+      file + filed issue, or `none`). This item then harvests flagged
+      candidates instead of re-deriving them, so a session that never
+      formally wraps still leaves the verdict captured
+    - **Strip the domain skin before judging.** Restate the convention
+      with the project's domain nouns removed and re-ask whether it
+      stands alone — a generic core ("scope the coverage denominator to
+      the CI-runnable surface") hides under domain framing ("omit the
+      GPU-only modules") and reads as project-specific
+    - **Reconcile periodically.** Every N sessions, or when a genericized
+      engineering-notes doc is produced, reconcile the whole accumulated
+      convention set against the resolved template chain — a once-missed
+      pattern is swept eventually, not lost forever
 12. **Flag gaps** — if any item cannot be completed this session, report
     it as pending (never as done) before closing — including deferred
     cross-repo work, such as an upstream contribution that was flagged

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -184,6 +184,21 @@ summarize — visible sequential execution prevents missed steps.
     reusable, name the upstream template file and file an issue on the
     upstream repo (not a downstream note) — naming a candidate is not
     contributing it
+    - **Capture at decision time, not only here.** When an ADR or
+      decision records a generic convention, judge reusability then and
+      record the verdict on the record (an `Upstream:` line: candidate
+      file + filed issue, or `none`). This item then harvests flagged
+      candidates instead of re-deriving them, so a session that never
+      formally wraps still leaves the verdict captured
+    - **Strip the domain skin before judging.** Restate the convention
+      with the project's domain nouns removed and re-ask whether it
+      stands alone — a generic core ("scope the coverage denominator to
+      the CI-runnable surface") hides under domain framing ("omit the
+      GPU-only modules") and reads as project-specific
+    - **Reconcile periodically.** Every N sessions, or when a genericized
+      engineering-notes doc is produced, reconcile the whole accumulated
+      convention set against the resolved template chain — a once-missed
+      pattern is swept eventually, not lost forever
 12. **Flag gaps** — if any item cannot be completed this session, report
     it as pending (never as done) before closing — including deferred
     cross-repo work, such as an upstream contribution that was flagged


### PR DESCRIPTION
Closes #761.

## What
Strengthens `scope.md` End-of-session item 11 (Template feedback) with three axes: **capture at decision time** (record the reusability verdict on the ADR via an `Upstream:` line, so this item harvests rather than re-derives — robust to sessions that never formally wrap), **strip the domain skin** before judging reusability, and **reconcile periodically** (every N sessions, or when a genericized engineering-notes doc is produced) against the whole resolved template chain.

## Why
The item was strong on paper but had four failure modes (trigger-gating, delta-only scope, domain-skin bias, mark-and-move depth) that let genuinely reusable conventions sit unflagged across many sessions — exactly the process gap behind the #749–#760 batches, which had to be surfaced by a deliberate later gap-analysis instead of firing at their originating sessions.

## Note
The change lands in `scope.md` (in-chain); the issue also suggested an `ai-workflow.md` pointer, but that file is reference-only (zero chains), so the substantive rule lives where it can reach a generation.

Smoke: 23/23. `generated/` regenerated (scope.md resolves into the tutorial chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)