### PR TITLE
feat(containers): document the write-persistence boundary (#821)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3055,6 +3055,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3309,6 +3309,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3055,6 +3055,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3055,6 +3055,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -3775,6 +3775,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -3775,6 +3775,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3309,6 +3309,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3055,6 +3055,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 

--- a/templates/base/infra/containers.md
+++ b/templates/base/infra/containers.md
@@ -91,6 +91,21 @@ ENV PYTHONPATH=/app/src
 RUN python -c "import pkg, heavy_dep"
 ```
 
+- A write inside a `--rm` container is discarded on exit, and a write
+  to data baked into the image at build time never reaches the host or
+  a later build. Document where a state-mutating command's write lands
+  and route the reader to a boundary that persists. A quickstart that
+  shows such a command under `run --rm` misleads silently: the reader
+  runs it, sees it succeed, and the state reverts on the next run. For
+  a one-off, prefer the alternative that needs no write at all — pass
+  the value inline:
+
+```text
+run --rm (ephemeral)   bind-mount host path   edit source + rebuild
+write -> top layer     write -> host file     write -> next image
+gone on exit           persists               persists (shipped)
+```
+
 - Compose orchestrates local and single-host multi-service dev;
   production multi-service orchestration is Kubernetes (below)
 


### PR DESCRIPTION
Closes #821.

`base/infra/containers.md` covered `--rm` cleanup and bind-mount-for-dev, but never stated where a state-mutating write actually *lands* across the three configurations. A command that seeds a database, appends to a bundled data file, or writes config does nothing lasting under `docker run --rm` — and when the target is data baked into the image at build time, it never reaches the host or a later build either.

The failure is quiet: the reader runs the quickstart, sees it succeed, and the state reverts on the next run.

The rule requires documenting where the write lands and routing to a boundary that persists, with a table contrasting ephemeral / bind-mount / rebuild. It sits at the end of the Compose rules, after the bind-mount and editable-install rules it complements — those cover the read side, this one the write side.

Smoke 23/23, `sync.py --check` clean, no line over 80 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)