### PR TITLE
docs(quality): anchor comment-layout convention in Code style

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -365,6 +365,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -359,6 +359,15 @@ maintainer time on phantom fixes.
   MAY name a *source* (author + year + method — "Rappé 1992"), which
   ages gracefully where an issue number does not. Enforce with a test
   that greps comments/docstrings for `#\d+` / `ADR\s*\d+`
+- A block comment MUST sit directly above the item it documents: never
+  trailing to the right of code (tool directives like `# noqa` / `# nosec`
+  are excepted), and never separated from that item by a blank line
+- Separate each comment-plus-item group from the next with a single blank
+  line, so the comment and the lines it explains read as one unit
+- Wrap comment prose to the project's configured line-length limit, the same
+  limit as code. Enforce this for commented configuration files
+  (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not
+  scan them
 
 ## Debug code
 


### PR DESCRIPTION
## What

Adds a **comment-layout** convention to `base/core/quality.md` (Code style), next to the existing comment-content rules. Three rules:

- A block comment sits **directly above** the item it documents — never trailing to the right of code (`# noqa` / `# nosec` excepted), and never separated from that item by a blank line.
- **One blank line** separates each comment-plus-item group from the next, so the comment and the lines it explains read as a single unit.
- Comment prose wraps to the project's configured **line-length limit** — the same limit as code, and applied to commented config files (`pyproject.toml`, YAML, CI workflows) too, even where the linter does not scan them.

## Why

The comment *philosophy* (self-documenting, no ticket refs, reasoning-comments-rot) was already here, but the comment *layout* was unwritten — so config files and comment grouping drifted per-project. This is the generic core of the readability standard several downstream projects had adopted ad hoc.

## Notes

- Regenerated the cached chains with `tools/sync.py`; `sync.py --check` clean, so every stack's resolved chain now carries the rule (17 `generated/*.md` updated).
- Smoke suite green: 23/23.
- No ADR — a rule added to an existing template section is not a structural decision (no new layer, naming, or override change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)