### PR TITLE
feat(core): add the examples/ directory convention (#816, #824)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4203,6 +4216,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -4210,6 +4226,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4203,6 +4216,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -4210,6 +4226,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4203,6 +4216,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -4210,6 +4226,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -3421,6 +3434,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -3428,6 +3444,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -2647,6 +2660,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -2654,6 +2670,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4203,6 +4216,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -4210,6 +4226,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1245,6 +1245,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -67,6 +67,19 @@ Every README MUST contain the following sections, in this order:
   table (`Path` | `Purpose`) — a table renders consistently on GitHub
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
+- When the project ships an `examples/` directory, that directory MUST
+  carry its own `README.md` indexing each example as an exact command
+  paired with the output it produces. A bare folder of sample inputs
+  under-delivers and reads as broken data; the index turns it into a
+  try-it-now surface
+  - Examples MUST run offline against data the project already bundles
+  - Output MUST be real or a reproducible dry run — never fabricated
+    numbers. Where the true output needs an engine or service the
+    reader may not have, show the dry run, which conveys the shape and
+    runs anywhere
+  - A sample input that looks incomplete on purpose (an optional field
+    left blank) MUST say so next to the command, not leave the reader
+    to reverse-engineer the intent
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -30,6 +30,9 @@ src/
     [module].py
 tests/
   test_[module].py
+examples/
+  README.md
+  [pattern].py
 pyproject.toml
 README.md
 CLAUDE.md
@@ -37,6 +40,12 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
+- `examples/` holds runnable, maintained usage patterns — one file per
+  pattern or user journey, smoke-tested in CI against the library so
+  they cannot rot, and excluded from the built wheel like `tests/`.
+  Distinct from `scripts/`, which is throwaway probes and benchmarks
+  and is not shipped. A design document references an example rather
+  than duplicating its code
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package


### PR DESCRIPTION
Closes #816. Closes #824.

One convention in two files, landed together as the v2.37 planning called for
— splitting them would have shipped a directory with no index rule, or an
index rule for a directory nothing recommends.

- `base/core/readme.md` (Project structure) — when a project ships
  `examples/`, that directory carries its own README indexing each example as
  a command paired with its output. Offline-runnable, real or reproducible
  dry-run output, no fabricated numbers, deliberate gaps explained.
- `stack/python-lib.md` — the directory itself, smoke-tested in CI so the
  examples cannot rot, excluded from the wheel like `tests/`, and explicitly
  distinct from `scripts/` (throwaway, not shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)