### PR TITLE
feat(quality): sweep every surface that instructs a retired concept (#962)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -103,6 +103,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up

--- a/templates/base/core/quality.md
+++ b/templates/base/core/quality.md
@@ -97,6 +97,13 @@
   modules — if they do, the abstraction boundary is wrong
 - Before removing or renaming a public symbol, mark it deprecated with a
   comment referencing the replacement; remove it in a follow-up change
+- When retiring a concept — a label, a lane, a flag, a convention — sweep
+  every surface that still instructs its use, not just the source tree. An
+  open ticket body, a planning document, or a draft change description is a
+  delayed write: implemented verbatim later, it reintroduces the concept
+  into the very files the retirement stripped it from. The sweep is done
+  when a search for the concept returns only historical records — decision
+  logs, change logs, journals — and no surviving instruction to apply it
 - When extending a function's return type (value → list, scalar → tuple),
   keep a one-line shim under the old name returning the first/scalar
   element so existing callers and tests survive; remove it in a follow-up


### PR DESCRIPTION
Closes #962.

## What

New `## Maintainability` rule in `base/core/quality.md`: retiring a
concept MUST sweep every surface that still instructs its use — open
ticket bodies, planning documents, draft change descriptions — not just
the source tree. The sweep is done when a search returns only historical
records and no surviving instruction to apply the concept.

## Why

Fired twice in this repository, both times in the same issue body. After
ADR-023 deleted the `Backlog` lane, #831's proposed template text still
said "file a Backlog issue". After ADR-024 deleted the `P4` label, that
same issue's step 4 still instructed applying "a severity label plus
`P4`" — implementing it verbatim would have written the marker back into
`platform/github.md`, the exact file the ADR stripped it from.

## Placement

`quality.md` is core tier, measured 17/17 stacks. `issues.md` is the
topically obvious home but reaches 1/17 (stack-tutorial only), so the
rule would not have travelled. It sits beside the existing
before-removing-a-public-symbol rule, and mirrors the existing
citation-inherits-its-lifecycle rule pointing the other way.

## Verification

- `py tests/run_smoke.py` — 23/23
- `py tools/sync.py --check` — in sync
- All 17 `generated/` chains regenerated, confirming reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)