### PR TITLE
feat(issues): retire the P4 deferral marker for the milestone field (#960)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,9 @@ are terminal — applied when closing without action.
 | `P2` | `#EED12B` | Medium — important but not blocking |
 | `P3` | `#4BCE97` | Low — nice to have, including trivial |
 
-#### Deferral label (optional)
-
-| Label | Color | Meaning |
-|-------|-------|---------|
-| `P4` | `#8590A2` | Deliberately deferred — accompanies a severity, never replaces one |
+There is no fifth band. Deferral is carried by an empty milestone
+field, not by a label — milestoned means planned, unmilestoned means
+backlog (ADR-024).
 
 #### Triage labels
 

--- a/docs/decisions/021-priority-scale-four-severities.md
+++ b/docs/decisions/021-priority-scale-four-severities.md
@@ -1,10 +1,10 @@
 ---
 id: "021"
-status: Accepted
+status: Superseded
 date: 2026-08-01
 category: process
 supersedes: []
-superseded_by: []
+superseded_by: ["024"]
 ---
 
 # ADR-021: Four severities, with P4 as a deferral marker

--- a/docs/decisions/024-priority-severity-only.md
+++ b/docs/decisions/024-priority-severity-only.md
@@ -1,0 +1,94 @@
+---
+id: "024"
+status: Accepted
+date: 2026-08-02
+category: process
+supersedes: ["021"]
+superseded_by: []
+---
+
+# ADR-024: Priority is severity only, and the milestone field carries deferral
+
+## Context
+
+The priority scale carries four severities plus a fifth label that is
+not a severity but a scheduling statement. Alongside it, a named
+holding milestone once carried the same scheduling signal. That lane
+has since been deleted, on the reasoning that a lane's meaning is lost
+when the milestone is closed while a label travels with the issue —
+which left the marker as the sole carrier of deferral.
+
+Sole carrier is the right shape; this marker is the wrong carrier. It
+overlaps the milestone field rather than complementing it. An issue can
+be marked deferred while sitting in a planned cut, or unmarked while
+sitting in no milestone at all, and both combinations exist in the
+tracker this was measured on: of four open issues carrying the marker,
+two also carry a milestone and two carry none. In neither pair does the
+marker say anything the milestone field does not already say.
+
+The earlier reasoning kept the marker because dropping it would push
+deferral into prose, where it stops being filterable. That assumed the
+alternative to a label was prose. It is not. The milestone field is
+itself a first-class, filterable axis, already mandatory reading when
+scoping a release, and already documented as optional — an empty
+milestone is a valid state meaning the work is not tied to a release.
+Deferral was being recorded twice, in a label and in a field that
+encodes the same fact.
+
+## Decision
+
+1. **Priority is severity only** — the scale is `P0` critical, `P1`
+   high, `P2` medium, `P3` low. Every issue MUST carry exactly one
+   band. There MUST NOT be a fifth priority label.
+
+2. **The milestone field carries deferral** — a milestoned issue is
+   planned into that cut; an unmilestoned issue is backlog. Deferral
+   MUST NOT be recorded as a label, and MUST NOT be recorded as a
+   named holding milestone.
+
+3. **Triage is labels, not milestones** — an issue is triaged when it
+   carries a type and a severity, which the at-creation rule already
+   requires. An empty milestone field therefore MUST NOT be read as
+   untriaged; it means unscheduled.
+
+4. **Deferred work still names its triggers** — an unmilestoned issue
+   that is deliberately deferred MUST state its trigger conditions in
+   the body. The milestone field records that the work is unscheduled;
+   the body records what would schedule it.
+
+## Alternatives considered
+
+- **Keep the marker as an orthogonal label** — rejected; it duplicates
+  the milestone field, and two carriers for one signal can disagree
+  without either being wrong.
+- **Rename the marker to `deferred`** — rejected; the name was never
+  the problem. A non-priority name leaves the same duplication.
+- **Re-introduce a named holding milestone** — rejected; a lane's
+  meaning is lost the moment the milestone is closed or deleted, and
+  it competes with dated cuts for the same field.
+- **Close deferred work with a triage label** — rejected; the triage
+  labels are terminal and record a decision not to act. Deferred work
+  is work the project still intends to do.
+
+## Consequences
+
+- `base/workflow/issues.md` drops the marker from the priority table
+  and restates its deferred-work section against the milestone field.
+- `platform/github.md` drops its deferral label table, and its label
+  conformance check no longer needs a caveat explaining why a fifth
+  band is excluded from the priority pattern.
+- `platform/linear.md` restates its label and priority sections over
+  `P0`–`P3`; the prohibition on recreating priority as labels narrows
+  to the four bands that exist.
+- `CLAUDE.md` §2.2 drops the deferral label table.
+- The `P4` label is deleted from the repository, which strips it from
+  closed issues as well as open ones. Issues that carried it keep their
+  severity and their milestone, or their absence of one, which already
+  states their scheduling.
+- Deferred work becomes discoverable by an empty-milestone filter
+  rather than a label filter. Trigger conditions in the issue body
+  remain the record that a deferral was deliberate rather than an
+  oversight.
+- A deferred-work rule previously stated against the marker is restated
+  against the milestone field. The prohibition on named holding
+  milestones is unaffected.

--- a/docs/wiki/devsecops.md
+++ b/docs/wiki/devsecops.md
@@ -68,7 +68,7 @@ SCA report → triage
   ├→ Critical + exploitable → P0, fix immediately
   ├→ High + reachable       �� P1, fix this sprint
   ├→ Medium + deep transitive → P2, track and monitor
-  └→ Low + no path          → P4, accept risk
+  └→ Low + no path          → P3, accept risk
 ```
 
 **When to use:**

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -4038,10 +4038,10 @@ project-specific; the at-creation discipline is not.
 | P2 | Medium — important but not blocking |
 | P3 | Low — nice to have, including trivial |
 
-`P4` is not a severity. It marks work deliberately deferred, and MAY
-accompany any of `P0`–`P3` — deferring a high-severity issue is a
-scheduling decision, not a downgrade. Every issue MUST carry exactly
-one of `P0`–`P3`; `P4` is optional and additional.
+Priority is severity and nothing else. It MUST NOT encode scheduling —
+there is no band meaning "someday", and deferring a high-severity issue
+is a scheduling decision recorded elsewhere, not a downgrade to a lower
+band.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
@@ -4053,8 +4053,7 @@ otherwise. Where the tracker can enforce mutual exclusion natively
 (Linear label groups), that is the check; where it cannot (GitHub
 labels), state the query and its pass condition in the platform
 template. The check reports every open issue not carrying exactly one
-type and exactly one of `P0`–`P3`; `P4` is additional and MUST NOT
-count toward the priority total.
+type and exactly one of `P0`–`P3`.
 
 ---
 
@@ -4086,15 +4085,20 @@ written before the rule exists is already permanent.
 
 When work is genuinely valuable but intentionally deferred — not in the
 next milestone, perhaps not the next several — the right home is an
-open issue carrying the `P4` deferral marker and explicitly named
-trigger conditions, not a TODO line in an ADR or a code comment. `P4`
-records that the deferral is deliberate rather than an untriaged
-oversight. Do NOT park the work in a named holding milestone instead —
-a lane's meaning is lost when the milestone is closed or deleted, while
-a label travels with the issue.
+open, unmilestoned issue with explicitly named trigger conditions, not
+a TODO line in an ADR or a code comment. The milestone field carries
+the scheduling: milestoned means planned into that cut, unmilestoned
+means backlog. Do NOT add a deferral label or a named holding milestone
+on top — either one duplicates the milestone field, and two carriers
+for one signal can disagree without either being wrong.
+
+An empty milestone MUST NOT be read as untriaged. Triage is the type
+and severity applied at creation; scheduling is a separate axis, and an
+issue is fully triaged whether or not it is scheduled.
 
 - Open the body with the deferral note: "Do not pick up before one of
-  the trigger conditions fires."
+  the trigger conditions fires." The milestone field records that the
+  work is unscheduled; the body records what would schedule it.
 - State trigger conditions as concrete, observable events ("a second
   component exhibits pattern X", "badged data runs four weeks without
   pushback") — natural language is fine; naming them is the discipline.
@@ -4103,6 +4107,9 @@ a label travels with the issue.
   Decision section), so the decision stays discoverable from the tracker
   rather than buried where it will be re-litigated or quietly done
   unnecessarily.
+- Re-read the unmilestoned set when scoping a cut. Deferral is now the
+  absence of a field rather than the presence of a label, so nothing
+  surfaces the backlog on its own.
 
 ---
 

--- a/templates/base/workflow/issues.md
+++ b/templates/base/workflow/issues.md
@@ -28,10 +28,10 @@ project-specific; the at-creation discipline is not.
 | P2 | Medium — important but not blocking |
 | P3 | Low — nice to have, including trivial |
 
-`P4` is not a severity. It marks work deliberately deferred, and MAY
-accompany any of `P0`–`P3` — deferring a high-severity issue is a
-scheduling decision, not a downgrade. Every issue MUST carry exactly
-one of `P0`–`P3`; `P4` is optional and additional.
+Priority is severity and nothing else. It MUST NOT encode scheduling —
+there is no band meaning "someday", and deferring a high-severity issue
+is a scheduling decision recorded elsewhere, not a downgrade to a lower
+band.
 
 Platform-specific label implementation (names, colors) is defined in
 the platform template (e.g. `platform/github.md`).
@@ -43,8 +43,7 @@ otherwise. Where the tracker can enforce mutual exclusion natively
 (Linear label groups), that is the check; where it cannot (GitHub
 labels), state the query and its pass condition in the platform
 template. The check reports every open issue not carrying exactly one
-type and exactly one of `P0`–`P3`; `P4` is additional and MUST NOT
-count toward the priority total.
+type and exactly one of `P0`–`P3`.
 
 ---
 
@@ -76,15 +75,20 @@ written before the rule exists is already permanent.
 
 When work is genuinely valuable but intentionally deferred — not in the
 next milestone, perhaps not the next several — the right home is an
-open issue carrying the `P4` deferral marker and explicitly named
-trigger conditions, not a TODO line in an ADR or a code comment. `P4`
-records that the deferral is deliberate rather than an untriaged
-oversight. Do NOT park the work in a named holding milestone instead —
-a lane's meaning is lost when the milestone is closed or deleted, while
-a label travels with the issue.
+open, unmilestoned issue with explicitly named trigger conditions, not
+a TODO line in an ADR or a code comment. The milestone field carries
+the scheduling: milestoned means planned into that cut, unmilestoned
+means backlog. Do NOT add a deferral label or a named holding milestone
+on top — either one duplicates the milestone field, and two carriers
+for one signal can disagree without either being wrong.
+
+An empty milestone MUST NOT be read as untriaged. Triage is the type
+and severity applied at creation; scheduling is a separate axis, and an
+issue is fully triaged whether or not it is scheduled.
 
 - Open the body with the deferral note: "Do not pick up before one of
-  the trigger conditions fires."
+  the trigger conditions fires." The milestone field records that the
+  work is unscheduled; the body records what would schedule it.
 - State trigger conditions as concrete, observable events ("a second
   component exhibits pattern X", "badged data runs four weeks without
   pushback") — natural language is fine; naming them is the discipline.
@@ -93,6 +97,9 @@ a label travels with the issue.
   Decision section), so the decision stays discoverable from the tracker
   rather than buried where it will be re-litigated or quietly done
   unnecessarily.
+- Re-read the unmilestoned set when scoping a cut. Deferral is now the
+  absence of a field rather than the presence of a label, so nothing
+  surfaces the backlog on its own.
 
 ---
 

--- a/templates/platform/github.md
+++ b/templates/platform/github.md
@@ -345,14 +345,14 @@ MUST have exactly one type label and one priority label. Triage
 labels are terminal — applied when closing without action.
 
 Milestones are optional. An issue MAY carry one; an empty milestone
-field is valid and means the work is not tied to a release. A PR
-SHOULD inherit the milestone of the issue it closes, when that issue
-has one.
+field is valid and means the work is not tied to a release, and is
+where deferred work sits. A PR SHOULD inherit the milestone of the
+issue it closes, when that issue has one.
 
 Do NOT stand up a named holding lane — a `Backlog` or `Expedite`
-milestone — to mark work as unscheduled or fast-tracked. Deferral is
-carried by the `P4` label and urgency by the severity label. Both
-travel with the issue and stay filterable, where a lane's meaning is
+milestone — to mark work as unscheduled or fast-tracked. An empty
+milestone field already says unscheduled, and urgency is carried by the
+severity label, which travels with the issue where a lane's meaning is
 lost the moment the milestone is closed or deleted.
 
 Milestones are forward-looking planning; GitHub Releases are the
@@ -386,14 +386,8 @@ remain visually distinct when displayed side by side.
 | `P2`  | `#EED12B` | P2 — Medium   |
 | `P3`  | `#4BCE97` | P3 — Low      |
 
-### Deferral label (optional)
-
-| Label | Color     | Meaning                       |
-| ----- | --------- | ----------------------------- |
-| `P4`  | `#8590A2` | Deliberately deferred         |
-
-`P4` is not a severity and MUST accompany a severity label rather than
-replace one.
+There MUST NOT be a fifth priority label. Deferral is carried by an
+empty milestone field, not by a band below `P3`.
 
 ### Triage labels
 
@@ -419,5 +413,6 @@ gh issue list --state open --limit 200 --json number,labels \
 
 Output MUST be `[]`. Each reported entry names the issue and its actual
 type and priority counts. The type alternation is the project's own
-taxonomy; the `P[0-3]` pattern is fixed, and `P4` is excluded by it so
-a deferred issue still passes on its severity alone.
+taxonomy; the `P[0-3]` pattern is fixed, and matches the whole priority
+scale — the check does not filter on the milestone field, so a deferred
+issue passes on its labels like any other.

--- a/templates/platform/linear.md
+++ b/templates/platform/linear.md
@@ -37,7 +37,7 @@ convention.
 - Type label names MUST match the code-host platform template character
   for character, lowercase included — a label differing only by case
   does not round-trip through the code-host integration.
-- MUST NOT create `P0`–`P4` labels. Priority is a native field; see
+- MUST NOT create `P0`–`P3` labels. Priority is a native field; see
   `platform-linear-priority`.
 - MUST NOT create `duplicate` or `wontdo` labels. Both are native
   workflow states; see `platform-linear-triage`.
@@ -57,7 +57,7 @@ convention.
 
 **Check:** list the team's issue labels. Every row above MUST report a
 parent of `Type` and a non-null team, no row MUST appear a second time
-outside the group, and no label named `P0`–`P4`, `duplicate`, or
+outside the group, and no label named `P0`–`P3`, `duplicate`, or
 `wontdo` MUST exist.
 
 ---
@@ -112,9 +112,10 @@ filters.
   severity. It is the default for an untouched issue, so spending it on
   a severity makes deliberate decisions indistinguishable from absent
   ones.
-- `P4` is a deferral marker, not a severity, so it has no place in this
-  field. Carry it as a label outside every group, or as the tracker's
-  own deferral mechanism.
+- Deferral has no place in this field, and MUST NOT be encoded as a
+  band below `Low`. It is carried by the absence of a scheduling
+  assignment — no cycle, no project milestone — exactly as an empty
+  milestone field carries it on the code host.
 
 ---
 


### PR DESCRIPTION
Closes #960.

## What

Priority becomes a pure four-band severity scale, `P0`–`P3`. Deferral
moves to the milestone field: milestoned means planned into that cut,
unmilestoned means backlog.

ADR-024 supersedes ADR-021, with reciprocal frontmatter links.

## Why

The retired `Backlog` lane and the `P4` label were two carriers for one
signal. The lane is gone; retiring the marker leaves one mechanism
rather than a label and a field that can disagree — of the four open
issues carrying the marker, two also carried a milestone and two carried
none, and in neither pair did the label say anything the milestone field
did not.

ADR-021 kept the marker because dropping it would push deferral into
prose. The milestone field is itself first-class and filterable, so the
alternative to the label was never prose.

## Changes

- `docs/decisions/024-priority-severity-only.md` — new; supersedes ADR-021
- `docs/decisions/021-...` — `status: Superseded`, `superseded_by: ["024"]`
- `templates/base/workflow/issues.md` — priority table drops the marker;
  deferred-work section restated against the milestone field, plus an
  explicit "empty milestone is not untriaged" rule and a backlog sweep
- `templates/platform/github.md` — deferral label table removed;
  conformance-check caveat no longer excludes a fifth band
- `templates/platform/linear.md` — label and priority sections over `P0`–`P3`
- `CLAUDE.md` 2.2 — deferral label table removed
- `docs/wiki/devsecops.md` — triage flow lands on `P3`
- `generated/stack-tutorial.md` — regenerated

## Out of band

- `P4` label deleted repo-wide (was on 4 open, 6 closed issues). All four
  open issues keep their type and severity; #844/#369 keep v3.0,
  #831/#832 stay unmilestoned, which is now what records their deferral.
- #831/#832 bodies updated — #831's proposed template text instructed
  future readers to apply `P4`, which would have reintroduced the marker
  into the file this PR strips it from.

## Verification

- `py tests/run_smoke.py` — 23/23
- `py tools/sync.py --check` — all files in sync
- Label conformance query returns `[]`
- No live `P4` reference outside historical records (dev journal, ADR-002/021/023)

🤖 Generated with [Claude Code](https://claude.com/claude-code)