### PR TITLE
feat(quality): add expensive-computation robustness rules (#818, #828)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -169,6 +169,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -163,6 +163,61 @@
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
 
+## Expensive computations (if applicable)
+
+[ID: quality-expensive-compute]
+
+A step built on an iterative numerical routine (a fixed-point solver, an
+optimizer) or on a memory-heavy intermediate fails in ways that produce a
+plausible answer rather than an error. These rules keep the failure loud
+and the cost paid once.
+
+### Verify convergence — escalate, then fail loud
+
+- A routine that exposes a convergence flag but does not force the caller
+  to read it MUST be wrapped in one helper that checks the flag. An
+  unconverged result handed back as if it were valid feeds a wrong number
+  straight downstream
+- On failure, escalate through progressively stronger and slower
+  stabilization strategies, cheapest first, before raising a descriptive
+  error naming what would not converge. The ladder fires ONLY on
+  non-convergence, so the path that already converges is untouched
+- Keep the ladder unit-testable without the heavy engine: each
+  stabilization step is a small function, the driver is pure
+  orchestration, and a stub with scripted per-attempt convergence
+  exercises every rung
+
+### An output-changing approximation is opt-in and off by default
+
+- A speed knob that shifts the numbers (a lower-rank approximation, a
+  coarser grid) MUST default off, so the canonical output is never
+  silently perturbed
+- Carry it as a per-run field in the same single source of truth as the
+  rest of the run's parameters, so a run that needs it is self-reproducing
+
+### Size the budget to the box; spill or refuse, never OOM
+
+- A memory-heavy step detects its real budget (env override → container
+  cgroup limit → physical RAM, scaled for headroom) rather than assuming
+  a fixed library default
+- Estimate the large intermediate up front: keep it in RAM while it fits,
+  stream it to a disk scratch path beyond that, refuse past a hard
+  ceiling. A diagnosable error beats an OOM crash
+- The scratch path MUST be real disk, not a RAM-backed tmpfs
+
+### Persist the reusable intermediate, not just the scalar read off it
+
+- When already paying for an expensive computation, persist its reusable
+  internal state to a checkpoint, not only the scalar this caller needed.
+  Discard the state and the next question about the same input forces a
+  full re-run
+- Make it opt-in (a checkpoint-path parameter, default off) so cheap
+  callers pay nothing, and store the checkpoint with the other
+  regenerable artifacts (gitignored)
+- Validate the round-trip once on a small case before trusting a long
+  batch to it — including any wrapper or proxy layer around the engine,
+  which can silently swallow the checkpoint parameter
+
 ## Calibration discipline
 
 [ID: quality-calibration]


### PR DESCRIPTION
Closes #818. Closes #828.

## Why these two together

Both govern the same construct — a step whose computation is expensive —
from opposite ends. #818 is *don't hand back garbage from it*; #828 is
*don't throw away what you already paid for*. They want one section, not
two.

## Why it matters

An iterative numerical routine that exposes a convergence flag but does
not force the caller to read it does not fail loudly. It returns a
plausible number. Downstream (corrosim), the shared solver call never
checked the flag, so a run that silently failed to converge fed a
wrong-but-believable answer straight on — the same failure shape as a
byte-counting line-length tool, one layer down.

The same project hit two neighbours in a memory-limited container: an
output-changing speed knob that silently perturbed the canonical numbers,
and a memory-heavy step that OOM-crashed rather than spilling to disk.

#828 comes from the same engine: a DFT single point converges a
wavefunction, reads one scalar, and discards the density — so a backfill
re-ran the full SCF per molecule to read one number, and any later
density-derived property would have re-run it again.

## What changed

New `## Expensive computations (if applicable)` in
`templates/base/core/quality.md`, placed before Calibration discipline:

| Rule | From |
|---|---|
| Verify convergence — escalate cheapest-aid-first, then fail loud | #818 |
| An output-changing approximation is opt-in and off by default | #818 |
| Size the budget to the box; spill or refuse, never OOM | #818 |
| Persist the reusable intermediate, not just the scalar read off it | #828 |

## Placement

#828 suggested `base/data/`. `resolve.py` shows `data-quality.md`
resolves in only **4 of 17** chains (python-service, flask, fastapi,
django) — all web services, none of them the compute pipelines this rule
is about. `quality.md` is **17/17**, so the rule goes there and the
heading carries `(if applicable)` per the optional-section convention, so
stacks that run no solver are not diluted.

The issues suggest siblinghood with #815 (persist-by-default CLI rule).
#815 is in v3.0, blocked on `base/core/cli.md`, so no cross-reference is
written yet.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated
- Line length checked character-based, per #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)