### PR TITLE
feat(templates): provenance-doc backfill is a data audit (#747)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -862,6 +862,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -199,6 +199,14 @@ reference for a specific subsystem's empirical numbers.
 - Reference the findings doc from the source where the constant is
   defined (a one-line comment naming the file is enough) so a
   future reader can trace why the constant has the value it does
+- Backfilling a provenance or justification doc — one whose job is to
+  justify a stored value against a cited source (a scoring-log, a
+  data-provenance table) — is a data audit, not transcription: writing
+  "field = X because source says Y" is the moment to cross-check X
+  against Y. Surface a discovered gap or inconsistency (fix it or file
+  it), never encode it as a false "not tested" marker. Distinguish
+  "source silent on the field" (legitimately undefined) from "source has
+  data, record unpopulated" (a data gap, not an untested field)
 
 Example skeleton:
 


### PR DESCRIPTION
Closes #747.

## What
Adds a rule to `docs.md` §Findings docs: backfilling a provenance/justification doc (a scoring-log, a data-provenance table — anything whose job is to justify a stored value against a cited source) is a **data audit**, not transcription. Writing "field = X because source says Y" is the moment to cross-check X against Y; surface a discovered gap/inconsistency (fix or file) rather than encoding a false "not tested" marker. Names the distinction: "source silent on the field" (legitimately undefined) vs "source has data, record unpopulated" (a data gap).

## Why
A pure docs pass transcribes stored values and marks anything missing "not tested" — even when the cited source did test it — shipping false provenance and hiding real gaps. Downstream (wuseria): backfilling `scoring-log.md` against already-cited reviews surfaced six unpopulated-but-tested fields plus one inconsistent score; the gaps were the real deliverable. Sibling of quality.md's source-silent-vs-source-says-false rule, for the doc-backfill trigger.

Smoke: 23/23. `generated/` regenerated (docs.md is core-tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)