### PR TITLE
fix(git): distinguish the two branch-deletion paths under a stack (#863)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -533,7 +533,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -558,15 +562,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -106,7 +106,11 @@ remaining commits are silently lost.
 - MUST verify that all branch commits are accounted for before
   deleting a branch — compare the squash diff against the branch diff
 - SHOULD enable "automatically delete head branches" in repository
-  settings to prevent stale branches from accumulating
+  settings to prevent stale branches from accumulating. It fires on
+  merge only — a PR closed without merging leaves its branch behind
+  permanently, so branch hygiene is not fully automatic. It is the
+  safe way to delete a branch under a stack, because deletion as part
+  of the merge retargets dependent PRs rather than closing them
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —
@@ -131,15 +135,25 @@ dependency-free diff.
 
 ### Merging a stack
 
-Merging the base PR with a delete-branch flag does not retarget the PR
-stacked on it. The host closes that PR and deletes its head branch, and
-it cannot be reopened, because reopening requires the base ref to exist.
+How the base branch is deleted decides whether the PR stacked on it
+survives. The two paths differ, and only one is safe:
+
+- Deleting the branch **as part of the merge** — the repository's
+  automatic head-branch deletion — retargets the dependent PR onto the
+  merged PR's own base and leaves it open
+- Deleting the branch **as a separate step**, such as a delete-branch
+  flag on the merge command, does not. The host closes the dependent PR,
+  and it cannot be reopened, because reopening requires the base ref to
+  exist
+
+Rules:
 
 - MUST merge a stack bottom-up
-- MUST NOT delete a branch while any PR still targets it — retarget the
-  dependent PR to `main` first, then delete
-- To recover: recreate the deleted ref from `main`, reopen the PR,
-  retarget it to `main`, delete the ref again, then update the branch
+- MUST NOT pass a delete-branch flag while any PR still targets the
+  branch — let automatic deletion handle it, or retarget the dependent
+  PR first and delete afterwards
+- To recover: recreate the deleted ref from the base branch, reopen the
+  PR, retarget it, delete the ref again, then update the branch
 
 The same shape bites automated dependency PRs. Merging a change to the
 bot's own config invalidates every open PR it raised, closing them and


### PR DESCRIPTION
Closes #863. Corrects #859 (shipped in #890).

#863 asked whether the *automatic* head-branch deletion behaves like the
manual `--delete-branch` flag under a stack, and deliberately did not assert
an answer. I tested it on two throwaway stacks against scratch bases, so
`main` was never involved.

| Path | Stacked PR | Base |
|---|---|---|
| `gh pr merge --squash --delete-branch` | CLOSED, unrecoverable | not retargeted |
| `gh pr merge --squash` + repo auto-delete | OPEN | retargeted to the merged PR's base |

Two consequences:

1. **#863's Gap 1** — auto-delete fires on merge only, so a PR closed unmerged
   leaves its branch behind. Recorded on the bullet.
2. **#859 was too broad.** Its `MUST NOT delete a branch while any PR still
   targets it` also forbade the automatic path, contradicting the same file's
   `SHOULD enable "automatically delete head branches"` two sections earlier.
   Narrowed to the delete-branch *flag*, which is the actual hazard.

The probe PRs (#891–#894) and all `probe/*` branches are deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)