### PR TITLE
feat(workflow): drop the Backlog and Expedite milestone lanes (#914)

### DIFF
--- a/docs/decisions/023-no-named-milestone-lanes.md
+++ b/docs/decisions/023-no-named-milestone-lanes.md
@@ -1,0 +1,87 @@
+---
+id: "023"
+status: Accepted
+date: 2026-08-02
+category: process
+supersedes: []
+superseded_by: []
+---
+
+# ADR-023: Carry deferral and urgency on labels, not milestone lanes
+
+## Context
+
+The issue guidance prescribed two named milestones that hold work rather
+than schedule it. A `Backlog` milestone caught issues with no target
+release, so that "unmilestoned" and "deliberately unscheduled" stayed
+distinguishable. An `Expedite` milestone was a rolling fast-track lane
+for out-of-cycle work; by definition it never closed.
+
+Both are milestones doing a label's job. A milestone answers "which
+release is this in"; these two answered "is this parked" and "is this
+urgent" — properties of the issue, not of a release. The mismatch has
+costs that showed up in use:
+
+- A lane that never closes accumulates indefinitely and stops being a
+  planning signal. `Expedite` shipped nine issues across four months and
+  spent most of that time empty or holding one item.
+- The two lanes compete with the labels that already encode the same
+  facts. Deferral is `P4`; urgency is the severity band. An issue could
+  be `P4` and `Backlog`-milestoned, or `P0` and not in `Expedite`, with
+  no rule for which reading won.
+- A milestone's meaning is not durable. Closing or deleting one strips
+  the field from every attached issue, and the "deliberately unscheduled"
+  fact it carried is gone — where a label survives.
+
+The priority scale had already moved. `P4` was redefined as a deferral
+marker orthogonal to severity, which is exactly what the `Backlog` lane
+was for. The deferred-work rule was not updated to match, and went on
+calling its `Backlog` issue "distinct from a P4 'someday' issue" — a
+description of a band that no longer exists.
+
+## Decision
+
+1. **No named holding lanes** — a project MUST NOT stand up a `Backlog`,
+   `Expedite`, or equivalent milestone to mark work as unscheduled or
+   fast-tracked. Milestones remain optional, forward-looking, and scoped
+   to a planned release.
+
+2. **Deferral is a label** — deliberately deferred work MUST carry the
+   `P4` marker plus explicitly named trigger conditions on the issue.
+
+3. **Urgency is severity** — out-of-cycle or fast-tracked work is
+   identified by its severity band. It needs no separate lane to be
+   findable.
+
+4. **An unscheduled release needs no milestone** — a routine or emergent
+   release that was never scoped as a milestone gets none; the Release is
+   its shipped record.
+
+## Alternatives considered
+
+- **Keep both lanes, document the precedence against the labels** —
+  rejected; it preserves two encodings of one fact and adds a rule to
+  arbitrate them, which is more surface than either lane earns.
+- **Keep `Backlog`, drop `Expedite`** — rejected; `Backlog` is the one
+  fully subsumed by `P4`, so this keeps the redundant lane and drops the
+  one with a distinct (if weak) meaning.
+- **Close the lanes rather than forbidding them** — rejected as the rule;
+  closing is a fine local migration step, but the guidance has to say
+  what to do instead, or the next project rebuilds them.
+- **Replace the lanes with a `deferred` label** — rejected; `P4` already
+  is that label, and adding a synonym repeats the original error.
+
+## Consequences
+
+- `platform/github.md` drops the `Backlog` routing rule and the
+  `Expedite` lane paragraph, and no longer names either milestone in the
+  release-record rule.
+- `base/workflow/issues.md` restates the deferred-work rule against `P4`,
+  resolving its contradiction with the priority scale.
+- Projects running these lanes migrate by labelling the open issues
+  `P4` (for `Backlog`) or by severity alone (for `Expedite`), then
+  deleting the milestones. Attached closed issues lose the milestone
+  field; the Release record is the shipped history.
+- Nothing distinguishes "untriaged" from "deliberately unscheduled"
+  except the `P4` label, so applying it at deferral time is now
+  load-bearing rather than advisory.

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3765,11 +3765,13 @@ the platform template (e.g. `platform/github.md`).
 [ID: base-issues-defer]
 
 When work is genuinely valuable but intentionally deferred — not in the
-next milestone, perhaps not the next several — the right home is a
-Backlog-milestoned issue with explicitly named trigger conditions, not a
-TODO line in an ADR or a code comment. This is distinct from a P4
-"someday" issue: the deferral is deliberate, the trigger is named, and
-the work is sized.
+next milestone, perhaps not the next several — the right home is an
+open issue carrying the `P4` deferral marker and explicitly named
+trigger conditions, not a TODO line in an ADR or a code comment. `P4`
+records that the deferral is deliberate rather than an untriaged
+oversight. Do NOT park the work in a named holding milestone instead —
+a lane's meaning is lost when the milestone is closed or deleted, while
+a label travels with the issue.
 
 - Open the body with the deferral note: "Do not pick up before one of
   the trigger conditions fires."

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -42,11 +42,13 @@ the platform template (e.g. `platform/github.md`).
 [ID: base-issues-defer]
 
 When work is genuinely valuable but intentionally deferred — not in the
-next milestone, perhaps not the next several — the right home is a
-Backlog-milestoned issue with explicitly named trigger conditions, not a
-TODO line in an ADR or a code comment. This is distinct from a P4
-"someday" issue: the deferral is deliberate, the trigger is named, and
-the work is sized.
+next milestone, perhaps not the next several — the right home is an
+open issue carrying the `P4` deferral marker and explicitly named
+trigger conditions, not a TODO line in an ADR or a code comment. `P4`
+records that the deferral is deliberate rather than an untriaged
+oversight. Do NOT park the work in a named holding milestone instead —
+a lane's meaning is lost when the milestone is closed or deleted, while
+a label travels with the issue.
 
 - Open the body with the deferral note: "Do not pick up before one of
   the trigger conditions fires."

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -310,24 +310,19 @@ field is valid and means the work is not tied to a release. A PR
 SHOULD inherit the milestone of the issue it closes, when that issue
 has one.
 
-A project that does use milestones SHOULD route issues with no target
-release to a `Backlog` milestone, so "unmilestoned" and "deliberately
-unscheduled" stay distinguishable.
-
-The `Expedite` milestone is a rolling fast-track lane for work
-shipping between versioned releases — mainly bugs and incidents,
-also small tasks. It never closes; issues move in when expedited
-and out when shipped. Use `Expedite` instead of `Backlog` when the
-work is small, urgent, or out-of-cycle and does not fit the current
-versioned milestone's theme.
+Do NOT stand up a named holding lane — a `Backlog` or `Expedite`
+milestone — to mark work as unscheduled or fast-tracked. Deferral is
+carried by the `P4` label and urgency by the severity label. Both
+travel with the issue and stay filterable, where a lane's meaning is
+lost the moment the milestone is closed or deleted.
 
 Milestones are forward-looking planning; GitHub Releases are the
 backward-looking shipped record. Create a versioned milestone (e.g.
-`v1.0.0`) only for a deliberately planned, scoped release. Routine or
-emergent releases cut from `Backlog` / `Expedite` get no versioned
-milestone — the Release is their shipped record. Do NOT backfill empty
-per-version milestones after the fact; a planning artifact created
-retroactively carries no information.
+`v1.0.0`) only for a deliberately planned, scoped release. A routine or
+emergent release that was never scoped as a milestone gets none — the
+Release is its shipped record. Do NOT backfill empty per-version
+milestones after the fact; a planning artifact created retroactively
+carries no information.
 
 Colors follow the Atlassian design system palette. Type labels use
 saturated hues; priority labels use a warm-to-cool gradient to


