### PR TITLE
feat(core): warn that vendoring the submodule breaks tree-walking tools (#861)

### DIFF
--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -345,6 +345,23 @@ checklist into a short bullet list: that silently drops steps and the
 
 ---
 
+## Vendoring the templates
+
+The reference and hybrid models both vendor this repository as a
+submodule. That puts files on disk which the consuming repository does
+not track, and any tool that walks the tree rather than the VCS index
+will scan them — linters, formatters, secret scanners, spell checkers,
+link checkers.
+
+- MUST exclude the submodule path in each such tool's config before the
+  first commit. Tools scoped by an explicit file list need no change
+- CI may not reveal the problem: checkout actions commonly skip
+  submodules by default, so the CI job sees an empty directory while the
+  local command contributors are told to run before pushing fails. A
+  green dashboard is not evidence here
+
+---
+
 ## Monorepo support (optional)
 
 Some agents walk the directory tree from the project root to the


### PR DESCRIPTION
Closes #861.

`agents.md` recommends the hybrid and reference models, both of which vendor
this repository as a submodule — and then says nothing about what that does to
the consuming project's tooling.

Linters and formatters walk the filesystem, not the VCS index. The submodule's
files are untracked by the consumer but present on disk, so they get scanned.
Downstream in page-fetcher that was 85 ruff errors within minutes of adding the
submodule, none fixable from the consuming repository.

The part worth stating explicitly is that **CI stays green**: checkout actions
skip submodules by default, so the lint job sees an empty directory. Only the
local command the README tells contributors to run breaks — the one nobody
watches on a dashboard.

New shared section rather than a note in each model, since both vendor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)