### PR TITLE
chore(markdownlint): disable MD029 — continuous list numbering is intentional (#900)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,7 @@
   "default": true,
   "MD013": { "line_length": 80, "code_blocks": false, "tables": false },
   "MD022": false,
+  "MD029": false,
   "MD031": false,
   "MD032": false,
   "MD040": false,


### PR DESCRIPTION
Closes #900.

`base/core/git.md` splits one release procedure across three subheadings and numbers it continuously — 1–3 under Pre-release checks, 4–10 under Projects with a version manifest, 11–12 under Post-release verification. Markdown treats each block as a new list, so MD029 asks for a restart at 1 in each.

The numbering is correct as written: CommonMark honours an ordered list's start value, so the blocks render 4, 5, 6 as intended. Restarting each block would give the reader three step-1s in one procedure.

markdownlint is not in CI, so this is editor noise only — but it is noise that argues against a deliberate convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)