### PR TITLE
feat(config): an empty source must not fall back to the default (#963)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -3058,6 +3058,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -2364,6 +2364,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -2364,6 +2364,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -2312,6 +2312,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -3058,6 +3058,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 

--- a/templates/base/core/config.md
+++ b/templates/base/core/config.md
@@ -40,6 +40,13 @@ Sources override in this order (highest wins):
 - Document the precedence model for the project
 - Never let a lower-priority source silently override a
   higher-priority one
+- Distinguish "source absent" from "source present but empty". A
+  lookup that returns the same null for both makes the
+  highest-priority source silently lose to the lowest — a flag passed
+  with no value MUST be an error naming the accepted input, never a
+  fallback to the default the user was reaching past. This applies to
+  an empty environment variable and an empty config key as much as to
+  a trailing CLI flag
 
 ## In-process config model
 


### PR DESCRIPTION
## What

One bullet under `Config precedence` in `base/core/config.md`, naming the
mechanism behind the rule already there.

## Why

`Never let a lower-priority source silently override a higher-priority
one` states the principle. The common way to violate it is not obvious
from the rule, and it fails silently.

A hand-rolled argument parser typically has one helper returning the
value after a flag, or null when there is none. That null means two
different things — **flag absent**, and **flag present as the last
argument with nothing after it**. A parser that tests only the return
value treats the second as the first, so:

```
$ tool <target> --wait
```

runs with the hardcoded default. The highest-priority source has
silently lost to the lowest. No error, no warning, exit zero — and the
shape of the bug guarantees it fires exactly when the user was trying to
set the value.

The rule extends the same distinction to an empty environment variable
and an empty config key, which fail the same way for the same reason.

Found downstream while replacing a boolean flag with a value flag under
the `quality.md` no-boolean-flags rule: the new parser guarded against
it, three older flags in the same file did not, and nothing had ever
caught them.

## Checks

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync (`base-config` resolves in 15/17
  stacks)

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)