### PR TITLE
feat(docs): re-read divergence records when their source moves (#951)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1033,6 +1033,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -138,6 +138,19 @@ wrong before changing either.
   evidence and a post-mortem (Symptom / Root cause / Why missed / Fix /
   Prevention) if the original shipped any change; the superseded ADR's
   status flips to `Superseded by ADR-NNN` in the same PR
+- When a rule the project deliberately does NOT follow moves in its own
+  source — an upstream chain, a vendored rule set, a submodule pointer
+  bump — re-read the divergence record before deciding what the change
+  means. The reconciliation is done by reading a diff, and the diff does
+  not know the divergence exists, so the change reads as a gap to close
+  rather than a decision already reasoned about
+- A reconciliation that touches a recorded divergence MUST state whether
+  the divergence still holds, and MUST separate what the range refuted
+  from what it merely moved nearby. A decision can survive intact while
+  a neighbouring rule it named — a fallback, an alternative mechanism,
+  an exemption it relied on — is deleted; that is a repair to the
+  record, not grounds to reverse it. Recency is no protection, since
+  the source can move within hours of the record merging
 - File naming: `NNN-slug.md` — zero-padded sequence number + kebab-case slug
   (e.g. `001-data-storage.md`, `002-hosting.md`)
 - ADR file format:


### PR DESCRIPTION
## What

Two bullets under `Decision logs` in `base/core/docs.md`.

## Placement — not where the issue proposed

The issue targets `scope.md` item 10, next to the submodule pointer bump,
which is genuinely where the failure occurs. Measured with `resolve.py`:

```
base/workflow/scope.md   1/17   stack-tutorial only
base/core/docs.md       17/17
```

A rule landed in `scope.md` reaches the Astro tutorial site and nothing
else — the least likely place for a submodule reconciliation. So it goes
to `docs.md`, generalised past submodules to any source a divergence was
recorded against: an upstream chain, a vendored rule set, a submodule
pointer bump.

`Decision logs` is the right neighbourhood on the merits too. It already
carries the closest rule — when an ADR's premise is refuted shortly after
it merges, prefer a supersession ADR over silently closing the follow-ups.
This is the same shape with the refutation arriving from outside.

Nothing is added to `scope.md`: a pointer there would restate the rule
(the redundancy audit's concern) and the repository has no inline
cross-references by design.

## Why

A project records a deliberate divergence — "the template prescribes X,
we do Y, here is why". The upstream then moves X. The reconciliation is
done by reading the diff, and **the diff does not know the divergence
exists**, so the change reads as a gap to close. The ADR is the one
document that would say otherwise, and nothing prompts opening it.

The second bullet is the part the source case turned on. A downstream
project retired an optional label, and named the chain's own alternative
mechanism as the fallback for the case its argument did not cover. The
next bump crossed a commit that deleted that alternative and made the
label the sole sanctioned mechanism. The decision survived — the facts
under it had not moved — but the fallback it named was gone. Separating
*refuted* from *moved nearby* is what stops that from reading as a
reversal. The rule moved twice inside the single bumped range, and the
gap between the ADR merging and the bump partly refuting it was about
three hours, so recency was no protection either.

## Checks

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync (17 `generated/` chains refreshed)
- `py tools/audit_redundancy.py --check` — 0 exact in-chain duplicates

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)