### PR TITLE
feat(platform-github): extend the lychee note to cover external link checking (#848)

### DIFF
--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -285,14 +285,47 @@ git diff --numstat FETCH_HEAD..<branch>
 | Link checking             | `lycheeverse/lychee-action` (see note)   |
 | All lint/format/type/test | Language-specific CLI in CI steps        |
 
-**Lychee note:** When checking internal links on static site build
-output, MUST use `--root-dir <build-dir>` to resolve root-relative
-paths. Without it, links like `/about` produce false errors:
+**Lychee note (internal links):** When checking internal links on static
+site build output, MUST use `--root-dir <build-dir>` to resolve
+root-relative paths. Without it, links like `/about` produce false
+errors:
 
 ```yaml
 - uses: lycheeverse/lychee-action@<commit-sha>  # v2
   with:
     args: --offline --no-progress --root-dir dist dist/
+```
+
+**Lychee note (external links):** External checking has different
+failure modes and MUST be configured as a separate job:
+
+- MUST run on a schedule, never as a merge-blocking check — a
+  third-party outage is unrelated to the change under review, and a
+  failure means a cited page moved, which is content work
+- MUST accept `403` and `429` — some hosts refuse automated clients
+  while serving browsers normally. Record in a comment beside the
+  exclusion that this forfeits detection of a genuine permission change
+- MUST pass `GITHUB_TOKEN` — a private repository's own README
+  self-links return `404` to an unauthenticated client
+- MUST exclude documentation example URLs by pattern — a placeholder
+  host cited to demonstrate a format never resolves
+- MUST enumerate paths rather than pass a bare `**/*.md` — a recursive
+  glob skips dot-directories, silently omitting agent and skill
+  definition files, which frequently carry external citations
+- MUST run the check by hand and configure out its false positives
+  before committing the workflow — a check that fails on its first run
+  gets muted rather than fixed
+
+```yaml
+- uses: lycheeverse/lychee-action@<commit-sha>  # v2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    args: >-
+      --no-progress --accept 200,403,429 --max-retries 2 --timeout 20
+      --exclude "^https://example-placeholder/"
+      "docs/**/*.md" ".claude/**/*.md" "README.md"
+    fail: true
 ```
 
 **Aggregator timing:** when branch protection requires an aggregator


### PR DESCRIPTION
Closes #848.

The Lychee note covered internal links on build output only. External checking has a different set of failure modes and had no guidance, so the note splits into an internal and an external half under the one heading.

Six rules, each configuring out a real false positive: schedule rather than block, accept 403/429, pass `GITHUB_TOKEN`, exclude placeholder hosts, enumerate paths instead of a bare `**/*.md` (a recursive glob skips dot-directories, omitting agent and skill files), and dry-run before committing the workflow.

Two deviations from the issue:

- The example pins `lychee-action@<commit-sha>  # v2` rather than `@v2`, matching the internal-link snippet directly above it and the repo's action-pinning convention.
- No pointer added from `base/core/docs.md`, which the issue floats as a possibility — inline cross-references between templates are not used here; relationships go through `[DEPENDS ON]` and the manifest.

Smoke 23/23, `sync.py --check` clean, no line over 80 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)