### PR TITLE
feat(issues): two tickets must not close each other (#913)

### DIFF
--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -4098,6 +4098,26 @@ a label travels with the issue.
 
 ---
 
+## Closing a duplicate
+[ID: base-issues-duplicate]
+
+When two issues describe the same work, exactly one MUST survive.
+
+- Before closing an issue as a duplicate or superseded, verify the
+  survivor is **open**. If it is closed, reopen it or file a
+  replacement first.
+- A duplicate chain that terminates in a closed issue silently drops
+  the work: every trail leads to a closed record pointing at another
+  closed record, and both claim the work is handled elsewhere.
+- The surviving ticket carries the better description; the closed one
+  carries the triage label and a link to the survivor.
+- Reconcile closed issues against work actually shipped at the end of a
+  session. Two closures made in opposite directions are each
+  individually reasonable and invisible until something compares the
+  tracker against the tree.
+
+---
+
 ## Epic
 
 A large initiative too big for one task. Tracks progress via child issue

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -96,6 +96,26 @@ a label travels with the issue.
 
 ---
 
+## Closing a duplicate
+[ID: base-issues-duplicate]
+
+When two issues describe the same work, exactly one MUST survive.
+
+- Before closing an issue as a duplicate or superseded, verify the
+  survivor is **open**. If it is closed, reopen it or file a
+  replacement first.
+- A duplicate chain that terminates in a closed issue silently drops
+  the work: every trail leads to a closed record pointing at another
+  closed record, and both claim the work is handled elsewhere.
+- The surviving ticket carries the better description; the closed one
+  carries the triage label and a link to the survivor.
+- Reconcile closed issues against work actually shipped at the end of a
+  session. Two closures made in opposite directions are each
+  individually reasonable and invisible until something compares the
+  tracker against the tree.
+
+---
+
 ## Epic
 
 A large initiative too big for one task. Tracks progress via child issue


### PR DESCRIPTION
Closes #913.

New `[ID: base-issues-duplicate]`. When two issues describe the same
work, exactly one must survive — closing each in favour of the other
leaves the work untracked while both records claim it is handled
elsewhere.

This repository did exactly that on 2026-08-02: #883 was closed as
"superseded by #886", then #886 was closed as "duplicate of #883, which
is already closed". A P1 rule then had no open ticket and the change was
never made. Both closures were individually reasonable; neither author
checked the other direction.

It was caught only by the end-of-session reconcile against work actually
shipped, so that reconcile is part of the rule rather than a separate
suggestion.

Worth noting: #883 is the ticket that went missing, and it shipped
earlier in this same milestone (PR #953).

🤖 Generated with [Claude Code](https://claude.com/claude-code)