### PR TITLE
feat(review): re-read the whole section after changing a sentence (#847)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1877,6 +1877,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 

--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -34,6 +34,14 @@ such as
 - [ ] Any new dependency carries a license compatible with the project policy
 - [ ] Significant logic or architectural decisions are captured in documentation
 - [ ] Existing documentation reflects the state of the code after this change
+- [ ] Every changed section was re-read whole, not just the changed line — a
+      sentence is correct only in relation to its neighbours, and each one
+      reads fine alone, so a diff review cannot catch the contradiction
+- [ ] Every claim the text makes **about itself** ("each section covers X",
+      "the table below compares N criteria") was verified by counting or
+      grepping the thing claimed — `grep -c` the sections, count the rows —
+      not by reading. Scope both checks to changed sections, so the cost
+      stays proportional to the diff
 
 ## MUST checklist — state and boundaries
 


### PR DESCRIPTION
Closes #847.

## Why

A sentence is correct or incorrect only in relation to its neighbours. An
edit made for a good unrelated reason routinely introduces a claim the
surrounding text contradicts — and that defect is invisible to every
check that normally catches things, because each sentence is defensible
when read alone. It survives a diff review, a linter, and a proofread of
the changed line. The defect exists only in the relationship between the
changed sentence and text nobody re-read.

It is self-perpetuating too. Downstream, three occurrences landed on one
article in a single day, and the third was introduced by the commit that
fixed the second — that fix was reviewed as an isolated sentence.

Detection normally happens too late: two of the three were caught by a
scoring pass that runs after merge, the third by a reader asking whether
a claimed property actually held.

## What changed

Two items in the `review.md` MUST checklist, beside the existing
"Existing documentation reflects the state of the code after this
change" — that one compares docs against code; these compare a document
against itself, which is a different operation and gets skipped by
default.

1. Re-read every changed section whole, not just the changed line
2. Verify every claim the text makes **about itself** by counting or
   grepping the thing claimed, not by reading it

Both scope to changed sections, so the cost stays proportional to the
diff. #847 asked for this as its own review step rather than folded into
"check accuracy", which is why it is two checklist lines and not a note.

The second is mechanically checkable, so it names its check
(`grep -c` the sections, count the rows) per the
`quality-gates-pair-check` convention in CLAUDE.md §2.7.

## Not a duplicate of 360.md

`360.md` Content quality already carries "no counts that contradict
claims" and "no outdated or contradictory statements". Both compare
content against **reality**. This compares a document against **itself**.
`360.md` also resolves in 0 chains, so no in-chain duplication is
possible either way — `audit_redundancy.py --check` confirms 0.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated
- Line length checked character-based, per #912

Dogfooded: the MUST checklist section was re-read whole after the edit,
which is the rule this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)