### PR TITLE
feat(issues): make the code host the system of record (#883)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -4040,6 +4040,29 @@ the platform template (e.g. `platform/github.md`).
 
 ---
 
+## System of record
+[ID: base-issues-record]
+
+The code host is the system of record. The tracker is a view over it,
+chosen for its UI, and MUST be replaceable without losing anything.
+
+- A ticket description MUST NOT be the only copy of anything that
+  outlives the ticket. Decisions go in ADRs, rationale and specs in
+  `docs/`. The tracker carries status, ordering and assignment — state
+  that is worthless after a migration anyway.
+- A commit message or PR title SHOULD reference the code-host issue
+  number. It lives with the repository and survives a tracker change,
+  where a tracker identifier in either becomes a dead reference the
+  moment the tracker does.
+- A tracker identifier MAY appear in a branch name. Branches are
+  deleted after merge, so that reference is ephemeral, and the
+  identifier is what drives in-flight status.
+
+Retrofitting this is expensive: every commit message and PR title
+written before the rule exists is already permanent.
+
+---
+
 ## Deferred work
 [ID: base-issues-defer]
 

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -38,6 +38,29 @@ the platform template (e.g. `platform/github.md`).
 
 ---
 
+## System of record
+[ID: base-issues-record]
+
+The code host is the system of record. The tracker is a view over it,
+chosen for its UI, and MUST be replaceable without losing anything.
+
+- A ticket description MUST NOT be the only copy of anything that
+  outlives the ticket. Decisions go in ADRs, rationale and specs in
+  `docs/`. The tracker carries status, ordering and assignment — state
+  that is worthless after a migration anyway.
+- A commit message or PR title SHOULD reference the code-host issue
+  number. It lives with the repository and survives a tracker change,
+  where a tracker identifier in either becomes a dead reference the
+  moment the tracker does.
+- A tracker identifier MAY appear in a branch name. Branches are
+  deleted after merge, so that reference is ephemeral, and the
+  identifier is what drives in-flight status.
+
+Retrofitting this is expensive: every commit message and PR title
+written before the rule exists is already permanent.
+
+---
+
 ## Deferred work
 [ID: base-issues-defer]
 

--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -215,6 +215,8 @@ Linear tracks parent and child natively and rolls up progress.
   offers may lower-case it; either works.
 - Configure the automation to move an issue to a `started` state on PR
   open and to a `completed` state on merge.
-- Two-way issue sync duplicates the tracker. Enable it per repository
-  only where the code host is the source of truth for that repository;
-  leave it off otherwise.
+- Two-way issue sync duplicates the tracker. The code host is the
+  system of record for every repository (see `base-issues-record`), so
+  sync is a convenience and never what confers authority. Enable it per
+  repository only where the duplication earns its keep; leave it off
+  otherwise.


### PR DESCRIPTION
Closes #883.

`platform-linear` already says Linear "carries the tracker ONLY" and
pairs with a code-host template. It did not say which of the two is
authoritative, or what may live in the tracker and nothing else. Without
that, a project accumulates tracker lock-in by ordinary use — identifiers
in commit messages and PR titles, rationale typed into ticket
descriptions, all of it permanent.

New `[ID: base-issues-record]` in `issues.md`, tracker-agnostic so it
holds for Jira or anything else:

- the code host is the system of record; the tracker is a replaceable
  view
- a ticket description MUST NOT be the only copy of anything outliving
  the ticket — decisions to ADRs, rationale and specs to `docs/`
- commit messages and PR titles SHOULD reference the code-host issue
  number; a tracker identifier there becomes a dead reference
- a tracker identifier MAY appear in a branch name — branches are
  deleted after merge, so that reference is ephemeral

`platform-linear-codehost` is reworded so code-host authority is the
premise rather than a condition on enabling two-way sync. The branch-name
rule was already correct and is unchanged.

Evidence: `braboj/page-fetcher` mandated the Linear identifier in both
branch names and PR titles. Nine commits already carry `Refs BRA-...`
and would be dead references after a migration; the exposure was small
only because the convention was two days old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)