### PR TITLE
feat(core): delegate to a self-documenting source, don't re-tabulate it (#822)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1013,6 +1013,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -301,6 +301,13 @@ is incomplete.
   commands and flags in prose rather than transcribing them as inline code
 - Summarize intent and link to the source — do not transcribe methods,
   constants, or flags into prose
+- The same holds for a self-documenting source. A hand-maintained table
+  restating a CLI's `--help`, a generated schema, or generated API docs
+  is a second copy that drifts the moment someone adds an option and
+  forgets the table, leaving readers trusting a list that is quietly
+  wrong. Point at the command or the generated artifact instead, and
+  document only what it cannot state itself — why an option exists,
+  which combinations are meaningful
 
 ## Diagrams and assets
 


### PR DESCRIPTION
Closes #822.

Extends the existing "Summarize intent and link to the source" rule rather
than adding a parallel one, as the v2.37 milestone planning called for.

`docs.md` covered doc-to-doc duplication ("structure lives in README, do not
duplicate it") but not a doc duplicating a *self-documenting tool* — a CLI's
`--help`, a generated schema, generated API docs. Downstream, a README
Configuration reference tabulated a subcommand's flags and had already
drifted: a user-facing `--plan` flag was missing from the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)