### PR TITLE
fix(platform-github): restore the GitHub Pages heading and repair the mismatch rule (#916, #917)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -254,9 +254,15 @@ git fetch origin refs/pull/<N>/head
 git diff --numstat FETCH_HEAD..<branch>
 ```
 
-- Lines present only on the local side are safe when they are text later
-  commits superseded. Unique work in the file the branch authored is
-  not — push it before deleting
+- Lines present only on the local side are safe when they are text that
+  later commits superseded. Work the branch authored that appears nowhere
+  in the PR head is not — push it before deleting
+
+---
+
+## GitHub Pages
+
+[ID: platform-github-pages]
 
 - MUST enable "Enforce HTTPS" in repository Settings → Pages for custom
   domains — GitHub Pages does not enforce HTTPS by default


### PR DESCRIPTION
Closes #916. Closes #917.

`## GitHub Pages` and its `[ID: platform-github-pages]` anchor were deleted when the Branch cleanup section replaced the heading instead of being inserted above it. The two HTTPS bullets were never removed — they were left behind under `[ID: platform-github-branch-cleanup]`, unreachable by their own ID and reading as branch-cleanup rules.

Restores the heading below the Branch cleanup content, and repairs the mismatch bullet immediately above it (#917) while the lines are open: `they are text later commits superseded` was missing a relative pronoun, and `unique work in the file the branch authored` stacked two reduced relative clauses. Both issues land in one PR because they touch adjacent lines; splitting them would conflict.

Smoke 23/23, `sync.py --check` clean. No manifest change — section IDs are file-level-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)