### PR TITLE
docs(platform): make milestones optional (#866)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3894,15 +3894,17 @@ before it becomes planned work:
 - A handoff breadcrumb names continuity, not priority. A
   "next: continue on X" pointer marks the cheapest resumption of the last
   thread, not the highest-priority move. Before acting, re-check X's
-  milestone and priority against the project's current milestone — if
-  they differ, ask first. The wrap-up writer MUST validate each candidate
-  against the tracker before listing it (`gh issue view <N>` or
-  equivalent — still open, in the current milestone, not blocked), drop
-  closed or out-of-milestone candidates, and record each surviving
-  pointer's milestone and priority inline so the next session sees any
-  mismatch. A breadcrumb is captured from session memory, not synced from
-  the tracker, so a stale entry burns the next session's setup time on
-  already-done work.
+  priority — and its milestone, where the project uses milestones —
+  against what the project is currently working on; if they differ, ask
+  first. The wrap-up writer MUST validate each candidate against the
+  tracker before listing it (`gh issue view <N>` or equivalent — still
+  open, not blocked, and not in a milestone the project has moved past),
+  drop closed candidates, and record each surviving pointer's priority
+  (and milestone, if any) inline so the next session sees any mismatch.
+  An issue with no milestone MUST NOT be dropped on that basis — an empty
+  milestone carries no scheduling signal either way. A breadcrumb is
+  captured from session memory, not synced from the tracker, so a stale
+  entry burns the next session's setup time on already-done work.
 
 ## Default scope boundaries
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -110,15 +110,17 @@ before it becomes planned work:
 - A handoff breadcrumb names continuity, not priority. A
   "next: continue on X" pointer marks the cheapest resumption of the last
   thread, not the highest-priority move. Before acting, re-check X's
-  milestone and priority against the project's current milestone — if
-  they differ, ask first. The wrap-up writer MUST validate each candidate
-  against the tracker before listing it (`gh issue view <N>` or
-  equivalent — still open, in the current milestone, not blocked), drop
-  closed or out-of-milestone candidates, and record each surviving
-  pointer's milestone and priority inline so the next session sees any
-  mismatch. A breadcrumb is captured from session memory, not synced from
-  the tracker, so a stale entry burns the next session's setup time on
-  already-done work.
+  priority — and its milestone, where the project uses milestones —
+  against what the project is currently working on; if they differ, ask
+  first. The wrap-up writer MUST validate each candidate against the
+  tracker before listing it (`gh issue view <N>` or equivalent — still
+  open, not blocked, and not in a milestone the project has moved past),
+  drop closed candidates, and record each surviving pointer's priority
+  (and milestone, if any) inline so the next session sees any mismatch.
+  An issue with no milestone MUST NOT be dropped on that basis — an empty
+  milestone carries no scheduling signal either way. A breadcrumb is
+  captured from session memory, not synced from the tracker, so a stale
+  entry burns the next session's setup time on already-done work.
 
 ## Default scope boundaries
 

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -275,10 +275,14 @@ GitHub implements issue types and priorities as labels. Every issue
 MUST have exactly one type label and one priority label. Triage
 labels are terminal — applied when closing without action.
 
-Every issue and pull request MUST also be assigned to a milestone
-at creation. Issues without a target release MUST use the `Backlog`
-milestone — the milestone field MUST NOT be empty. PRs SHOULD inherit
-the milestone of the issue they close.
+Milestones are optional. An issue MAY carry one; an empty milestone
+field is valid and means the work is not tied to a release. A PR
+SHOULD inherit the milestone of the issue it closes, when that issue
+has one.
+
+A project that does use milestones SHOULD route issues with no target
+release to a `Backlog` milestone, so "unmilestoned" and "deliberately
+unscheduled" stay distinguishable.
 
 The `Expedite` milestone is a rolling fast-track lane for work
 shipping between versioned releases — mainly bugs and incidents,


### PR DESCRIPTION
Closes #866.

Drops the MUST requiring a milestone on every issue and PR.

## Changes

**`platform/github.md`** — the mandate becomes a MAY. An empty
milestone field is valid and means the work is not tied to a release.
A project that *does* use milestones still gets the `Backlog` routing
advice, so "unmilestoned" and "deliberately unscheduled" stay
distinguishable. The `Expedite` lane and the milestones-versus-Releases
paragraphs are untouched.

**`base/workflow/scope.md`** — the handoff guard validated candidates
as "still open, in the current milestone, not blocked" and dropped
out-of-milestone ones. With milestones optional that filter discards
*every* unmilestoned issue, silently. It now treats an empty milestone
as carrying no scheduling signal, and only drops issues in a milestone
the project has moved past.

## Gate

- `grep -rn 'MUST also be assigned to a milestone'` over `templates/` — no matches
- `py tools/sync.py --check` — all files in sync (`generated/stack-tutorial.md` regenerated)
- `py tests/run_smoke.py` — 23 checks, 23 passed
- No prose line over 80 characters in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)