### PR TITLE
feat(git): recommend fetch.prune for stale remote-tracking refs (#836)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -538,6 +538,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -111,6 +111,10 @@ remaining commits are silently lost.
   permanently, so branch hygiene is not fully automatic. It is the
   safe way to delete a branch under a stack, because deletion as part
   of the merge retargets dependent PRs rather than closing them
+- SHOULD set `fetch.prune` so every fetch reconciles remote-tracking
+  refs deleted on the server — the client-side complement to the
+  setting above. Without it, `origin/<branch>` survives the branch it
+  points at and reads as a branch that will not delete
 - SHOULD use one focused commit per scope-slice on the branch
   rather than per-folder atomic commits. The squash collapses
   them on merge, so the per-folder narrative is wasted effort —


### PR DESCRIPTION
Closes #836.

`git.md` already advises enabling automatic head-branch deletion. That removes
the branch on the server and, on a synced merge, locally — but leaves a third
artifact: the remote-tracking ref `origin/<branch>`. A plain fetch or pull
never removes it, so deleted branches keep appearing in `git branch -r`
indefinitely. They are dangling pointers, but they read as "branches that
won't delete".

Added as a sibling bullet to the existing rule rather than its own section,
since it is the client-side half of the same hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)