### PR TITLE
feat(git): prove a bulk regeneration is scoped with a control and a masked diff (#834)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -601,6 +601,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -87,6 +87,24 @@ the diff is real and the output is correct.
   "Binary files differ" — opaque to git and often uncovered by the
   test suite. Open each in a viewer (or an image-read tool for agent
   workflows) and confirm it tracks its source data with no corruption
+- Regenerate a known-current control artifact on its own first. A zero
+  diff proves the generator is byte-deterministic in this environment
+  and already matches the committed baseline, so every remaining diff
+  is genuine change. A non-zero control diff means the environment
+  disagrees with whatever produced the committed files — reconcile
+  that before committing, or ship a spurious mass rewrite disguised as
+  the intended change
+- Mask the known-volatile parts, then diff the remainder. A
+  self-contained bundle carries pieces that legitimately change every
+  run — an embedded base64 blob, a generation timestamp, a build id. A
+  clean masked remainder proves the data and prose are untouched and
+  the change lives only where intended:
+
+```bash
+mask() { sed -E 's/base64,[A-Za-z0-9+/=]+/base64,#/g' "$1"; }
+diff <(mask old.html) <(mask new.html) | grep -v 'generated '
+```
+
 - When a fix regenerates many artifacts, pair a spot-check of 3-5
   representative cases (the fix's primary target, the most complex
   case, a clean baseline) with a global metric that aggregates across


### PR DESCRIPTION
Closes #834.

Adds two verification checks to `base/core/git.md` § Verifying regenerated artifacts:

- **Regenerate a known-current control first.** A zero diff proves the generator is byte-deterministic in this environment and already matches the committed baseline, so every remaining diff is genuine. A non-zero control diff means the environment disagrees with whatever produced the committed files.
- **Mask the volatile parts, then diff the remainder.** A clean masked remainder proves the data and prose are untouched.

## Deviation from the issue

The issue names `base/workflow/scope.md` as the home. Measured with `resolve.py`, that file resolves into **1 of 17** chains (`stack-tutorial` only), so the rule would have reached almost nothing. `base/core/git.md` is **17/17** and already owns a `### Verifying regenerated artifacts` section covering this exact topic. Placement follows the reach rule added to the PLAYBOOK in #930.

The issue's third rule — drop churn a VCS normalizes away — is **already covered** by the first bullet of that section (`git diff --ignore-all-space`, then `git checkout --` to drop it), so it is not repeated.

Regenerating touched all 17 chains, which independently confirms the reach measurement.

Smoke 23/23, `sync.py --check` clean, no line over 80 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)