### PR TITLE
feat(workflow): four severities, P4 as a deferral marker (#869)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,8 +104,13 @@ are terminal — applied when closing without action.
 | `P0` | `#E06C00` | Critical — blocks everything |
 | `P1` | `#FCA700` | High — must fix before next milestone |
 | `P2` | `#EED12B` | Medium — important but not blocking |
-| `P3` | `#4BCE97` | Low — nice to have |
-| `P4` | `#8590A2` | Backlog — someday |
+| `P3` | `#4BCE97` | Low — nice to have, including trivial |
+
+#### Deferral label (optional)
+
+| Label | Color | Meaning |
+|-------|-------|---------|
+| `P4` | `#8590A2` | Deliberately deferred — accompanies a severity, never replaces one |
 
 #### Triage labels
 

--- a/docs/decisions/021-priority-scale-four-severities.md
+++ b/docs/decisions/021-priority-scale-four-severities.md
@@ -1,0 +1,94 @@
+---
+id: "021"
+status: Accepted
+date: 2026-08-01
+category: process
+supersedes: []
+superseded_by: []
+---
+
+# ADR-021: Four severities, with P4 as a deferral marker
+
+## Context
+
+The priority scale defines five bands, `P0`–`P4`, described as
+critical, high, medium, low and "Backlog — someday". Four of those are
+severities; the fifth is a scheduling statement. `P4` has carried both
+meanings since it was written, and the two do not compose: an issue can
+be trivially small *and* urgent, or critical *and* parked.
+
+The ambiguity stayed latent while the only implementation was GitHub
+labels, which impose no structure on what a label means. It surfaced
+when the scale had to map onto a tracker with a typed priority field.
+Such fields offer four named severities plus an "unset" value that
+means untriaged, not "lowest". Five bands cannot map onto four names
+without either merging two severities or spending the untriaged slot on
+a real one.
+
+Spending the untriaged slot is the worse option in practice. In the
+workspace this was measured on, 185 of 370 issues were untriaged and 22
+carried `P4`; folding the latter into the former makes 22 deliberate
+decisions unfindable among 185 non-decisions.
+
+Usage across seven repositories, issues open and closed (n=482), shows
+where the scale earns its keep:
+
+| Band | Count | Share |
+|------|-------|-------|
+| `P0` | 10    | 2%    |
+| `P1` | 47    | 10%   |
+| `P2` | 124   | 26%   |
+| `P3` | 279   | 58%   |
+| `P4` | 22    | 5%    |
+
+`P0` fires on 2% of issues, which is the distribution a "drop
+everything" band should have — rare, not withering. `P3` and `P4`
+together account for 63%, and the distinction between "low" and
+"trivial" is not one the project has ever acted on.
+
+## Decision
+
+1. **Four severities** — the scale is `P0` critical, `P1` high, `P2`
+   medium, `P3` low. `P3` MUST cover work previously described as
+   trivial; "low" and "trivial" are one band.
+
+2. **`P4` is not a severity** — it marks work deliberately deferred,
+   and MUST NOT be read as a severity ranking. An issue MAY carry `P4`
+   at any severity.
+
+3. **Severity is mandatory, deferral is not** — every issue MUST carry
+   exactly one of `P0`–`P3`. `P4` is optional and additional.
+
+4. **On a tracker with a typed priority field**, `P0`–`P3` MUST map
+   onto the four named values in order, and the unset value MUST mean
+   untriaged. `P4` MUST NOT consume the unset value; it is carried as a
+   label, a milestone, or the tracker's own deferral mechanism.
+
+## Alternatives considered
+
+- **Collapse `P0` into `P1`** — rejected; it merges "stop other work"
+  with "take next" to solve a problem at the opposite end of the scale,
+  and discards the one band whose rarity is evidence it is working.
+- **Keep five severities, map `P4` to the unset value** — rejected;
+  deliberate deferrals become indistinguishable from untriaged issues,
+  which outnumber them roughly eight to one.
+- **Keep five severities and let platforms diverge** — rejected; the
+  point of defining the scale centrally is that a band means the same
+  thing wherever it is read.
+- **Drop `P4` entirely** — rejected; deferral is real and needs a
+  marker. Removing it pushes the information into prose, where it stops
+  being filterable.
+
+## Consequences
+
+- `base/workflow/issues.md` restates the priority table with four
+  severities and `P4` as a deferral marker.
+- `platform/github.md` and `platform/linear.md` restate their priority
+  sections; the Linear mapping table drops its `P4` row from the native
+  field.
+- `CLAUDE.md` §2.2 restates the priority label meanings.
+- Existing `P4` issues keep their label and gain a severity. Projects
+  MUST assign one rather than inferring it, since `P4` never encoded a
+  severity in the first place.
+- Tooling that treats `P0`–`P4` as a single ordered enum needs to treat
+  `P4` as orthogonal instead.

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3587,8 +3587,12 @@ project-specific; the at-creation discipline is not.
 | P0 | Critical — blocks everything |
 | P1 | High — must fix before next milestone |
 | P2 | Medium — important but not blocking |
-| P3 | Low — nice to have |
-| P4 | Backlog — someday |
+| P3 | Low — nice to have, including trivial |
+
+`P4` is not a severity. It marks work deliberately deferred, and MAY
+accompany any of `P0`–`P3` — deferring a high-severity issue is a
+scheduling decision, not a downgrade. Every issue MUST carry exactly
+one of `P0`–`P3`; `P4` is optional and additional.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -26,8 +26,12 @@ project-specific; the at-creation discipline is not.
 | P0 | Critical — blocks everything |
 | P1 | High — must fix before next milestone |
 | P2 | Medium — important but not blocking |
-| P3 | Low — nice to have |
-| P4 | Backlog — someday |
+| P3 | Low — nice to have, including trivial |
+
+`P4` is not a severity. It marks work deliberately deferred, and MAY
+accompany any of `P0`–`P3` — deferring a high-severity issue is a
+scheduling decision, not a downgrade. Every issue MUST carry exactly
+one of `P0`–`P3`; `P4` is optional and additional.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -321,7 +321,15 @@ remain visually distinct when displayed side by side.
 | `P1`  | `#FCA700` | P1 — High     |
 | `P2`  | `#EED12B` | P2 — Medium   |
 | `P3`  | `#4BCE97` | P3 — Low      |
-| `P4`  | `#8590A2` | P4 — Backlog  |
+
+### Deferral label (optional)
+
+| Label | Color     | Meaning                       |
+| ----- | --------- | ----------------------------- |
+| `P4`  | `#8590A2` | Deliberately deferred         |
+
+`P4` is not a severity and MUST accompany a severity label rather than
+replace one.
 
 ### Triage labels
 

--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -96,9 +96,9 @@ fails on this unless the order is right.
 
 [ID: platform-linear-priority]
 
-Linear ships a native priority field with exactly five values, mapping
-one-to-one onto the base taxonomy. Use it — a label cannot drive board
-ordering, saved filters, or the no-priority bucket.
+Linear's native priority field carries four named severities plus an
+unset value. Use it — a label cannot drive board ordering or saved
+filters.
 
 | Base | Linear field | API value |
 | ---- | ------------ | --------- |
@@ -106,13 +106,15 @@ ordering, saved filters, or the no-priority bucket.
 | P1   | High         | 2         |
 | P2   | Medium       | 3         |
 | P3   | Low          | 4         |
-| P4   | No priority  | 0         |
 
-- Set priority at creation.
-- `No priority` is also the default for an untouched issue, so P4 and
-  never-triaged are indistinguishable in the field. When that
-  distinction matters, route intake through Triage rather than
-  reintroducing a priority label.
+- Set a severity at creation.
+- `No priority` (0) MUST mean untriaged, and MUST NOT be used for any
+  severity. It is the default for an untouched issue, so spending it on
+  a severity makes deliberate decisions indistinguishable from absent
+  ones.
+- `P4` is a deferral marker, not a severity, so it has no place in this
+  field. Carry it as a label outside every group, or as the tracker's
+  own deferral mechanism.
 
 ---
 


### PR DESCRIPTION
Closes #869. Records the decision as ADR-021.

## The problem

`P4` was defined as "Backlog — someday", a *scheduling* statement, while
the scale it sits in is a *severity* ranking. Those axes do not compose:
work can be trivially small and urgent, or critical and parked.

It surfaced when the scale had to map onto a typed priority field, which
offers four named severities plus an unset value meaning untriaged. Five
bands cannot map onto four names without either merging two severities or
spending the untriaged slot.

## Why not collapse `P0`/`P1`, the first instinct

Usage across seven repositories, open and closed (n=482):

| Band | Count | Share |
|------|-------|-------|
| `P0` | 10    | 2%    |
| `P1` | 47    | 10%   |
| `P2` | 124   | 26%   |
| `P3` | 279   | 58%   |
| `P4` | 22    | 5%    |

`P0` fires on 2% — the distribution a "drop everything" band *should*
have. Merging it into `P1` conflates "stop other work" with "take next"
to fix a problem at the opposite end. `P3`+`P4` take 63%, and the
low/trivial distinction has never been acted on.

Spending the untriaged slot is also worse than it looks: 185 of 370
issues in the reference workspace are untriaged against 22 `P4`s, so
folding one into the other buries 22 decisions among 185 non-decisions.

## Decision

Four severities — `P0` critical, `P1` high, `P2` medium, `P3` low
including trivial. `P4` stops being a severity and becomes an optional
deferral marker that accompanies one.

## Changed

| File | Change |
|---|---|
| `docs/decisions/021-*.md` | new ADR |
| `base/workflow/issues.md` | priority table, plus the `P4` rule |
| `platform/github.md` | `P4` moved to its own "Deferral label" table |
| `platform/linear.md` | native-field mapping drops its `P4` row; `No priority` MUST mean untriaged |
| `CLAUDE.md` §2.2 | same split |

## Migration

Existing `P4` issues keep the label and need a severity assigned — not
inferred, since `P4` never encoded one.

## Gate

- `py tests/run_smoke.py` — 23 checks, 23 passed (incl. `ADR-01` schema)
- `py tools/sync.py --check` — all files in sync
- No prose line over 80 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)