### PR TITLE
feat(python-lib): a stale in-tree egg-info shadows the fresh dist-info (#840)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4596,6 +4596,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4596,6 +4596,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4596,6 +4596,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3773,6 +3773,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2999,6 +2999,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4596,6 +4596,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -143,6 +143,12 @@ CLAUDE.md
   editable install reports a stale version after a `[project].version`
   bump until `pip install -e .` is rerun. Built artifacts (wheel, image)
   install fresh and are unaffected
+- Rerunning the install does not always clear it. A leftover in-tree
+  `*.egg-info` from an older build sits in the project root, which is on
+  `sys.path` ahead of `site-packages`, so it shadows the freshly written
+  `dist-info` and the version stays stale immediately after a clean
+  reinstall. Delete it first: `rm -rf ./*.egg-info && pip install -e .`.
+  Being gitignored is what keeps it invisible
 
 ---
 


### PR DESCRIPTION
Closes #840.

The existing `python-lib-packaging` tip covers the ordinary stale-version
case and prescribes rerunning `pip install -e .`. There is a sharper
failure mode where that is not enough.

A leftover `*.egg-info` from an older build, sitting in the project root
and gitignored, still wins on the import path because the current
directory precedes `site-packages` on `sys.path`:

```
  sys.path when run from the repo root:
    .              -> ./mypkg.egg-info      (stale, gitignored)  wins
    site-packages  -> mypkg-0.4.0.dist-info (fresh, correct)     shadowed
```

The symptom is a version that stays stale *immediately after* a clean
reinstall, which reads as the reinstall having failed.

Adds the delete step (`rm -rf ./*.egg-info && pip install -e .`) and
names gitignoring as the reason it stays invisible.

Provenance: hit downstream in `corrosim` wiring `corrosim --version` —
stayed `0.1.0` after a `0.4.0` bump and reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)