### PR TITLE
feat(git): never delete a base branch under a stacked PR (#859)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -556,6 +556,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -129,6 +129,23 @@ force-push, which is forbidden.
 This keeps remote history intact and yields a clean,
 dependency-free diff.
 
+### Merging a stack
+
+Merging the base PR with a delete-branch flag does not retarget the PR
+stacked on it. The host closes that PR and deletes its head branch, and
+it cannot be reopened, because reopening requires the base ref to exist.
+
+- MUST merge a stack bottom-up
+- MUST NOT delete a branch while any PR still targets it — retarget the
+  dependent PR to `main` first, then delete
+- To recover: recreate the deleted ref from `main`, reopen the PR,
+  retarget it to `main`, delete the ref again, then update the branch
+
+The same shape bites automated dependency PRs. Merging a change to the
+bot's own config invalidates every open PR it raised, closing them and
+deleting their branches. Merge the pending bumps first when the intent
+is to take them and change the policy.
+
 ### Bulk operations
 
 When a bulk operation (cohort emit, codebase-wide migration, mass


### PR DESCRIPTION
Closes #859.

`git.md` already had "De-stacking a dependent branch", which handles the
*post*-merge case: B contains A's now-duplicate commit, don't rebase, branch
fresh and cherry-pick. It did not cover the hazard that happens one step
earlier and is irreversible.

Merging the base PR with a delete-branch flag does not retarget the PR
stacked on it — the host closes it and deletes its head branch, and it cannot
be reopened because reopening requires the base ref to exist.

New `Merging a stack` section, sibling to the existing one, with the rule and
the recovery sequence. Kept host-agnostic; the `gh` spelling stays out of the
base layer, matching how #865 split scope.md from platform/github.md.

Also covers the same shape in automated dependency PRs: merging a change to
the bot's config invalidates and closes every open PR it raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)