### PR TITLE
feat(python-lib): a test suite's own sys.path insert defeats the src/ layout (#938)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4505,6 +4505,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4505,6 +4505,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4505,6 +4505,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3682,6 +3682,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2908,6 +2908,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4505,6 +4505,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -52,6 +52,15 @@ CLAUDE.md
   directories, and anchor them (`"./name"`). Verify by comparing
   scanned-file counts before and after — a colliding pattern silently
   drops a whole sub-package from the scan while CI stays green
+- When adopting `src/`, delete every `sys.path` manipulation from the
+  test suite rather than repointing it — importing the package under
+  test is the installation's job. Check: `grep -rn "sys.path" tests/`,
+  output MUST be empty
+- Prove the layout took by running the suite against an uninstalled
+  package (`pip uninstall -y [package] && pytest --collect-only`) —
+  collection MUST fail with `ModuleNotFoundError`. A suite that still
+  passes has not adopted the layout, it has only moved files; the
+  exclude audit above cannot detect this, because nothing collided
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 


### PR DESCRIPTION
Closes #938.

`python-lib-structure` claims the `src/` layout "prevents accidental
imports of the uninstalled package". That holds for the layout, not for
a suite that recreates the working-directory import itself — and a
suite written under a flat layout usually has.

Repointed to the new depth, a `conftest.py` `sys.path` insert keeps
working, the suite stays green, and the move achieves nothing.

Two rules added to `[ID: python-lib-structure]`, each paired with its
check per `quality-gates-pair-check`:

- delete the insert rather than repointing it — `grep -rn "sys.path"
  tests/` MUST be empty
- prove the layout took — `pip uninstall -y [package] && pytest
  --collect-only` MUST fail with `ModuleNotFoundError`

The second is the part the existing #719 exclude audit cannot reach:
comparing scanned-file counts proves no exclude collided, which is
genuinely true here while the suite still imports from the tree.

`generated/` regenerated — python-lib is in 6 resolved chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)