### PR TITLE
feat(testing): verify a visual change against the render (#820)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1572,6 +1572,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -317,6 +317,31 @@ reached the bug site AND took the new branch.
 
 ---
 
+## Verify a visual change against the render
+[ID: testing-verify-the-render]
+
+When a change's intended effect is visual — a style edit, a template, a
+chart, a rendered document — re-reading the source proves only that the
+source changed. Several things break the link between source and result
+silently: a design token resolves to an unexpected value, a more
+specific rule wins the cascade, a built or deployed artifact lags its
+source until pushed, or a cached copy is served.
+
+- MUST verify by capturing the rendered output and asserting on it —
+  render headless, then read the value off the pixels or the resolved
+  DOM, not off the stylesheet
+- SHOULD capture the before as well as the after. The before confirms
+  the problem is real; a page may already satisfy the request, making
+  the change a fix for nothing
+- When the render still looks wrong, confirm it is the fresh build
+  before re-editing. Correct source and a stale deploy is the common
+  shape of "it's still broken" reported against already-fixed code
+
+This complements golden-output gating, which pins structure and text but
+cannot answer whether something is actually black, centred, or on screen.
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 


### PR DESCRIPTION
Closes #820.

New section in `base/core/testing.md`, placed after "Verify the fix fires on
real data" — same family: an indirect green signal that lies.

The downstream case: a `color: var(--accent)` → `var(--ink)` CTA change was
confirmed correct in source, but the stakeholder still saw the old colour,
because the CI-built gallery had not been redeployed. A headless render plus a
pixel sample confirmed the fix locally and located the real gap.

Includes the two parts that are easy to skip — capturing the *before* (a page
may already satisfy the request, making the change a fix for nothing), and
confirming you are looking at a fresh build before re-editing correct code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)