### PR TITLE
feat(containers): guard a bind-mounted editable image against layout drift (#817)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3036,6 +3036,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3362,6 +3381,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3290,6 +3290,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3616,6 +3635,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3036,6 +3036,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3362,6 +3381,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3036,6 +3036,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3362,6 +3381,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3756,6 +3756,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -4173,6 +4192,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3756,6 +3756,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -4173,6 +4192,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -3763,6 +3763,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3819,6 +3819,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3290,6 +3290,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3616,6 +3635,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3036,6 +3036,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 
@@ -3362,6 +3381,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/templates/base/infra/cicd.md
+++ b/templates/base/infra/cicd.md
@@ -20,6 +20,13 @@ merged PR and a deployed artifact — humans approve, machines execute.
 - Use gate job, path filtering, fan-out/fan-in, artifact promotion,
   caching, matrix builds, auto-merge, and deploy preview patterns
   where appropriate
+- An image built by hand rather than by the pipeline drifts silently —
+  its heavy dependencies often live only in the container, so the main
+  test suite never exercises it and nothing forces a rebuild. Rebuild
+  it and smoke-test its import in a job path-gated to the files that
+  define the image contract: the Dockerfile, the packaging manifest,
+  and the Compose file. This keeps the check off the hot path of every
+  PR while denying the image a way to drift unnoticed
 
 ## Pipeline stages
 

--- a/templates/base/infra/containers.md
+++ b/templates/base/infra/containers.md
@@ -72,6 +72,25 @@ on the host. Not every project needs Compose — keep it to those cases.
 - Bind-mount the source for local dev so edits are live without a
   rebuild; do NOT bind-mount in CI or production — there the image is
   the artifact, and a mount would shadow it with host files
+- An image that installs the project's own package in editable mode
+  bakes an absolute package path at build time. When the source is
+  bind-mounted over the workdir, a later layout change — a flat to
+  `src/` migration — leaves that baked path pointing at a directory
+  that no longer exists, so the import fails while the live code sits
+  under the mount. Resolve the package by an explicit source path
+  instead of the baked finder, and assert the import at build time so
+  a broken layout fails the build rather than every run:
+
+```dockerfile
+RUN pip install -e ".[accel,dev]"
+
+# Resolve by the live location, not the path the editable finder baked
+ENV PYTHONPATH=/app/src
+
+# Fail the build, not the run
+RUN python -c "import pkg, heavy_dep"
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 


### PR DESCRIPTION
Closes #817.

**`base/infra/containers.md` (reach 8/17)** — an editable install bakes an absolute package path at build time. With the source bind-mounted over the workdir, a later layout change leaves that path pointing at a directory that no longer exists, so `import pkg` fails even though the live code is present under the mount. The rule requires resolving by an explicit source path and asserting the import at build time, placed directly after the existing bind-mount rule it qualifies.

**`base/infra/cicd.md` (reach 10/17)** — the drift guard. These images are frequently not exercised by the main test suite (heavy deps live only in the container), so nothing forces a rebuild. A rebuild-and-import-smoke job path-gated to the Dockerfile, packaging manifest and Compose file catches drift without putting a container build on every PR.

The Dockerfile snippet moves the issue's trailing comments above the lines they document, per the comment-layout convention.

Smoke 23/23, `sync.py --check` clean, no line over 80 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)