### PR TITLE
feat(git): allow merging main into a dependent branch when de-stacking (#919)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -724,12 +724,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 

--- a/templates/base/core/git.md
+++ b/templates/base/core/git.md
@@ -172,12 +172,23 @@ rebase B onto main — but B is already pushed, so this requires a
 force-push, which is forbidden.
 
 - MUST NOT rebase the already-pushed B to drop A's commit
-- MUST branch fresh off the updated main and cherry-pick only B's
-  own commits; open the PR from the new branch
-- Delete the old stacked branch once its superseded PR is closed
-
-This keeps remote history intact and yields a clean,
-dependency-free diff.
+- MUST take one of two routes, both force-push free. Under squash
+  merge they put byte-identical content on main, so the choice is
+  about what happens to B, not about the result:
+  - **Cherry-pick fresh** — branch off the updated main, cherry-pick
+    only B's own commits, open the PR from the new branch, and delete
+    the old stacked branch once its superseded PR is closed. Yields a
+    clean, dependency-free diff, and discards B's review history
+  - **Merge main in** — retarget B's PR to main, then merge the
+    updated main into B and push. Keeps the PR, its comments and its
+    approvals; carries a merge commit that the squash then discards
+- SHOULD cherry-pick fresh when the diff will be read carefully and B
+  has no review history worth keeping; SHOULD merge main in when B is
+  already reviewed, or when the stack is deep enough that
+  re-cherry-picking each level is error-prone
+- Both routes keep remote history intact. Where merge is not the
+  squash kind, the merge commit survives on main — cherry-pick fresh
+  instead
 
 ### Merging a stack
 


### PR DESCRIPTION
## What

`De-stacking a dependent branch` in `base/core/git.md` mandated one
route. This permits a second and names the trade-off that picks between
them.

The `MUST NOT rebase the already-pushed B` bullet is untouched — #336
settled it and it is not in question here.

## Why

Cherry-picking B fresh means closing B's PR and opening B'. That
discards B's comments and approvals, which on a reviewed PR is the more
expensive loss:

| | Cherry-pick fresh | Merge `main` in |
| -- | -- | -- |
| Force-push | none | none |
| PR diff | clean | carries a merge commit until squashed |
| Result on `main` | identical | identical |
| Review history | **lost** — new PR | preserved |
| Steps | branch, cherry-pick each commit, open PR, close old | four commands |

Under squash merge the merge commit is discarded, so the two routes land
byte-identical content on `main` — a cost that the squash deletes is not
really a cost. The new wording states that condition explicitly and
sends non-squash repositories down the cherry-pick route, since there the
merge commit does survive.

Guidance for the choice: cherry-pick fresh when the diff will be read
carefully and B has no review history worth keeping; merge `main` in when
B is already reviewed, or when the stack is deep enough that
re-cherry-picking each level is error-prone.

## Checks

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync (17 `generated/` chains refreshed)

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)