### PR TITLE
docs: carry the Linear ticket in branch names, in upper case (#878)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,10 @@ py tools/audit_redundancy.py --check          # CI gate — fail on new dups
 ### 2.1 Git
 
 - Branch: `main` (protected) — never commit directly
-- Branch naming: `feat/<scope>`, `fix/<scope>`, `docs/<scope>`,
-  `chore/<scope>`
+- Branch naming: `<type>/<TICKET>-<scope>` — e.g.
+  `feat/BRA-42-label-scope`. Types: feat, fix, docs, chore. The Linear
+  ticket goes in upper case, as Linear displays it. Omit it only when
+  there is no ticket
 - Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
   docs, refactor
 - PR titles: `<type>(<scope>): <summary> (#issue)` — same format

--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -206,9 +206,13 @@ Linear tracks parent and child natively and rolls up progress.
   issue still closes, but no pull request attaches to it and it jumps
   straight to `completed`, never passing through a `started` state.
 - Match the identifier anywhere in the name, so the code host's own
-  branch convention survives: `feat/<identifier>-<scope>`. Only the
+  branch convention survives: `feat/<IDENTIFIER>-<scope>`. Only the
   identifier is matched; the title slug the tracker suggests is
   decoration.
+- The identifier matches case-insensitively. Write it in the case the
+  tracker displays — upper case for Linear — so the branch reads as the
+  same token as the ticket. The generated branch name the tracker
+  offers may lower-case it; either works.
 - Configure the automation to move an issue to a `started` state on PR
   open and to a `completed` state on merge.
 - Two-way issue sync duplicates the tracker. Enable it per repository


### PR DESCRIPTION
Closes #878.

- `CLAUDE.md` §2.1 — branch naming becomes `<type>/<TICKET>-<scope>`,
  e.g. `feat/BRA-42-label-scope`
- `platform/linear.md` — states that matching is case-insensitive and
  recommends writing the identifier in the tracker's display case

Without the ticket in the branch, issue sync still closes it on merge,
but no PR attaches to it and it never passes through a started state.
Upper case is legibility, not function.

## Gate

- `py tools/sync.py --check` — all files in sync
- `py tests/run_smoke.py` — 23 checks, 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)