### PR TITLE
feat(devsecops): add a redistribution-attribution rule (#839)

### DIFF
--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -3638,6 +3638,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -3892,6 +3892,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -3638,6 +3638,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -3638,6 +3638,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -4449,6 +4449,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -4449,6 +4449,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -4005,6 +4005,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -4103,6 +4103,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -3892,6 +3892,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -3638,6 +3638,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 

--- a/templates/base/security/devsecops.md
+++ b/templates/base/security/devsecops.md
@@ -85,6 +85,19 @@ a base layer you do not control does not.
 - Before adding a dependency, verify its license is acceptable
 - Copyleft licenses (GPL, AGPL) require explicit approval before use
 - Document and justify any dependency with a non-standard or ambiguous license
+- Approving a license does not discharge the obligation that attaches
+  when the dependency is **redistributed** inside a built artifact
+  handed to users (container image, bundle, installer, fat jar). A
+  permissive or weak-copyleft (LGPL, MPL) dependency shipped that way
+  carries an attribution obligation of its own
+- Ship a third-party notice file inside the artifact, at a stable path
+  a runtime bind mount cannot shadow (e.g. `/licenses/`), placed after
+  the dependency-install layer so editing it does not bust the build
+  cache
+- Guard the notice with a test that derives the required entries from
+  the dependency manifest, so a newly added redistributed dependency
+  fails the build until it is documented. Hand-maintained attribution
+  rots
 
 ## DAST (Dynamic Application Security Testing)
 


### PR DESCRIPTION
Closes #839.

`## License compliance` covered *choosing and approving* a dependency's
license — verify it is acceptable, copyleft needs approval, document
ambiguous ones. It did not cover the obligation that attaches when you
**redistribute** that dependency inside a built artifact handed to users:
a container image, a bundled desktop app, an installer, a fat jar.

A permissive or weak-copyleft (LGPL, MPL) dependency shipped inside the
artifact carries an attribution obligation that "we approved the
license" does not discharge.

Three rules:

- name the redistribution case explicitly, so approval is not mistaken
  for discharge
- ship the notice file inside the artifact at a stable path a runtime
  bind mount cannot shadow (`/licenses/`), placed after the
  dependency-install layer so editing it does not bust the build cache
- derive the required entries from the dependency manifest in a test, so
  a newly added redistributed dependency fails the build until it is
  documented — hand-maintained attribution rots

Provenance: downstream `corrosim`, a Python CLI whose published QM image
redistributes the LGPL `ase`/`tblite`. Fixed there with a root
`THIRD_PARTY_NOTICES.md` copied into the image at `/licenses/`, plus a
pytest that parses core and extra deps from `pyproject` and fails if any
is missing from the notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)