### PR TITLE
feat(quality): name a pluggable tier for its requirement, not its library (#908)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -76,6 +76,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -70,6 +70,16 @@
   to reduce indentation rather than adding else branches
 - No boolean flag parameters — they force the caller to read the implementation
   to understand what `true` means; use an enum or two named functions instead
+- Name a pluggable tier for what it requires of the caller, not for the
+  library behind it — a public enum member, CLI flag, or result
+  discriminator MUST be named for the capability or requirement it
+  represents; a private symbol MAY name the library it drives. Prefer
+  `Transport.HTTP` / `JS` / `HEADED` over `Transport.PLAYWRIGHT` /
+  `NODRIVER`: the first says when to pick each, the second makes the
+  caller learn what each library is
+- Corollary: if swapping the implementation would force a caller to
+  change code, the name has leaked. Which library sits behind a tier
+  changes without notice and is not the caller's problem
 - Avoid negative conditions in `if` statements where possible —
   `if isEnabled` reads better than `if !isDisabled`
 


### PR DESCRIPTION
Closes #908.

`base/core/quality.md` bans boolean flag parameters and pushes callers
toward enums. It did not say what those enum members should be *called*,
and the default is to name them after whatever implements them.

That makes the implementation part of the public contract: swapping the
library becomes a breaking change for callers who never asked which
library it was, and the name tells a caller nothing about when to pick
it.

Evidence from `braboj/page-fetcher`: `Transport.PLAYWRIGHT`,
`Transport.NODRIVER` and `Transport.UC` required knowing what SeleniumBase
UC mode is to choose correctly. Renamed to `HTTP`, `JS`, `HEADED` and
`HEADLESS` — what each tier needs *from the caller*. The two bot-bypass
tiers differ only in whether a display is available, which is a fact
about the caller's environment they cannot change; which fingerprints
each library hides changes without notice and is not their problem.

Lands in Readability beside the boolean-flag rule — same underlying
idea, that a caller should express intent rather than mechanism — with
the leak test as a corollary.

Touches a core-tier file, so all 17 resolved chains are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)