### PR TITLE
fix(release): mandate annotated release tags (#812)

### DIFF
--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -1,0 +1,27 @@
+name: Release tag guard
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  annotated-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Require annotated release tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
+          type="$(git cat-file -t "${tag}")"
+          if [ "${type}" != "tag" ]; then
+            echo "::error::Release tag ${tag} is lightweight (${type})." \
+                 "Tags MUST be annotated: git tag -a ${tag} -m '${tag}'." \
+                 "See issue #812."
+            exit 1
+          fi
+          echo "Release tag ${tag} is annotated. OK."

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -620,7 +620,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -634,6 +637,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"
@@ -4138,9 +4143,10 @@ Follow `templates/base/core/git.md` release process:
 2. `git commit --allow-empty -m "chore: release vX.Y.Z"`
 3. Push, open PR, merge
 4. `git checkout main && git pull`
-5. `git tag vX.Y.Z && git push origin vX.Y.Z`
+5. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
 
-Tags use semver: `v1.0.0` (lowercase v, three segments).
+Tags use semver: `v1.0.0` (lowercase v, three segments). Release
+tags MUST be annotated (`-a`) so `git describe` reports them.
 
 ---
 

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -202,7 +202,10 @@ When NOT to close-and-resubmit:
   6. `git commit -m "chore: release vX.Y.Z"`
   7. Push, open PR, merge
   8. `git checkout main && git pull`
-  9. `git tag vX.Y.Z && git push origin vX.Y.Z`
+  9. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
+     — release tags MUST be annotated (`-a`/`-s`); a lightweight
+     `git tag vX.Y.Z` is invisible to `git describe`, which reports
+     a stale version to submodule/`describe` consumers
   10. SHOULD create a GitHub Release from the tag:
       `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`
       — a pushed tag alone does NOT create a Releases page entry.
@@ -216,6 +219,8 @@ When NOT to close-and-resubmit:
 ### Projects without a version manifest (no-build)
   4. `git checkout main && git pull`
   5. `git tag -a vX.Y.Z -m "vX.Y.Z — <milestone name>"`
+     — the `-a` is mandatory: a lightweight `git tag` is skipped by
+     `git describe`, so consumers report a stale version
   6. `git push origin vX.Y.Z`
   7. Create a GitHub Release with auto-generated notes:
      `gh release create vX.Y.Z --title "vX.Y.Z — <milestone name>"

--- a/templates/stack/static-site-tutorial.md
+++ b/templates/stack/static-site-tutorial.md
@@ -159,9 +159,10 @@ Follow `templates/base/core/git.md` release process:
 2. `git commit --allow-empty -m "chore: release vX.Y.Z"`
 3. Push, open PR, merge
 4. `git checkout main && git pull`
-5. `git tag vX.Y.Z && git push origin vX.Y.Z`
+5. `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`
 
-Tags use semver: `v1.0.0` (lowercase v, three segments).
+Tags use semver: `v1.0.0` (lowercase v, three segments). Release
+tags MUST be annotated (`-a`) so `git describe` reports them.
 
 ---
 


### PR DESCRIPTION
## Incident

`git describe` reports **`v2.17.0-128-g6969ccd`** for a commit that is exactly **`v2.35.0`**. Adding this repo as a git submodule in another project therefore reports a stale version. 30 of 37 release tags are lightweight, including every release `v2.18.0`→`v2.35.0`.

Fixes #812 (recurrence-prevention half — historical retag done separately).

## Root cause

Both were creating **lightweight** tags, which `git describe` skips by default:
- `templates/base/core/git.md` — the version-manifest release flow used `git tag vX.Y.Z`
- `templates/stack/static-site-tutorial.md` — same pattern

The no-build flow already used `git tag -a`, but had no rationale, so an operator "simplifying" it to `git tag` reintroduced the bug (which is how this repo's own tags went lightweight).

## Changes

- **Templates**: both release flows now use `git tag -a` and carry a one-line rationale (annotated tags are what `git describe` sees).
- **CI guard** (`.github/workflows/tag-guard.yml`): triggers on pushed `v*` tags and fails if the tag is lightweight — prevents recurrence.
- **generated/**: regenerated the 17 pre-resolved chains (base-git is core-tier).

## Not in this PR

- Retagging the 30 historical lightweight tags as annotated (rewrites tag refs + force-push of tags) — done as a separate direct git operation, tracked on #812.

## Verification

- `py tests/run_smoke.py` → 23/23 pass
- `py tools/sync.py --check` and `py tools/resolve.py --check` → in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)