### PR TITLE
feat(quality): document the module-to-package split pattern (#837)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -178,6 +178,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -172,6 +172,27 @@
   re-exports), README, tests, and requirements; a thin CLI wraps the
   library rather than being the product. Extraction stays deferred, but
   the module is ready the moment it is wanted
+- **Split an oversized module into a package behind its import path**:
+  when `mod.py` becomes `mod/`, preserve the public import path via
+  `__init__` re-exports so callers and the test module are NOT modified.
+  The unchanged suite is then the split's regression oracle; rewriting
+  the tests' imports to the new submodules forfeits it, by touching the
+  oracle in the same change that restructures the code under test. This
+  is the in-repo step toward **Build extraction-ready internal
+  modules** — the same `__init__`-owns-the-API discipline, applied
+  before extraction is on the table
+- Split by a cohesive seam (data-flow stage is the usual one) and keep
+  the submodule graph acyclic: each submodule imports only earlier
+  stages, and no submodule imports the package `__init__`. Re-export
+  the public API and the private helpers the test module imports
+  directly, listing both in `__all__` so the linter does not flag them
+  unused. Constants travel with the functions that use them — a central
+  `constants.py` orphans provenance from the code and fights cohesion
+- Verify a split with the cheap static gates before the slow suite:
+  linter undefined-name/unused, an import smoke check, then test
+  collection. They catch every mechanical split error instantly, so the
+  full suite runs once — and a green run of the untouched suite plus a
+  byte-identical output diff is what proves the split behaviour-neutral
 
 ## Expensive computations (if applicable)
 


### PR DESCRIPTION
Closes #837.

Adds a maintainability convention for decomposing an oversized module
into a package (`mod.py` -> `mod/`) without touching callers or tests,
so the refactor is provably behaviour-neutral.

Three rules, placed after **Build extraction-ready internal modules**
and naming it as the rule they lead into — the same
`__init__`-owns-the-API discipline, applied before extraction is on the
table:

- preserve the public import path via `__init__` re-exports, so callers
  and the test module are not modified and the unchanged suite is the
  regression oracle
- split by a cohesive seam, keep the submodule graph acyclic (no
  submodule imports the package `__init__`), re-export the private
  helpers the tests import directly and list them in `__all__`;
  constants travel with their functions rather than into a central
  `constants.py`
- run the cheap static gates first (undefined-name/unused lint, import
  smoke, collection) — they catch every mechanical split error
  instantly, so the slow suite runs once

Provenance: splitting a 2100-line module into a 4-submodule package. A
green run of the untouched suite plus a byte-identical golden-output
diff proved it output-neutral.

Acceptance criteria from the issue: both met — the pattern is documented
and it cross-references the extraction-ready rule.

Core-tier file, so all 17 resolved chains are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)