### PR TITLE
feat(testing): forbid tests from signalling host processes (#858)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1435,6 +1435,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -215,6 +215,17 @@ fixing the design fixes the testability.
   frameworks), never rely on the ambient process state. A test that
   passes or fails depending on run order is an isolation bug, not
   flakiness
+- A test MUST NOT enumerate, signal, or terminate a process it did not
+  start, and MUST NOT mutate host state outside the working directory —
+  the process table, system services, the registry, or the user's
+  running applications. Where the code under test reaches the host,
+  the suite MUST stub that boundary rather than exercise it, even when
+  the test's own subject is already faked: a fake at one seam does not
+  neutralise a real call at another. This is a distinct class from
+  in-process leakage, and more severe — the failure is damage to the
+  developer's machine, not a flaky test, and a suite doing it can pass
+  every assertion while leaving only a line on stderr. Code that
+  reaches the host SHOULD take that reach as an injectable dependency
 - A failing test MUST trigger an investigation before any other action —
   never suppress or skip a failing test without a documented reason
 - Tests are code and MUST be treated as such — they MAY contain bugs; when


### PR DESCRIPTION
Closes #858.

`base/core/testing.md` covers in-process isolation well — shared state,
environment variables, import-time mutation. It said nothing about a test
reaching *outside* its own process, which is a different and more severe
class: the failure is damage to the developer's machine, not a flaky test.

The evidence in #858 is a plain `pytest` run that killed a real Chrome
process on the dev machine. No test launched a browser — the engines were
faked — but the code under test sampled the live OS process list and
registered an `atexit` handler to kill anything new. Every test passed; the
only sign was one line on stderr.

Added as a sibling of "Each test MUST be independent", including the part
that makes it non-obvious: a fake at one seam does not neutralise a real
call at another.

Regenerates all 17 chains — `testing.md` is core tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)