### PR TITLE
feat(issues): pair the label-at-creation rule with a conformance check (#952)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -4038,6 +4038,16 @@ one of `P0`–`P3`; `P4` is optional and additional.
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
 
+The at-creation rule MUST be paired with a conformance check over open
+issues (`quality-gates-pair-check`) — an unlabeled ticket looks
+identical to a labeled one, so the discipline decays silently
+otherwise. Where the tracker can enforce mutual exclusion natively
+(Linear label groups), that is the check; where it cannot (GitHub
+labels), state the query and its pass condition in the platform
+template. The check reports every open issue not carrying exactly one
+type and exactly one of `P0`–`P3`; `P4` is additional and MUST NOT
+count toward the priority total.
+
 ---
 
 ## System of record

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -36,6 +36,16 @@ one of `P0`–`P3`; `P4` is optional and additional.
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
 
+The at-creation rule MUST be paired with a conformance check over open
+issues (`quality-gates-pair-check`) — an unlabeled ticket looks
+identical to a labeled one, so the discipline decays silently
+otherwise. Where the tracker can enforce mutual exclusion natively
+(Linear label groups), that is the check; where it cannot (GitHub
+labels), state the query and its pass condition in the platform
+template. The check reports every open issue not carrying exactly one
+type and exactly one of `P0`–`P3`; `P4` is additional and MUST NOT
+count toward the priority total.
+
 ---
 
 ## System of record

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -401,3 +401,23 @@ replace one.
 | ----------- | --------- | -------------------------------------- |
 | `duplicate` | `#C1C7D0` | Already tracked by another issue       |
 | `wontdo`    | `#C1C7D0` | Acknowledged but will not be addressed |
+
+### Label conformance check
+
+GitHub has no mutually-exclusive label group, so nothing stops an
+unlabeled or double-labeled issue being created. The rule is enforced
+by running the check, not by the platform:
+
+```bash
+gh issue list --state open --limit 200 --json number,labels \
+  --jq '[.[] | {n: .number,
+                t: ([.labels[].name
+                     | select(test("^(bug|epic|task|spike|incident)$"))] | length),
+                p: ([.labels[].name | select(test("^P[0-3]$"))] | length)}
+        | select(.t != 1 or .p != 1)]'
+```
+
+Output MUST be `[]`. Each reported entry names the issue and its actual
+type and priority counts. The type alternation is the project's own
+taxonomy; the `P[0-3]` pattern is fixed, and `P4` is excluded by it so
+a deferred issue still passes on its severity alone.


### PR DESCRIPTION
Closes #952.

`base-issues-types` and `platform-github-labels` both assert "exactly one
type and one priority, applied at creation" as a MUST, and neither named
a check. Per `quality-gates-pair-check` that makes it decorative — a
violating repository looks identical to a clean one.

Evidence: #938 and #939 were created with no labels at all and stayed
that way through a full session and a release. Nothing objected. They
surfaced only because the next session enumerated unmilestoned issues by
hand.

`base-issues-types` gets the requirement in taxonomy-agnostic form, and
names the split: where the tracker enforces mutual exclusion natively
that is the check; where it cannot, the platform template states the
query. `platform-github-labels` gets the concrete `gh` invocation, with
`P4` excluded from the priority pattern so a deferred issue still passes
on its severity alone.

`platform-linear-labels` is unchanged — it already puts the type taxonomy
in a mutually-exclusive label group and says so.

**Verified.** The command as written in the template (wrapped form
included) runs clean against this repository and returns `[]`. The
predicate was separately exercised against a synthetic set: it flags an
unlabeled issue, one with two type labels, and one missing a priority,
while passing `task`+`P3` and `task`+`P1`+`P4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)