### PR TITLE
feat(git): record the batch-merge staleness refusal (#923)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -692,6 +692,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -140,6 +140,30 @@ remaining commits are silently lost.
   breakdown in the PR description, where it stays after merge.
   Use path globs in `git add` for staging hygiene when needed.
 
+### Merging a batch of PRs
+
+Where branch protection requires branches be up to date before merging,
+only the first PR in a batch merges cleanly. That merge moves the base
+and makes every other open PR stale, so the next merge is refused:
+
+```
+Pull request #<N> is not mergeable: the head branch is not up to date
+with the base branch.
+```
+
+This is a staleness check on the ref, not a content conflict. It fires
+even when the two PRs touch entirely disjoint files, and even when
+neither was stacked on the other — so neither "De-stacking a dependent
+branch" nor "Merging a stack" explains it.
+
+- MUST merge the base into every remaining PR of the batch after each
+  merge, and let its checks re-run before merging it
+- MUST NOT read the refusal as a conflict — merging the base in and
+  pushing is the whole fix; no rebase, no fresh branch, no force-push
+- SHOULD budget one update-plus-CI cycle per PR after the first. A
+  batch of N ready PRs is N merges and N-1 update cycles, which is
+  what makes merging a batch cost more than its diffs suggest
+
 ### De-stacking a dependent branch
 
 When branch B was stacked on branch A and A has squash-merged to main,


### PR DESCRIPTION
## What

Adds `### Merging a batch of PRs` to `base/core/git.md`, between
`Squash-merge safety` and `De-stacking a dependent branch`.

## Why

Two **independent** PRs, both branched off `main`, merged back to back
hit the same refusal a stack does:

```
Pull request #<N> is not mergeable: the head branch is not up to date
with the base branch.
```

`De-stacking a dependent branch` frames the merge-`main`-in step as a
consequence of duplicate commits; `Merging a stack` frames it as a
consequence of stacking. Neither applies when nothing was stacked and
the files are disjoint, so a reader who has internalised both sections
still does not expect the rejection. The mechanism was already covered
at `Pull requests` (merge `main` in, never rebase) — what was missing is
that it is *predictable*, fires on the ref rather than on content, and
carries a cost.

The new section states the cost explicitly: a batch of N ready PRs is
N merges and N-1 update-plus-CI cycles. That changes how a session's
remaining time is estimated.

`platform/github.md` `[ID: platform-github-branch-cleanup]` already
documents the same setting producing a different downstream effect (a
differing `headRefOid` after `gh pr update-branch`) — this closes the
other half.

## Checks

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync (17 `generated/` chains refreshed;
  `base-git` resolves in all 17 stacks)

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)