### PR TITLE
feat(quality-gates): audit every step of a composite gate command (#843)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -3273,7 +3273,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4083,7 +4083,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4083,7 +4083,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4083,7 +4083,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2527,7 +2527,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2527,7 +2527,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2527,7 +2527,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2527,7 +2527,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3301,7 +3301,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2527,7 +2527,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4083,7 +4083,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3273,7 +3273,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates

--- a/templates/base/workflow/quality-gates.md
+++ b/templates/base/workflow/quality-gates.md
@@ -324,7 +324,14 @@ not by widening an existing filter:
   enumeration-free
 - Keep output-measuring and language-scoped jobs (build, e2e, perf,
   per-language tests) path-filtered — promote only the cross-cutting
-  deterministic step to always-run
+  deterministic steps to always-run
+- Audit the whole command, not the step that broke. When adding the
+  first mirror job for a composite gate command (`validate` = lint +
+  format + typecheck + test + build), enumerate every step in the same
+  pass and check each for inputs outside the path-filter's coverage.
+  Mirror all exposed steps at once, or record which steps read only
+  covered paths — an unaudited assertion that "the rest are covered"
+  is how the second step surfaces later as its own incident
 - This complements `quality-gates-skip-equivalent`: skip noisy output
   gates on PRs that provably cannot affect them; always run
   deterministic cross-cutting gates


### PR DESCRIPTION
Closes #843.

## Why

"Mirror cross-cutting checks with an always-run job" was framed in the
singular: *promote only the cross-cutting deterministic step to
always-run*. A composite gate command can have **more than one** step
with cross-cutting inputs, and the singular framing invites mirroring the
step that broke while asserting the others are covered — without ever
auditing them.

Downstream (wuseria) that produced two incidents of exactly one shape:

1. A deploy runs `npm run validate` unconditionally. The **format** step
   (Prettier over all tracked files) broke `main` from a docs-only PR the
   path-filter skipped. The fix added an always-run `format` job, and its
   ADR asserted "the other validate steps read only covered paths".
2. Weeks later the **test** step broke `main` the same way — vitest reads
   a `docs/optical-specs/**` tree the path-filter also omitted. The
   assertion from (1) was never audited.

One root shape: a composite command mirrored one step at a time. The rule
as written did not prompt the full-command audit that would have caught
the `test` exposure when the `format` job was added.

## What changed

One bullet in `quality-gates.md` → "Mirror cross-cutting checks with an
always-run job": when adding the first mirror job for a composite gate
command, enumerate every step in the same pass and check each for inputs
outside the path-filter's coverage. Mirror all exposed steps at once, or
record which steps read only covered paths.

Also `step` → `steps` in the adjacent bullet, which now covers more than
one.

Existing guidance is intact per the acceptance criteria: output-measuring
and language-scoped jobs stay path-filtered; deterministic cross-cutting
steps get always-run mirrors.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 13 files changed (12 generated
  chains + the template), matching this file's 12/17 reach
- Line length checked character-based, per #912
- Section re-read whole after the edit, per #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)