### PR TITLE
fix(workflow): verify branch cleanup against the PR record (#865)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3839,9 +3839,16 @@ Before starting any work, the agent MUST:
    wrap — not stash or delete. If the change is something else, ask what
    it is and whether it should ship before the new scope.
 5. Clean up stale branches: `git fetch --prune` to remove stale
-   remote-tracking refs, then `git branch --merged main | grep -v
-   main | xargs -r git branch -d` to delete local branches whose
-   PRs have squash-merged
+   remote-tracking refs, then delete local branches whose PRs have
+   merged. Verify each against the PR record, never against
+   `git branch --merged` — a squash merge writes a new commit that
+   the branch tip is not an ancestor of, so the filter matches
+   nothing and exits 0, which is indistinguishable from "nothing to
+   clean". When the PR is merged but its head no longer matches the
+   local tip, the remote head was rewritten (safe) or the branch
+   holds unpushed commits (not safe): inspect the difference rather
+   than assuming either. Concrete commands belong in the platform
+   template.
 6. Check deploy health — verify the latest CI/CD deploy on `main`
    completed successfully; flag if stuck, failed, or pending. A deploy
    can sit broken for hours unnoticed when startup checks only cover

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -28,9 +28,16 @@ Before starting any work, the agent MUST:
    wrap — not stash or delete. If the change is something else, ask what
    it is and whether it should ship before the new scope.
 5. Clean up stale branches: `git fetch --prune` to remove stale
-   remote-tracking refs, then `git branch --merged main | grep -v
-   main | xargs -r git branch -d` to delete local branches whose
-   PRs have squash-merged
+   remote-tracking refs, then delete local branches whose PRs have
+   merged. Verify each against the PR record, never against
+   `git branch --merged` — a squash merge writes a new commit that
+   the branch tip is not an ancestor of, so the filter matches
+   nothing and exits 0, which is indistinguishable from "nothing to
+   clean". When the PR is merged but its head no longer matches the
+   local tip, the remote head was rewritten (safe) or the branch
+   holds unpushed commits (not safe): inspect the difference rather
+   than assuming either. Concrete commands belong in the platform
+   template.
 6. Check deploy health — verify the latest CI/CD deploy on `main`
    completed successfully; flag if stuck, failed, or pending. A deploy
    can sit broken for hours unnoticed when startup checks only cover

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -224,9 +224,39 @@ gate categories to GitHub Actions workflows and GitHub-native features.
 
 ---
 
-## GitHub Pages
+## Branch cleanup
 
-[ID: platform-github-pages]
+[ID: platform-github-branch-cleanup]
+
+A squash merge writes a new commit, so `git branch --merged main` never
+matches a squash-merged branch. It exits 0 having deleted nothing, which
+reads exactly like a clean tree. Use the PR record instead — it survives
+the head branch's deletion.
+
+```bash
+gh pr view <N> --json state,headRefOid --jq '"\(.state) \(.headRefOid)"'
+git rev-parse <branch>
+```
+
+- `MUST` treat the branch as deletable only when the PR state is
+  `MERGED` and `headRefOid` equals the local tip — then `git branch -D`
+  (`-d` refuses, for the same ancestry reason `--merged` fails)
+- A differing `headRefOid` is the normal case wherever branch protection
+  requires branches be up to date, because `gh pr update-branch` rewrites
+  the remote head and leaves the clone on the commit it replaced. Treat
+  the mismatch as a prompt to inspect, never as proof of unpushed work
+- `MUST` inspect a mismatch by content before deleting. Comparing
+  ancestry gives false positives after a rebase, since the same work
+  carries a new SHA on each side:
+
+```bash
+git fetch origin refs/pull/<N>/head
+git diff --numstat FETCH_HEAD..<branch>
+```
+
+- Lines present only on the local side are safe when they are text later
+  commits superseded. Unique work in the file the branch authored is
+  not — push it before deleting
 
 - MUST enable "Enforce HTTPS" in repository Settings → Pages for custom
   domains — GitHub Pages does not enforce HTTPS by default


### PR DESCRIPTION
Closes #865.

`git branch --merged main` lists branches whose tip is an ancestor of main.
A squash merge writes a new commit, so a squash-merged branch never matches —
the pipeline exits 0 having deleted nothing, indistinguishable from a clean
tree. This session hit it live: four merged branches survived the documented
cleanup.

- `base/workflow/scope.md` — startup item 5 states the requirement
  (verify against the PR record, not `--merged`) and defers commands to the
  platform template, matching how item 6 already handles deploy checks.
- `platform/github.md` — new `Branch cleanup` section with the `gh` commands.

Includes the third step #865 left open: a differing `headRefOid` is the
*normal* case under branch protection, because `gh pr update-branch` rewrites
the remote head. Without that, the check trades a silent false-negative for a
permanent false-positive — all four branches this session mismatched, and all
four were safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)