### PR TITLE
docs(platform): state Linear's label-scope constraints (#870)

### DIFF
--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -56,8 +56,39 @@ convention.
 | `incident` | `#AE2E24` | Incident |
 
 **Check:** list the team's issue labels. Every row above MUST report a
-parent of `Type`, and no label named `P0`–`P4`, `duplicate`, or
+parent of `Type` and a non-null team, no row MUST appear a second time
+outside the group, and no label named `P0`–`P4`, `duplicate`, or
 `wontdo` MUST exist.
+
+---
+
+## Label scope
+
+[ID: platform-linear-label-scope]
+
+A Linear label belongs either to the workspace or to one team, and the
+two do not mix. Migrating an existing workspace onto the taxonomy above
+fails on this unless the order is right.
+
+- A label group is team-scoped. A workspace label MUST NOT be parented
+  into one — Linear rejects it as a team mismatch.
+- Linear's stock `Bug`, `Feature` and `Improvement` labels are
+  workspace-scoped, so the labels a workspace already has are exactly
+  the ones that cannot join the group. Recreate the ones worth keeping
+  as team labels.
+- Label names are reserved workspace-wide. To replace a workspace label
+  with a team label of the same name: rename the original to free the
+  name, create the replacement inside the group, apply it to every issue
+  that carried the original, and only then delete the original.
+  Deleting first strips the label from every issue in the gap.
+- Retiring one grouped label into another MUST rewrite the issue's whole
+  label set in one update. A group admits one label, so adding the
+  replacement first is rejected, and removing first leaves the issue
+  untyped while the write is in flight.
+- After deleting a label, re-read the label list and delete any residual
+  copy. `issueLabelDelete` reports success while leaving an ungrouped
+  duplicate carrying the label's pre-rename colour, so a migration that
+  trusts the return value leaves the workspace dirty.
 
 ---
 


### PR DESCRIPTION
Closes #870.

Adds `[ID: platform-linear-label-scope]` to `platform/linear.md`, and
extends the existing type-label **Check**.

`platform-linear-labels` said to create a `Type` group and put every
type label in it, without saying that Linear labels are scoped to
either the workspace or one team. Applying it to a workspace that
already has Linear's stock labels fails three ways:

| constraint | Linear's error |
|---|---|
| a group is team-scoped | `Cannot add a label to a group from a different team.` |
| names are reserved workspace-wide | `Label "bug" already exists in the workspace.` |
| a group admits one label | `Only one label in a group can be applied to an issue.` |

The obvious workaround is worse than the failure. Deleting the stock
label to free the name **succeeds**, and strips it from every issue
that carried it — 14 issues in the workspace this was derived from.
The template now mandates rename-first, so the original stays on its
issues until the replacement is applied.

A fourth behaviour is documented because it is silent:
`issueLabelDelete` returned `success: true` twice while leaving an
ungrouped residual carrying the label's pre-rename colour. A migration
that trusts the return value stops early and leaves a duplicate,
wrongly-coloured label behind. The **Check** now asserts no row appears
a second time outside its group, and that every grouped label reports a
non-null team.

## Gate

- `py tools/sync.py --check` — all files in sync
- `py tests/run_smoke.py` — 23 checks, 23 passed
- No prose line over 80 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)