### PR TITLE
feat(templates): reconcile mypy --strict with gradual adoption (#760)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4074,6 +4074,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4074,6 +4074,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4074,6 +4074,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3292,6 +3292,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2518,6 +2518,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4074,6 +4074,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -72,6 +72,17 @@ CLAUDE.md
 - Prefer `collections.abc` types (`Sequence`, `Mapping`) over `list`, `dict`
   in public signatures
 - Use `TypeAlias` for complex type aliases
+- `--strict` is the target end-state, not always the day-one setting. A
+  project on the scientific / data / ML stack (numpy, pandas, rdkit,
+  native libs) whose deps ship no usable stubs would face a wall of
+  unavoidable errors under `--strict` from the start. Adopt in stages:
+  start non-strict with `ignore_missing_imports`, then per module flip
+  `disallow_untyped_defs` + `strict_optional` and drop the
+  missing-imports escape, converging on `--strict`
+- Quarantine an untyped third-party lib with a per-module override
+  (`follow_imports = "skip"`) AND a stated reason, rather than globally
+  weakening the check — the escape stays visible and scoped to the
+  library that needs it
 
 ---
 


### PR DESCRIPTION
Closes #760.

## What
Adds two bullets to `python-lib.md` §Typing: `--strict` is the target end-state, not always day-one — adopt in stages (non-strict + `ignore_missing_imports` → per-module `disallow_untyped_defs` + `strict_optional` → drop the escape, converging on `--strict`); and quarantine an untyped third-party lib with a per-module `follow_imports = "skip"` override plus a stated reason, rather than globally weakening the check.

## Why
The flat `mypy --strict`-from-day-one mandate is impractical for scientific/data/ML projects whose deps ship no usable stubs — it produces a wall of unavoidable errors, so teams fake compliance or drop the gate. A sanctioned staged path keeps the gate real and moving toward strict. Language-layer typing discipline.

Smoke: 23/23. `generated/` regenerated (python-lib chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)