### PR TITLE
feat(agents): read the issue list at HEAD and the rules at the pinned revision (#927)

### DIFF
--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -360,6 +360,26 @@ link checkers.
   local command contributors are told to run before pushing fails. A
   green dashboard is not evidence here
 
+A consuming repository asks two different questions of the upstream
+templates, and they need different revisions. The two coincide only
+when the pin equals HEAD.
+
+- "Has this already been raised?" MUST be answered against the upstream
+  issue list at HEAD. Reading the pinned file answers "does this rule
+  exist in the revision we pin", which is a different question, and
+  produces duplicate issues against rules already fixed upstream —
+  inside the commits the pin is behind
+- "What do our rules require?" MUST be answered at the pinned revision:
+  `git -C <submodule> show HEAD:templates/<file>`. This is the more
+  damaging direction to get wrong, because it yields a citation rather
+  than a duplicate: a rule read from HEAD and quoted as governing does
+  not govern until the pin moves, and it makes a local document look
+  conformant when it is not
+- Never read from `origin/main`, and never from the working tree after
+  a bare `fetch`. Fetching makes `origin/main` live while the pin stays
+  put, so anything read there describes a future state of the consuming
+  repository, not its current one
+
 ---
 
 ## Monorepo support (optional)


### PR DESCRIPTION
Closes #927.

A repository consuming these templates as a pinned submodule has two
questions to ask of them, and they need different revisions. Nothing
said so, and getting them the wrong way round has now produced a mistake
in each direction in `braboj/page-fetcher`.

**"Has this already been raised?" — upstream HEAD.** Reading the file in
the submodule answers "does this rule exist in the revision we pin",
which is not the question. Three duplicate issues were filed in one
session against issues that were not only already open but already fixed
upstream, inside the commits the pin was behind.

**"What do our rules require?" — the pinned revision.** The more
damaging direction, because it produces a citation rather than a
duplicate. `platform-github-labels` was quoted downstream as saying
deferral is carried by `P4` and urgency by the severity label. That
sentence arrived eight commits after the pinned revision; at the pin the
section still says "exactly one type label and one priority label",
which supports the opposite reading. The downstream fix was
independently correct, so the error surfaced only on re-reading — a
citation that makes a local document look conformant when it is not.

Lands under **Vendoring the templates**, alongside #861's
filesystem-walking warning — same class of problem, in that a
submodule's revision is easy to lose track of when reading through it.
Includes the corollary that `origin/main` after a bare `fetch` describes
a future state of the consuming repository, not its current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)