### PR TITLE
docs(playbook): sweep for stale prose when an ADR removes a concept

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -153,7 +153,18 @@ convention change, override model change, governance rule, etc.).
    stays untouched.
 6. Run `py tests/run_smoke.py ADR-01` to validate the frontmatter
    schema before opening the PR.
-7. Open the PR. After merge, the ADR is immutable except for
+7. If the ADR **removes** a concept, sweep for prose that still
+   assumes it — in `templates/` and in open issue bodies:
+   ```bash
+   grep -rn "<concept>" templates/ docs/
+   gh issue list --state open --limit 100 --json number,title,body \
+     --jq '.[] | select(.body | test("<concept>")) | "#\(.number) \(.title)"'
+   ```
+   A queued issue proposing template text that reintroduces the
+   removed concept passes review on its own terms and undoes the
+   ADR when implemented. Fix the issue body, do not rely on
+   catching it at implementation time.
+8. Open the PR. After merge, the ADR is immutable except for
    future supersession metadata updates.
 
 ---


### PR DESCRIPTION
Adds a removal-sweep step to **Author a new ADR**.

Found during this session's wrap-up. ADR-023 deleted the `Backlog` and `Expedite` milestone lanes, and `templates/` was clean — but open issue #831 still proposed template text reading "File a Backlog issue per the `issues.md` deferred-work format". That issue would have reviewed fine on its own terms and put the retired lane back into the very file ADR-023 stripped it from.

The existing workflow sweeps nothing on removal; step 5 covers only superseding an ADR's metadata. The new step 7 greps `templates/`, `docs/`, and open issue bodies, and says to fix the issue body rather than rely on catching it at implementation time.

Routed here rather than to CLAUDE.md by the doc-placement decision tree — it is an operational recipe, not a rule the agent applies on every turn.

Smoke 23/23, `sync.py --check` clean. No added prose line over 80 characters (the `--jq` line sits inside a fence, which is exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)