### PR TITLE
docs(playbook): pick a rule's template by measured reach (#929)

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -69,16 +69,32 @@ genericity before it becomes template content:
 1. Extract the generic kernel — the rule that holds regardless of stack
    or domain. Strip project-specific nouns (entity, tool, and metric
    names)
-2. If the kernel is genuinely cross-cutting, add it to the relevant
+2. Pick the target by **measured chain reach**, not by the home the
+   issue suggests. A rule in a template no chain resolves reaches no
+   generated context file:
+
+   ```bash
+   # how many of the 17 stacks resolve a candidate file?
+   for s in $(py tools/resolve.py --list); do
+     py tools/resolve.py "$s" | grep -q 'core/review.md' && echo "$s"
+   done | wc -l
+   ```
+
+   A filed issue's suggested home is a hypothesis — it is usually
+   written from the downstream project, without running this. Where a
+   rule needs universal reach but applies only sometimes, put it in a
+   high-reach template behind an `(if applicable)` heading rather than
+   in a low-reach one
+3. If the kernel is genuinely cross-cutting, add it to the relevant
    `base/` or layer template per "Add a new base or layer template"
-3. If a fragment only applies to one stack or domain, fold it as an
+4. If a fragment only applies to one stack or domain, fold it as an
    *example* inside a generic rule — do not add it as standalone base
    content. Standalone one-stack content in a core-tier template loads
    into every chain and dilutes attention
-4. Prefer extending an existing related rule over adding a parallel
+5. Prefer extending an existing related rule over adding a parallel
    section — duplicate rules restated across templates are the same
    attention-dilution failure
-5. Validate per "Validate a template change"
+6. Validate per "Validate a template change"
 
 ---
 


### PR DESCRIPTION
Closes #929.

## Why

"Drain a downstream lesson into a template" step 2 said to add the
generic kernel to "the relevant `base/` or layer template" — without
saying how to determine which one is relevant. Neither "Add a new base or
layer template" nor "Validate a template change" fills the gap.

The criterion is **chain reach**, and it is one command away. A rule
placed in a template no chain resolves reaches no generated context file
at all.

## Evidence from this session

Draining twelve downstream lessons across v2.38 and v2.39, the filed
issue's own suggested home was wrong twice — both times because the
suggestion was written from the downstream project without measuring:

| Issue | Suggested home | Reach | Landed in |
|---|---|---|---|
| #849 | `base/core/agents.md` | **0/17** | `base/core/review.md` (17/17) |
| #828 | `base/data/` | **4/17**, all web services | `base/core/quality.md` (17/17) |

Session memory had also recorded `base-review` as reference-only with
zero chains. It resolves in **17 of 17**. The claim survived because
nobody ran the command that settles it.

## What changed

A new step 2 in the drain workflow naming measured reach as the placement
criterion, carrying the runnable command, and stating that a filed
issue's suggested home is a hypothesis.

It also names the companion move that came out of #828: where a rule
needs universal reach but applies only sometimes, put it in a high-reach
template behind an `(if applicable)` heading rather than in a low-reach
one.

Subsequent steps renumber 3–6.

## Verification

- The documented command was run as written — it returns 3/3 for
  `core/review.md` across the first three stacks, consistent with 17/17
- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — all files in sync
- No `generated/` change: PLAYBOOK is not a template
- Line length checked character-based; the two long lines in the file are
  both pre-existing and outside this diff
- Section re-read whole after the edit, per #847 — which is how the
  broken list numbering (1,2,3,3,4,5) got caught before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)