### PR TITLE
feat(python-lib): use increase-if-necessary for a library's dependency floors (#862)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4589,6 +4589,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4589,6 +4589,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4589,6 +4589,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3766,6 +3766,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2992,6 +2992,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4589,6 +4589,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -136,6 +136,16 @@ CLAUDE.md
 - All metadata in `pyproject.toml` — no `setup.cfg`, no `setup.py`
 - Pin minimum Python version in `requires-python`
 - Do not pin exact versions in `dependencies` — use ranges (`>=`, `<`)
+- A floor in a library's `dependencies` is a compatibility claim about
+  consumers, not a record of what CI ran. Raising one narrows what a
+  consumer may install without widening what is tested — CI resolves to
+  the newest release satisfying each floor whatever the floors say.
+  Move a floor only when a new version is genuinely required
+- Set `versioning-strategy: increase-if-necessary` on the pip ecosystem
+  in `.github/dependabot.yml` — the default `increase` lifts every floor
+  to the newest release regardless. Applications, which pin rather than
+  bound, keep the default. Leave the GitHub Actions ecosystem on its
+  default: SHA pins there MUST keep moving
 - Dev/test dependencies in `[project.optional-dependencies]` or
   `[dependency-groups]`
 - Lock file for reproducibility: `requirements-dev.lock` or equivalent


### PR DESCRIPTION
Closes #862.

`python-lib.md` covered packaging and tooling but said nothing about how
automated updates should treat version constraints. For a library the
default is the wrong one.

Every version in a library's `pyproject.toml` is a **lower bound**.
Raising one narrows what a consumer may install; Dependabot's default
pip strategy (`increase`) lifts every floor to the newest release
whether or not anything needs it. A reported PR raised six floors with
no feature behind any of them — three on a consumer-facing optional
extra, so a downstream project pinned to an older release could no
longer install it, and one excluding the version on the maintainer's own
machine.

The load-bearing point, and why the default looks harmless: **raising a
floor does not widen what is tested.** CI installs `-e ".[dev]"` and
resolves to the newest release satisfying each floor, so the toolchain
already runs at current versions whatever the floors say.

Two rules in `[ID: python-lib-packaging]`: floors are a compatibility
claim about consumers, and `versioning-strategy: increase-if-necessary`
on the pip ecosystem. Applications keep the default; GitHub Actions
keeps it too, since SHA pins there MUST keep moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)