### PR TITLE
feat(quality): govern what a derived artifact may emit (#827, #829)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -230,10 +230,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -270,6 +271,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -224,10 +224,11 @@ and the cost paid once.
 
 When a tool is calibrated against reference data (test fixtures with
 known-correct outputs, benchmark expected results, eval data, decision
-thresholds), three failure modes silently invalidate the calibration:
-suspect data treated as ground truth, the threshold tuned to mask a
-broken measurement, and reference values produced by the same actor
-that runs the tool. The rules below address each.
+thresholds), the calibration is silently invalidated by suspect ground
+truth, by a threshold tuned to mask a broken measurement, and by
+reference values produced by the same actor that runs the tool. The
+rules below govern that, and what a calibrated pipeline may then emit:
+a value it cannot justify is worse than a gap.
 
 ### Ground truth comes from raw artifacts, not suspect data
 
@@ -264,6 +265,37 @@ that runs the tool. The rules below address each.
   the source carries no value there (the correct answer) — the two
   demand opposite responses, and conflating them sends a maintainer to
   "fix" a correct absence
+
+### Report a derived quantity only where it is well-defined
+
+Distinct from the absence rules above, which cover a source that carries
+no value. Here the value is computable and the arithmetic succeeds — the
+condition that gives the result meaning is what fails.
+
+- A derived quantity is often well-defined only under a condition (a
+  non-zero denominator, a minimum sample size, a non-degenerate input).
+  Report it only where that condition holds
+- Where it does not hold, leave the cell empty — not zero, not a
+  placeholder, not the condition-violating value. An empty cell states
+  "undefined here"; a number computed outside its domain is
+  indistinguishable from a measurement and pollutes every downstream
+  aggregation
+- The check belongs at the point of emission. A consumer cannot recover
+  the condition from the value alone, which is exactly why the artifact
+  must not carry it
+
+### A user-visible artifact takes its bar from the strictest consumer
+
+- When a derived or extracted artifact feeds several consumers of
+  differing strictness AND is itself user-facing (rendered or displayed,
+  not only an internal input), its acceptance bar is set by the strictest
+  **visible** consumer
+- Do NOT loosen it to match a coarser downstream consumer, and do NOT
+  lower it for throughput. Coarsening the acceptance metric to a bucketed
+  score, or dropping a label only the visible artifact reads, is correct
+  for the score and corrupts the table a user looks at
+- The compatible throughput lever is honest gaps, not a looser bar: an
+  ambiguous cell is blanked per the rule above, never emitted wrong
 
 ### Thresholds move, not the measurement
 


### PR DESCRIPTION
Closes #827. Closes #829.

## Why these two together

#829's own acceptance criteria asks for a cross-reference to the
honest-gaps pattern — which is #827's rule. They are the two halves of
one question: *what may a calibrated pipeline put in front of a user?*

## #827 — report a derived quantity only where it is well-defined

A derived quantity is often well-defined only under a condition. Computed
regardless, it emits a **condition-violating artifact** that a downstream
consumer cannot tell apart from a real value.

Downstream instance: a molecular dipole magnitude is origin-independent
only for a net-neutral species. Reported for charged rows, it produced a
large, physically meaningless number sitting in the descriptor table as
if it were a measurement. Domain-stripped, the shape recurs — a rate
undefined at zero denominator, a ratio meaningless below a sample-size
threshold, an angle undefined for a zero-length vector.

**This was the redundancy risk in this PR.** Two rules already sit
nearby: `quality.md` "Honest absence beats a recovered wrong value" and
`data-quality.md` "Explicit absence over invented values". Both cover a
**source that carries no value**. #827 is the inverse — the value is
computable and the arithmetic succeeds; the condition that gives it
meaning is what fails. The new subsection opens by stating that
distinction outright, so the three do not read as restatements.
`audit_redundancy.py` reports 0 exact and 0 near duplicates involving the
new subsections.

## #829 — the strictest visible consumer sets the bar

Where a derived artifact feeds several consumers of differing strictness
AND is itself user-facing, its acceptance bar comes from the strictest
**visible** consumer — not the coarser downstream one, and not lowered
for throughput.

From wuseria ADR-081: an extractor feeds both a coarse bucketed score and
a user-visible re-rendered chart plus numeric table. Coarsening the
acceptance metric to the score's buckets, or dropping a label only the
visible artifact reads, is correct for the score and corrupts the table —
which is the product's differentiator.

## A stale claim this uncovered

The Calibration discipline intro read *"three failure modes ... The rules
below address each."* Counting the subsections: there were already **six**
before this change, and eight after. The claim was accurate when written
and drifted as rules were added — exactly the defect #847 describes,
found by running #847's own check (count, do not read) on the section I
was editing. The intro is rewritten to carry no count, so it cannot go
stale again.

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` and `--near` — 0 involving the
  new subsections
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated
- Line length checked character-based, per #912
- Whole Calibration section re-read after the edit, per #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)