### PR TITLE
feat(python-lib): re-run the commands the docs claim after a path move (#939)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4514,6 +4514,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4514,6 +4514,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4514,6 +4514,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3691,6 +3691,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2917,6 +2917,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4514,6 +4514,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -61,6 +61,17 @@ CLAUDE.md
   collection MUST fail with `ModuleNotFoundError`. A suite that still
   passes has not adopted the layout, it has only moved files; the
   exclude audit above cannot detect this, because nothing collided
+- After any path move the documentation references, execute every
+  command the documentation prints from a clean environment and a
+  neutral working directory — the repository root is the one place the
+  old behaviour still appears to work, so a check run there passes for
+  the wrong reason. No gate covers this: lint, types, tests, coverage
+  and wheel contents are all unchanged by a move that breaks the
+  README's headline example
+- A quick start opening with `git clone` MUST carry an install step
+  before the first command that imports the package. Any instruction to
+  run from the repository root is a symptom of the layout the move is
+  undoing, not a workaround for it
 - All public API exported from `__init__.py`
 - No `setup.py` — use `pyproject.toml` only
 


### PR DESCRIPTION
Closes #939. Extends #719.

#719 landed the config-side audit: grep every path-based exclude, anchor
it, compare scanned-file counts. That verifies the **toolchain** survived
the move — and in the reported case it verifies it correctly, answering
"nothing collided", which was true.

The regression was somewhere it does not look. Through a `src/` move,
tests (304), coverage (79.37%), `ruff format` file count (38), `mypy`
source count (21) and wheel contents were all identical before and
after, while the README quick start went from working to
`No module named [package]`.

Two rules added to `[ID: python-lib-structure]`:

- execute every documented command from a clean environment and a
  neutral working directory — the repository root is the one place the
  old behaviour still appears to work
- a `git clone` quick start MUST carry an install step; an instruction
  to "run from the repository root" is a symptom of the layout the move
  is undoing

🤖 Generated with [Claude Code](https://claude.com/claude-code)