### PR TITLE
feat(agents): a consumer's chain list does not decide what governs (#971)

### DIFF
--- a/templates/base/core/agents.md
+++ b/templates/base/core/agents.md
@@ -396,6 +396,23 @@ moves the pin to.
   correct until upstream keeps working past a release, then silently
   attributes rules to a range that does not contain them
 
+The pinned revision settles *when*; the dependency graph settles *what*.
+Governance resolves transitively through each template's `DEPENDS ON`
+header — declaring `platform/<host>.md` also declares every template it
+reaches, and every template those reach.
+
+- Resolve each changed file against the graph when reconciling a bump,
+  never against a list. A file absent from the list still governs if
+  anything declared reaches it; a file that reads as obviously
+  applicable does not govern unless something declared reaches it
+- Any chain list a consumer writes into its own context file is a cache
+  of that resolution, not the definition. It can go stale, and a stale
+  one changes governed scope without any edit to the rule it drops
+- Both errors pass for ordinary reconciliation work. The missed file
+  surfaces as a local document maintaining a convention upstream
+  already owns; the over-included one as a repository enforcing rules
+  it never adopted
+
 ---
 
 ## Monorepo support (optional)


### PR DESCRIPTION
A consuming repository typically lists its resolved chain in `CLAUDE.md`
as a convenience. Nothing said that list is not authoritative, and
treating it as authoritative is wrong in both directions at once.

Downstream, `page-fetcher`'s `CLAUDE.md` names nine chain files.
Reconciling the `v2.42.0` bump against that list gave the wrong answer
twice:

- **Missed a governing file.** `workflow/issues.md` is not in the list,
  but `platform/github.md` depends on it — so `base-issues-record`
  governs that repository, which had been restating it by hand as a
  local convention.
- **Nearly imported two that do not govern.** `agents.md` and
  `security/devsecops.md` both changed in the same range and read as
  obviously applicable. Neither is reachable from anything declared.

Adds a paragraph plus three bullets to "Vendoring the templates",
following the pin rule from #970 — that one settles *when*, this one
settles *what*.

Note: the rule originally spelled the directive out in its bracket form.
The smoke parser reads that as a real declaration even inside backticks
(SYS-01/SYS-04 both failed), so it names the `DEPENDS ON` header instead.

Smoke: 23/23 pass.

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)