### PR TITLE
docs(playbook): release recipe must push an annotated tag first

### DIFF
--- a/docs/PLAYBOOK.md
+++ b/docs/PLAYBOOK.md
@@ -366,15 +366,23 @@ Release — there is no `chore: release` branch, commit, or PR.
 
 1. Confirm the milestone's issues are all closed and `main` is green
    (`py tests/run_smoke.py` passes) and up to date (`git pull`)
-2. Cut the release from `main` with a bare-version title and
+2. Create and push the tag **annotated** — `tag-guard.yml` fails a
+   pushed lightweight `v*` tag, and `gh release create` makes a
+   lightweight one when the tag does not already exist:
+   ```bash
+   git tag -a vA.B.C -m "vA.B.C — <milestone theme>"
+   git push origin vA.B.C
+   ```
+3. Cut the release from the existing tag with a bare-version title and
    auto-generated notes:
    ```bash
-   gh release create vA.B.C --title vA.B.C --generate-notes
+   gh release create vA.B.C --verify-tag --title vA.B.C --generate-notes
    ```
-   This tags `main` at HEAD and publishes notes built from the PRs
-   merged since the previous tag
-3. Close the `vA.B.C` milestone once the release is published
-4. Add the session's `docs/dev-journal.md` entry **separately** — its
+   `--verify-tag` aborts rather than creating the tag, so the release
+   can only ever attach to the annotated tag pushed in step 2. Notes
+   are built from the PRs merged since the previous tag
+4. Close the `vA.B.C` milestone once the release is published
+5. Add the session's `docs/dev-journal.md` entry **separately** — its
    own `docs(journal): ...` PR with **no milestone**, not part of the
    release
 


### PR DESCRIPTION
## The defect

`Release a new version` step 2 read:

```bash
gh release create vA.B.C --title vA.B.C --generate-notes
```

With no pre-existing tag, `gh release create` creates the tag itself —
**lightweight**. `base/core/git.md` requires release tags be annotated
(`-a`/`-s`), and `.github/workflows/tag-guard.yml` fails CI on a pushed
lightweight `v*` tag. So the documented recipe, followed verbatim, breaks
the guard it is supposed to satisfy.

The annotated-tag requirement and the guard landed for #812 on
2026-07-12. This recipe was never updated to match — the rule shipped,
its prose did not.

## The fix

Step 2 creates and pushes the annotated tag; step 3 cuts the release from
it with `--verify-tag`, which aborts rather than creating a tag, so the
release can only ever attach to the annotated tag. Remaining steps
renumbered.

Found by the end-of-session checklist, one release too late — v2.43.0 was
tagged correctly today only because the annotated-tag step was applied
from memory rather than from this document.

## Checks

- `py tests/run_smoke.py` — 23/23 pass
- `py tools/sync.py --check` — in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)