### PR TITLE
docs(onboarding): list the GitHub CLI as a prerequisite

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -26,6 +26,8 @@ Read `docs/SPEC.md` for the full composition model before contributing.
 - Git
 - A Markdown editor (any)
 - Python 3.x — for running the structural smoke tests
+- GitHub CLI (`gh`) — for the issue, pull-request and release steps
+  in `docs/PLAYBOOK.md`
 - An AI agent for validation (Claude Code recommended) — for E2E tests
 
 ## First steps


### PR DESCRIPTION
Found during the end-of-session audit. `docs/PLAYBOOK.md` drives issues, pull requests and releases through `gh`, but ONBOARDING's Prerequisites listed only Git, a Markdown editor, Python and an agent — so a new contributor following it cannot complete the PLAYBOOK steps.

Filed as work rather than reported as a gap, per the audit wording #825 shipped this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)