### PR TITLE
feat(review): add a composite-metric independence check (#833)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1931,6 +1931,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 

--- a/templates/base/core/review.md
+++ b/templates/base/core/review.md
@@ -88,6 +88,13 @@ Practical guidance:
       not the shape between samples — on render-producing pipelines
       (charts, diagrams, illustrations) pair them with manual visual
       review; a passing numerical gate is necessary, not sufficient
+- [ ] A score that sums or averages several components draws them from
+      genuinely independent variables, not algebraic transforms of one
+      another (`x`, `x/2`, `1/x`). Scale-invariant aggregation (z-scores,
+      ranks) collapses such components onto one axis, silently
+      re-weighting it while the code and the docs still claim independent
+      contributions. Where components share a quantity, drop the
+      redundant ones or state the real weighting
 
 ## Structure audit
 


### PR DESCRIPTION
Closes #833.

## Why

Downstream (corrosim, their ADR 0034), a composite screening score
averaged three z-scored descriptors described everywhere as independent.
Two were algebraic restatements of the third — `hardness = gap/2`,
`softness = 2/gap`.

A z-score is scale-invariant, so all three collapsed onto a single axis.
The score double-weighted that axis while the code, the report and the
docs all claimed three independent contributions, and the mis-weighting
distorted precisely the tie/robustness verdict the score existed to
feed.

The failure is invisible by construction: every component is present,
every z-score is correct, and the aggregation runs clean. Nothing is
wrong except the claim of independence.

## What changed

One `review.md` SHOULD checklist item: when a score sums or averages
components, verify they are independent variables rather than algebraic
transforms of one another; where they share a quantity, drop the
redundant ones or state the real weighting.

## Placement

It sits beside the existing numerical-comparison-gates bullet, which is
the same family — a gate that passes while measuring the wrong thing.

#833 suggested "under correctness". `review.md` has no correctness
checklist; it has MUST and SHOULD, and the priority order lists
functional correctness separately. SHOULD matches how the adjacent
specialised numerical rule is already filed — both apply only when the
project has the construct in question. Say the word if you would rather
it were a MUST.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated
- Line length checked character-based, per #912
- SHOULD checklist re-read whole after the edit, per #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)