### PR TITLE
fix(platform): align epic and task label colours (#871)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -304,8 +304,8 @@ remain visually distinct when displayed side by side.
 | Label      | Color     | Maps to  |
 | ---------- | --------- | -------- |
 | `bug`      | `#C9372C` | Bug      |
-| `epic`     | `#8270DB` | Epic     |
-| `task`     | `#357DE8` | Task     |
+| `epic`     | `#9F8FEF` | Epic     |
+| `task`     | `#579DFF` | Task     |
 | `spike`    | `#6CC3E0` | Spike    |
 | `incident` | `#AE2E24` | Incident |
 

--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -50,8 +50,8 @@ convention.
 | Label      | Color     | Maps to  |
 | ---------- | --------- | -------- |
 | `bug`      | `#C9372C` | Bug      |
-| `epic`     | `#8270DB` | Epic     |
-| `task`     | `#357DE8` | Task     |
+| `epic`     | `#9F8FEF` | Epic     |
+| `task`     | `#579DFF` | Task     |
 | `spike`    | `#6CC3E0` | Spike    |
 | `incident` | `#AE2E24` | Incident |
 


### PR DESCRIPTION
Closes #871.

`platform/github.md` and `platform/linear.md` gave `epic` and `task`
colours that no other source used:

| Label | was | now | matches |
|--------|-----|-----|---------|
| `epic` | `#8270DB` | `#9F8FEF` | `CLAUDE.md` §2.2 + live labels |
| `task` | `#357DE8` | `#579DFF` | `CLAUDE.md` §2.2 + live labels |

`bug`, `spike` and `incident` already agreed everywhere.

The platform template is nominally authoritative for concrete label
colours, but it was authoritative over a value no repository has ever
carried. Changing two table cells costs nothing; relabelling eleven
repositories to match would break existing filters.

`linear.md` copied its table from `github.md`, so both carried it.

## Gate

- `grep -rn '8270DB\|357DE8'` over `templates/ docs/ README.md CLAUDE.md` — no matches
- `py tools/sync.py --check` — all files in sync
- `py tests/run_smoke.py` — 23 checks, 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)