### PR TITLE
fix(workflow): make the end-of-session audit produce, not just check (#825)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -4020,7 +4020,9 @@ summarize — visible sequential execution prevents missed steps.
 
 1. **Commits and push** — all changes committed and pushed (via PR if
    branch-protected)
-2. **Close issues** — close completed issues (verify auto-close worked)
+2. **Close issues** — reconcile the open-issue list against the work
+   shipped this session, from the tracker rather than memory, and close
+   what is done (verify auto-close worked)
 3. **Epic checklists** — update epic checklists if relevant
 4. **Dev journal** — add a session entry to `docs/dev-journal.md`
    (date, tool, key changes, PRs merged, issues closed/created)
@@ -4039,10 +4041,13 @@ summarize — visible sequential execution prevents missed steps.
    here. Evaluate items individually; do not batch-dismiss.
 7. **README.md** — for each new command, dependency, or structural
    change, is it reflected? Name the section.
-8. **ONBOARDING.md** — for each new tool, prerequisite, or setup step,
-   is it documented in `docs/ONBOARDING.md`? Name the section.
-9. **PLAYBOOK.md** — for each new command, script, or workflow added,
-   is it documented in `docs/PLAYBOOK.md`? Name the section.
+8. **ONBOARDING.md** — ensure `docs/ONBOARDING.md` exists and covers
+   each new tool, prerequisite, or setup step. Create it if missing;
+   name the section. A missing doc is work to do here, not a gap to
+   report.
+9. **PLAYBOOK.md** — ensure `docs/PLAYBOOK.md` exists and covers each
+   new command, script, or workflow added. Create it if missing; name
+   the section. A missing doc is work to do here, not a gap to report.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
@@ -4068,7 +4073,9 @@ summarize — visible sequential execution prevents missed steps.
 12. **Flag gaps** — if any item cannot be completed this session, report
     it as pending (never as done) before closing — including deferred
     cross-repo work, such as an upstream contribution that was flagged
-    but not yet landed
+    but not yet landed. Reserve "pending" for work that is genuinely
+    blocked — it needs a decision, a credential, or the user. Work the
+    agent could do but has not done is not pending; do it.
 13. **Summary** — summarize what was done and what's next
 
 

--- a/templates/base/workflow/scope.md
+++ b/templates/base/workflow/scope.md
@@ -163,7 +163,9 @@ summarize — visible sequential execution prevents missed steps.
 
 1. **Commits and push** — all changes committed and pushed (via PR if
    branch-protected)
-2. **Close issues** — close completed issues (verify auto-close worked)
+2. **Close issues** — reconcile the open-issue list against the work
+   shipped this session, from the tracker rather than memory, and close
+   what is done (verify auto-close worked)
 3. **Epic checklists** — update epic checklists if relevant
 4. **Dev journal** — add a session entry to `docs/dev-journal.md`
    (date, tool, key changes, PRs merged, issues closed/created)
@@ -182,10 +184,13 @@ summarize — visible sequential execution prevents missed steps.
    here. Evaluate items individually; do not batch-dismiss.
 7. **README.md** — for each new command, dependency, or structural
    change, is it reflected? Name the section.
-8. **ONBOARDING.md** — for each new tool, prerequisite, or setup step,
-   is it documented in `docs/ONBOARDING.md`? Name the section.
-9. **PLAYBOOK.md** — for each new command, script, or workflow added,
-   is it documented in `docs/PLAYBOOK.md`? Name the section.
+8. **ONBOARDING.md** — ensure `docs/ONBOARDING.md` exists and covers
+   each new tool, prerequisite, or setup step. Create it if missing;
+   name the section. A missing doc is work to do here, not a gap to
+   report.
+9. **PLAYBOOK.md** — ensure `docs/PLAYBOOK.md` exists and covers each
+   new command, script, or workflow added. Create it if missing; name
+   the section. A missing doc is work to do here, not a gap to report.
 10. **Submodules** — check if upstream submodules need updates
     (`git submodule update --remote`); commit the pointer bump if needed
 11. **Template feedback** — for each new pattern or convention
@@ -211,5 +216,7 @@ summarize — visible sequential execution prevents missed steps.
 12. **Flag gaps** — if any item cannot be completed this session, report
     it as pending (never as done) before closing — including deferred
     cross-repo work, such as an upstream contribution that was flagged
-    but not yet landed
+    but not yet landed. Reserve "pending" for work that is genuinely
+    blocked — it needs a decision, a credential, or the user. Work the
+    agent could do but has not done is not pending; do it.
 13. **Summary** — summarize what was done and what's next


### PR DESCRIPTION
Closes #825.

Several audit items were phrased as questions — "is it documented in
`ONBOARDING.md`? Name the section." A wrap agent reading that reasonably
*flags* a missing doc as pending rather than *creating* it, which is what
happened downstream in protocol-devicenet: ONBOARDING and PLAYBOOK flagged
pending, a completed issue left open, a reusable candidate named but not filed.

Four items made imperative:

- **2 Close issues** — reconcile against the tracker, not memory
- **8 ONBOARDING** / **9 PLAYBOOK** — ensure it exists and covers the change;
  create if missing. "A missing doc is work to do here, not a gap to report."
- **12 Flag gaps** — "pending" is reserved for genuinely blocked work (needs a
  decision, a credential, or the user); work the agent could do is not pending

Item 11 (template feedback) already carries the imperative "naming a candidate
is not contributing it" from #761, so it needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)