### PR TITLE
feat(core): cite software by persistent identifier, not URL (#845)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1082,6 +1082,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -370,6 +370,23 @@ general writing-style and diagram rules above still apply.
 - Documentation follows the same review process as code
 - All documentation MUST be written in Markdown
 
+## Citing the software (if applicable)
+
+Where the project expects to be cited, the citation of record MUST be a
+persistent identifier, not a URL. A repository URL or project domain can
+move, lapse, or be rebranded, and rots every citation pointing at it; a
+persistent identifier resolves to an archived, immutable snapshot and is
+independent of any website, so the domain stays freely swappable.
+
+- SHOULD archive each release and mint a persistent identifier, then
+  cite the identifier that resolves to the latest version rather than a
+  per-version one
+- SHOULD ship a machine-readable citation file at the repository root so
+  the forge renders a "cite this repository" affordance, and record the
+  identifier in it
+- A project domain or vanity URL is a convenience for readers and MUST
+  NOT be presented as the citation of record
+
 ## Generated files
 
 Files committed to the repository but produced by a tool (rendered


### PR DESCRIPTION
Closes #845.

New optional section in `docs.md`. Kept vendor-neutral — the issue named DOIs
and Zenodo-style archiving, but the rule holds for any persistent-identifier
scheme, and the base layer should not name a service.

Marked `(if applicable)` per the authoring convention, since most projects
are never cited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)