### PR TITLE
feat(readme): forbid a measured figure that moves (#907)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1431,6 +1431,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -112,6 +112,14 @@ Every README MUST contain the following sections, in this order:
   section with a `> Note: planned for vX.Y` callout
 - README MUST be updated in the same commit that changes the behaviour it
   describes — a stale README is a defect
+- A README MUST NOT state a measured value that changes without a
+  corresponding edit — coverage percentages, test counts, byte sizes,
+  timings. The rules above cover content that goes stale when someone
+  edits it; these go stale when nobody does, so no gate catches them.
+  Name the file that holds the value and let the reader read it there
+  (`fail_under` in the tool config, a CI badge, a generated report)
+- Where an example's output is genuinely useful, describe its shape
+  rather than its exact value
 
 ### Length and tone
 - Write in present tense — past or future tense signals out-of-sync content


### PR DESCRIPTION
Closes #907.

`base/core/readme.md` required accuracy — every command tested, a stale
README is a defect — but said nothing about the class of content that
goes stale without anyone touching it. The existing rules cover things
that change when someone edits them; a coverage percentage, test count,
byte size or timing changes when nobody does.

Evidence: `braboj/page-fetcher` claimed "coverage sits at roughly 65%
with a floor of 63%". Measured at the time of checking: 79.18% against a
floor of 76. Three ratchets had moved it, and the README was never wrong
at any single commit — it just stopped being right. The same README
quoted the byte size of a Wikipedia page it fetches, which drifts with
the page.

Two rules under Accuracy: name the file that holds the value rather than
restating it, and describe an example output's shape rather than its
exact value.

The README specifically, because it is read by someone deciding whether
to trust the project — a visibly wrong figure costs more there than in a
document read by people who already know the codebase.

Core-tier file; all 17 chains regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)