### PR TITLE
feat(core): check the inherited rule before calling a document wrong (#864)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -809,6 +809,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -97,6 +97,22 @@ Before every commit, update all relevant documentation:
   change
 - **`docs/ONBOARDING.md`** — update if the contributor workflow changes
 
+### When a document disagrees with the system
+
+A project document that contradicts the live state of the system it
+describes is not automatically the authority. Establish which one is
+wrong before changing either.
+
+- MUST check whether the rule is inherited. A document generated from a
+  template can drift from the template while the system still matches
+  it — in which case the document is stale and the system is correct
+- MUST NOT act on the document's reading alone when the observed state
+  is defensible. Acting first destroys a correct configuration to
+  satisfy a sentence that was already out of date
+- The order is: read the document, observe the system, then find the
+  rule that governs both. Reconcile to whichever the governing rule
+  supports, and fix the other
+
 ## Decision logs
 
 - Significant architectural decisions MUST be recorded as Architecture Decision


### PR DESCRIPTION
Closes #864.

`docs.md` covers documentation-vs-code drift in several places, but not the
case where a project document disagrees with the live state of the system it
describes — and the project inherited that rule from a template.

The failure from #864: a repo's CLAUDE.md documented priority labels as P0–P3
while the repo's actual labels were P0–P4, with an open issue carrying P4.
Reading the document first, the agent reported the P4 label as a violation and
offered to remove it. Backwards — the templates defined P0–P4, the labels were
right, and the inherited document had drifted. Acting on the first reading
would have destroyed a correctly applied label.

The rule states the ordering: read the document, observe the system, then find
the governing rule, and reconcile to whichever that supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)