### PR TITLE
feat(config): a registered config object should also load from a user file (#819)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -3031,6 +3031,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2337,6 +2337,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2337,6 +2337,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2285,6 +2285,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3031,6 +3031,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 

--- a/templates/base/core/config.md
+++ b/templates/base/core/config.md
@@ -63,6 +63,28 @@ deployment and secrets; the in-process object holds one run's inputs.
   (e.g. `out_dir` from the run name) so nothing hardcodes them; a copy
   accessor hands callers a mutable copy so they cannot mutate the shared
   frozen object
+- **Serialisable record** — give the object `to_dict` / `from_dict`
+  (plus `load` / `save`), keyed by field name. `from_dict` does
+  structural validation only — required keys, types, reject unknown
+  keys so a typo fails loud — which keeps deserialising cheap and
+  dependency-light
+- **One resolver, two sources** — the same selector that names a
+  built-in MUST also accept a user-supplied config file, so an
+  installed tool runs a user's own configuration without editing
+  source. The resolver grows one branch: a value carrying an explicit
+  file marker (an extension or a path separator) loads the file; a bare
+  word stays the registry lookup, byte-identical. Never branch on
+  `exists()` — a bare registry key would then collide with a
+  same-named file in the working directory
+- **Ad-hoc flags are sugar over the file path** — a second front door
+  materialises a file and delegates to it, so construction and
+  validation keep one path and the ad-hoc run leaves behind a
+  reproducible artifact
+- **Validate at the door** — check a user config against the supported
+  envelope on entry, reporting a message that names the supported set
+  rather than a traceback deep in the run. Separate the cheap
+  always-on checks (name safety, enum membership) from the expensive
+  ones that need a heavy import, so a dry run stays cheap
 
 ## Build-time vs runtime config
 


### PR DESCRIPTION
Closes #819.

`base/core/config.md` already models the in-process config object —
frozen record, registry, unset-means-default resolution, derived layout.
It stopped at built-ins registered in code. This completes it: when an
app ships named configurations selected by name, the same selector
should also accept a **user-supplied config file**, resolved through the
*same* seam.

It is the natural completion of "configuration is data" — the library of
configs is data, so a user's config should be too, through one resolver.

Four rules added to the In-process config model section:

- **Serialisable record** — `to_dict` / `from_dict` (+ `load` / `save`);
  `from_dict` does structural validation only, so deserialising stays
  cheap and dependency-light
- **One resolver, two sources** — one new branch on an explicit file
  marker (extension or path separator), never on `exists()`, so a bare
  registry key cannot collide with a same-named file in the cwd.
  Registry resolution stays byte-identical
- **Ad-hoc flags are sugar over the file path** — the second front door
  materialises a file and delegates, keeping one construction path and
  leaving a reproducible artifact behind
- **Validate at the door** — name the supported set in the error rather
  than raising deep in the run; split cheap always-on checks from ones
  needing a heavy import so a dry run stays cheap

`config.md` resolves into 15 of 17 stacks (measured with `resolve.py`);
those chains are regenerated.

Distilled from `corrosim`, where a code-registered case-study selector
was extended to run a user's own study file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)