### PR TITLE
feat(python-lib): exempt tests from ruff docstring (D) rules (#838)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4643,7 +4643,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -4653,6 +4653,12 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent
 
 
 <!-- templates/stack/python-service.md -->

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4643,7 +4643,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -4653,6 +4653,12 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent
 
 
 <!-- templates/stack/python-service.md -->

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4643,7 +4643,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -4653,6 +4653,12 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent
 
 
 <!-- templates/stack/python-service.md -->

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3820,7 +3820,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -3830,6 +3830,12 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent
 
 
 <!-- templates/base/infra/cicd.md -->

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -3046,7 +3046,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -3056,3 +3056,9 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4643,7 +4643,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -4653,6 +4653,12 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent
 
 
 <!-- templates/stack/python-service.md -->

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -190,7 +190,7 @@ twine check dist/*        # validate wheel/sdist metadata
 | Lint | Ruff | Ruff | Ruff | `pyproject.toml` |
 | Format | Ruff | Ruff format | Ruff format --check | `pyproject.toml` |
 | Type check | Pyright / mypy | mypy | mypy --strict | `pyproject.toml` |
-| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention) |
+| Docstrings | Ruff `D` rules | Ruff `D` rules | Ruff `D` rules | `pyproject.toml` (Google convention, `tests/**` exempt) |
 | Security | — | — | Bandit + platform SAST | — |
 | Secrets | — | gitleaks | gitleaks | `.pre-commit-config.yaml` |
 | Tests | — | — | pytest | `pyproject.toml` |
@@ -200,3 +200,9 @@ twine check dist/*        # validate wheel/sdist metadata
 - Hook framework: `pre-commit` — config in `.pre-commit-config.yaml`
 - Docstring convention: Google — enforced via Ruff `D` rules with
   `convention = "google"` in `pyproject.toml`
+- Exempt the test suite from the `D` rules —
+  `[tool.ruff.lint.per-file-ignores]` with `"tests/**" = ["D"]`.
+  Docstrings on test functions are the busywork
+  `quality-gates-exclusions` rules out, and without the exemption a
+  freshly scaffolded project fails `ruff check` on its own tests. The
+  naming convention under `base-testing` already carries a test's intent


### PR DESCRIPTION
Closes #838.

`python-lib.md` sets the ruff lint selection to include the `D`
(pydocstyle) rules with the Google convention, but never exempts tests.
Every project generated from the stack then fails `ruff check` with
`D103 Missing docstring in public function` on its test functions — 13
errors immediately after generation in the reported case.

That also contradicts `quality-gates-exclusions`, which already rules
out docstring coverage on non-public functions as busywork. The stack
was gating exactly what the base tells it not to.

Adds the per-file ignore (`"tests/**" = ["D"]`) as a rule under
`[EXTEND: base-quality-gates]`, and marks the exemption in the
Docstrings row of the gate table so the config cell matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)