### PR DESCRIPTION
Closes #914.

## What

The issue guidance prescribed two named milestones that hold work rather
than schedule it — `Backlog` for unscheduled work and `Expedite` as a
never-closing fast-track lane. Both are removed from the templates, and
the milestones are deleted in this repo.

## Why

Each lane was a milestone doing a label's job. `Backlog` answered "is
this parked" and `Expedite` "is this urgent" — properties of the issue,
not of a release. Deferral is already `P4` and urgency is already the
severity band, so each lane duplicated a fact the labels carried, with
no rule for which reading won.

A milestone's meaning is also not durable: closing or deleting one
strips the field from every attached issue, and the "deliberately
unscheduled" fact goes with it. A label survives.

Separately, the deferred-work rule had gone stale against the priority
scale. It called its `Backlog` issue "distinct from a P4 'someday'
issue", but ADR-021 redefined `P4` as exactly a deferral marker
orthogonal to severity — so the rule contradicted the table six lines
above it.

## Changes

| File | Change |
|------|--------|
| `templates/platform/github.md` | Drops the `Backlog` routing rule and the `Expedite` lane paragraph; stops naming either in the release-record rule |
| `templates/base/workflow/issues.md` | Restates deferred work against `P4`; resolves the contradiction with the priority scale |
| `docs/decisions/023-no-named-milestone-lanes.md` | New ADR recording the decision, alternatives, and migration |
| `generated/stack-tutorial.md` | Regenerated |

## Repo migration applied

- Milestones `Backlog` (#9) and `Expedite` (#15) deleted
- The three open ex-`Backlog` issues (#844, #832, #831) labelled `P4`,
  so the deliberate-deferral fact survives the milestone

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)