### PR TITLE
feat(testing): a diagnostic view runs through the production entry point (#830)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1752,6 +1752,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 

--- a/templates/base/core/testing.md
+++ b/templates/base/core/testing.md
@@ -342,6 +342,30 @@ cannot answer whether something is actually black, centred, or on screen.
 
 ---
 
+## A diagnostic view runs through the production entry point
+[ID: testing-diagnostic-production-path]
+
+When a diagnostic or debug rendering of a multi-stage pipeline exists —
+per-stage dumps, trace overlays, an "explain this output" view — it MUST
+be driven from the same entry point as the production path it inspects:
+same input resolution, same config or profile selection, same fan-out.
+
+A sibling command with its own setup diverges from production silently.
+It keeps running, keeps producing plausible output, and reports on a
+computation production never ran — so the bundle can look correct while
+production ships a wrong value, and the reverse.
+
+- Wire the diagnostic into the production entry point behind a flag
+  (`--debug`, `--explain`), not into a second command
+- A parameter the production caller passes and the diagnostic does not is
+  the whole defect. Any divergence in what the two resolve is a
+  divergence in what they compute
+- This is a standing property of a persistent diagnostic view, distinct
+  from choosing the production harness over a throwaway probe for a
+  one-off question
+
+---
+
 ## Identical metrics across distinct inputs are a smoking gun
 [ID: testing-identical-metrics]
 


### PR DESCRIPTION
Closes #830.

## Why

A diagnostic or debug rendering of a pipeline — per-stage dumps, trace
overlays, an "explain this output" view — that re-implements or
simplifies the orchestration it inspects diverges from production
silently. Nothing errors. It keeps producing plausible output about a
computation production never ran.

Downstream (wuseria S214), one extraction pipeline had two callers:

- a **production** CLI that resolved the input, selected a per-view
  config override, and fanned out per aperture
- a separate **`diagnose`** CLI that wrote a per-stage diagnostic bundle
  but called the pipeline *without* the view argument production passes

On lenses that use a per-view config override, `diagnose` therefore
visualized a different profile than production actually ran — so the
bundle could look correct while production shipped a wrong value, and the
reverse. The fix wired the bundle into the production entry point
(`extract --debug`) so it inherits production's exact orchestration,
rather than maintaining a second path.

## What changed

One section in `templates/base/core/testing.md`, placed after "Verify a
visual change against the render" — the same family of check-the-real-
thing-not-a-proxy rules.

The rule names the specific tell: a parameter the production caller
passes and the diagnostic does not *is* the defect.

## Not a duplicate

`ai-workflow.md` already says "prefer the production harness over a
throwaway probe when it already emits the classification". That is about
**choosing** a tool for a one-off classification. This is a standing
property of a **persistent** diagnostic view, and the failure mode is
silent divergence rather than a wasted probe. The new rule states the
distinction explicitly. (`ai-workflow.md` also resolves in 0/17 chains,
so it could not have carried this anyway; `testing.md` is 17/17.)

## Verification

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/audit_redundancy.py --check` — 0 duplicates
- `py tools/sync.py --check` — all files in sync
- `py tools/resolve.py --generate` — 17 chains regenerated
- Line length checked character-based, per #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)