### PR TITLE
docs(git): drop the Linear ticket from branch naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,8 @@ py tools/audit_redundancy.py --check          # CI gate — fail on new dups
 ### 2.1 Git
 
 - Branch: `main` (protected) — never commit directly
-- Branch naming: `<type>/<TICKET>-<scope>` — e.g.
-  `feat/BRA-42-label-scope`. Types: feat, fix, docs, chore. The Linear
-  ticket goes in upper case, as Linear displays it. Omit it only when
-  there is no ticket
+- Branch naming: `feat/<scope>`, `fix/<scope>`, `docs/<scope>`,
+  `chore/<scope>`
 - Commits: `<type>(<scope>): <summary>` — types: feat, fix, chore,
   docs, refactor
 - PR titles: `<type>(<scope>): <summary> (#issue)` — same format


### PR DESCRIPTION
CLAUDE.md §2.1 mandated a Linear ticket in branch names (`feat/BRA-42-scope`,
added in #879). GitHub is the system of record for this repo and Linear is a
read-only view, so the convention reverts to the tracker-agnostic form.

Only CLAUDE.md changes — `templates/platform/linear.md` is a deliverable for
consumers and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)