### PR TITLE
feat(core): forbid ADR citations in the README (#882)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1246,11 +1246,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -108,11 +108,16 @@ Every README MUST contain the following sections, in this order:
   describe what the project does, not how good it is
 
 ### Audience
-- A README serves two audiences. The first three sections (title,
-  quick start, usage) are user-facing — what the product does and
-  how to use it. The remaining sections (structure, setup, config)
-  are developer-facing — how to build and contribute. Write each
-  section for its audience.
+- A README serves two audiences. The first four sections (title,
+  features, quick start, usage) are user-facing — what the product
+  does and how to use it. The remaining sections (structure, setup,
+  config) are developer-facing — how to build and contribute. Write
+  each section for its audience.
+- A README MUST NOT cite an individual decision record. The two
+  audiences above are users and contributors; a decision record serves
+  whoever maintains the decision. Link the document that explains the
+  behaviour and let that document cite the record. The decisions
+  directory MAY still appear in Project structure, which maps the tree
 - Write for a reader who has not seen this project before — MUST
   NOT assume familiarity with internal terminology
 - Acronyms MUST be expanded on first use


### PR DESCRIPTION
Closes #882.

`readme.md` said nothing about decision records, so generated READMEs cite
them inline — "see ADR-002 for why the floor is measured against reality".
That asks a reader evaluating the project to follow an internal argument they
did not come for. Downstream in page-fetcher the README had grown four inline
ADR citations plus two links into an upstream repo; all six were reachable
through `docs/ARCHITECTURE.md`, which the README already linked, so removing
them cost no information.

Placed under Audience, since it follows directly from the two audiences that
rule already names.

**Also fixes a defect #901 introduced.** The Audience rule read "the first
three sections (title, quick start, usage) are user-facing". Inserting
Features as section 2 made that four, and I did not catch it in that PR —
found here by re-reading the whole section rather than the changed line, which
is what #847 is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)