### PR TITLE
feat(review): verify a finding by its provenance (#846, #860, #912, #849)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1955,7 +1955,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -1968,6 +2010,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -112,7 +112,49 @@ SHOULD also check:
 - No substantial duplication across sibling components — if two or more
   components share the same code, extract a shared module
 
-## Reviewing agent-produced findings
+## Verifying a finding before reporting it
+
+A finding is a hypothesis until it is demonstrated. Reporting a hypothesis as
+a defect costs the author more than missing it, because each one has to be
+disproved by hand. A finding that cannot be demonstrated MUST be labelled as
+unverified rather than presented alongside demonstrated ones.
+
+What you owe a finding depends on how it was produced.
+
+### From reading
+
+- [ ] Reproduce the defect before reporting it — run the path, not the
+      argument that the path is wrong
+- [ ] When a reproduction contradicts a passing test, read the test before
+      concluding the code is wrong. A test that pins surprising behavior is
+      usually documenting a decision, and its comment is where the reason
+      lives
+
+### From a measurement
+
+A tool that runs cleanly and returns a plausible number is the most convincing
+way to be wrong.
+
+- [ ] Confirm the tool measures the unit the rule is written in — bytes are
+      not characters, `wc -c` is not `wc -m`, disk size is not size on disk
+- [ ] Hand-check one flagged item. If the hand-count disagrees with the tool,
+      the tool is measuring something else
+
+### From an extraction
+
+Extraction tools are silently partial: a parser walks the node types it knows
+and drops the rest, so "X is missing" often means "my extractor does not
+traverse the structure X lives in".
+
+- [ ] Before asserting an element is **absent**, cross-check the raw artifact
+      itself, not just the tool's output
+- [ ] Sanity-check coverage — compare extracted size against the raw artifact
+      and confirm known-present elements survive the round trip
+- [ ] Scope the claim to what was inspected: "not verifiable from the
+      extract", never "missing". Absence of evidence from a lossy tool is not
+      evidence of absence
+
+### From an agent or subagent
 
 A finding reported by an agent is a lead, not evidence. Verify it against the
 source before acting on it or repeating it to anyone else.
@@ -125,6 +167,23 @@ source before acting on it or repeating it to anyone else.
   agents share the same blind spots and can agree on the same wrong answer
 - When a finding turns out to be wrong after you have passed it on, correct it
   plainly and name what the check actually showed
+
+When a finding contradicts an existing verified record, reconcile the two
+before changing anything:
+
+- Check whether both are reading the same artifact. Different pages,
+  endpoints, API versions, or product tiers routinely disagree, and each may
+  be locally correct
+- Prefer the source carrying more specific evidence — a record citing a file
+  with per-item detail outranks a summary citing a README
+- Treat "could not confirm" as a request to reconcile, never as a licence to
+  delete
+- Dispatch with the existing record attached, asking the agent to
+  **reconcile** rather than re-derive. An agent told only "verify this claim"
+  surfaces a different source; one told what was previously found, and where,
+  surfaces a genuine change
+- Record the reconciliation. If it reverses a documented decision, say so and
+  why, in the artifact that documented it
 
 Applies equally to the reviewer's own tooling: a grep that returns the expected
 answer for the wrong reason is the same failure in a cheaper form.

--- a/templates/base/workflow/360.md
+++ b/templates/base/workflow/360.md
@@ -58,6 +58,11 @@ Each subagent prompt MUST include:
 3. **Checklist** — the sub-dimensions and checklist items for that
    category
 4. **Output format** — letter grade (A–F), findings table, summary
+5. **Prior record**, when re-auditing ground a previous audit covered —
+   the earlier findings and the sources they cited, with an instruction
+   to reconcile against them rather than re-derive from scratch. A
+   subagent given only the checklist reports a fresh conclusion that
+   reads like a correction
 
 Sequential execution with role switches is acceptable when parallel
 agents are not available, but the role prompt MUST be restated before
@@ -429,16 +434,22 @@ Each subagent returns:
 
 ### Findings
 
-| #   | Sub-dimension | Status  | Finding |
-| --- | ------------- | ------- | ------- |
-| 1   | [name]        | PASS    | —       |
-| 2   | [name]        | FAIL    | [what]  |
-| 3   | [name]        | PARTIAL | [what]  |
+| #   | Sub-dimension | Status  | Finding | Reproduction |
+| --- | ------------- | ------- | ------- | ------------ |
+| 1   | [name]        | PASS    | —       | —            |
+| 2   | [name]        | FAIL    | [what]  | [how shown]  |
+| 3   | [name]        | PARTIAL | [what]  | UNVERIFIED   |
 
 ### Summary
 
 [2–3 sentences from the role's perspective]
 ```
+
+A whole-project audit is read at speed and written up in bulk, which is
+exactly the condition that produces asserted findings. Each entry SHOULD
+carry the command, file, or observation that demonstrates it; a finding
+that was not reproduced SHOULD be marked `UNVERIFIED` rather than
+presented alongside demonstrated ones.
 
 ### Summary table
 


### PR DESCRIPTION
Closes #846. Closes #860. Closes #912. Closes #849.

## Why these four together

They are one concern, not four. Each says the same thing about a
different input: **the check you owe a finding depends on how the
finding was produced.** Splitting them would mean four sequential
rewrites of the same section of `review.md`.

All four come from real retractions, and each was a confident,
high-severity, wrong finding — the most expensive kind, because the
author has to disprove it by hand.

| Issue | Provenance | What went wrong |
|---|---|---|
| #860 | reading | A deliberate behaviour reported as a defect; a test documenting the decision was never opened |
| #912 | measurement | `awk 'length>80'` counts bytes, so em-dash lines read as over-long; two false violations reported |
| #846 | extraction | A parser reported an "empty reference list"; 39 entries were present in a structure it does not traverse |
| #849 | subagent | Fresh subagents "corrected" a verified record; 4 of 10 corrections were wrong, three because the two passes read different pages |

## What changed

`templates/base/core/review.md` — the existing "Reviewing agent-produced
findings" section becomes **"Verifying a finding before reporting it"**,
organised by provenance. Every existing bullet is preserved; the agent
material becomes one group rather than the whole section.

The opening states the shared principle: a finding is a hypothesis until
demonstrated, and one that cannot be demonstrated MUST be labelled
unverified.

`templates/base/workflow/360.md` — the two audit-shaped halves:
- findings table gains a **Reproduction** column with an `UNVERIFIED`
  marker (#860) — a 360 is read at speed and written up in bulk, which
  is exactly the condition that produces asserted findings
- subagent prompt structure gains **prior record** as a required element
  when re-auditing covered ground (#849)

## Placement note

#849 suggested `base/core/agents.md` or a new `delegation.md`.
`resolve.py` shows `agents.md` resolves in **0 of 17** chains, and a new
file is v3.0-shaped work. `review.md` is in **17 of 17**, and #849's own
body says review fan-out is where this bites hardest — so it lands
there.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates, unchanged from
  baseline (this change sits next to related existing rules, so it was
  the specific risk)
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — all 17 chains regenerated; the
  generated diff contains no line not explained by the `review.md` edit
- Line length verified with a **character-based** check, not
  `awk 'length>80'` — which is the bug #912 adds a rule about

🤖 Generated with [Claude Code](https://claude.com/claude-code)