### PR TITLE
docs(arc42): add goal content rules, drop the §10 quality tree, join on QG0n (#983)

### DIFF
--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1267,6 +1267,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1261,9 +1261,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -1271,13 +1274,48 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -372,6 +372,9 @@ general writing-style and diagram rules above still apply.
   a sub-characteristic where that is more precise (Correctness,
   Functional Completeness, Availability) — distinct from the `Q1…`
   quality scenarios in §10
+- The `QG0n` id is the join key across §1, §4 and §10 — §4's
+  quality-approach table and §10's scenario table both carry it, so a
+  script can assert the three still agree
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -398,12 +398,16 @@ general writing-style and diagram rules above still apply.
   efficiency, a component with human users declares usability
 - A motivation gives a fact and the consequence that follows from it —
   a bare fact does not justify a priority
-- §10 quality-tree branches are falsifiable — a branch naming module
-  counts, file layout, or bind addresses describes what was built and
-  cannot fail
-- Adding or renaming a quality updates four places: the §1 goal table,
-  the §4 quality-approach table, the §10 tree, and the §10 scenario
-  table
+- §10 scenarios are falsifiable — a scenario naming module counts, file
+  layout, or bind addresses describes what was built and cannot fail
+- §10 is one table, not a table plus a quality tree — a tree duplicates
+  the scenarios at lower resolution and drifts from them; carry the ISO
+  25010 sub-characteristic and the `QG0n` id as columns instead
+- A §10 scenario known not to hold today says so in its expected
+  response and cites the §11 entry — a scenario stating only the target
+  reads as an aspiration
+- Adding or renaming a quality updates three places: the §1 goal table,
+  the §4 quality-approach table, and the §10 scenario table
 
 ### Concept sections
 

--- a/templates/base/core/docs.md
+++ b/templates/base/core/docs.md
@@ -366,9 +366,12 @@ general writing-style and diagram rules above still apply.
 ### IDs and register
 
 - Functional requirements use `FR01…` in shall-form (IEEE 29148);
-  quality goals use `QG01…` with ISO 25010 names (Correctness,
-  Reliability, Maintainability, Portability, Compatibility, Usability) —
-  distinct from the `Q1…` quality scenarios in §10
+  quality goals use `QG01…` named for an ISO 25010 characteristic
+  (Functional Suitability, Performance Efficiency, Compatibility,
+  Usability, Reliability, Security, Maintainability, Portability) or for
+  a sub-characteristic where that is more precise (Correctness,
+  Functional Completeness, Availability) — distinct from the `Q1…`
+  quality scenarios in §10
 - Requirements use "shall"; constraints and other givens stay
   declarative — avoid all-caps RFC 2119 keywords in arc42 prose
 - A per-section purpose line only where it adds meaning (define a term
@@ -376,13 +379,44 @@ general writing-style and diagram rules above still apply.
 - No forward cross-references to later-numbered sections (a section is
   authored before they exist); back-references are fine
 
+### Requirement and goal content
+
+- A quality goal states how well the system behaves, never what it
+  does. Tell: the clause appears verbatim as an `FR` row in the same
+  chapter — that is a duplicate, not a goal
+- A quality goal is not the product's purpose restated. Tell: the
+  motivation reads "…is the reason the service exists"
+- Security goals state who may do what; the mechanism that enforces it
+  (bind address, reverse proxy, allowlist) belongs in §2 or §4. Tell: a
+  goal the system's own top security risk cannot violate
+- Every quality goal carries its measurable target in §1 — a figure
+  living only in a §10 scenario leaves §1 unfalsifiable
+- One goal covers one quality with one failure mode — split a goal
+  whose clauses can fail independently of each other
+- Goal coverage follows what the component is, not only what its risk
+  register lists: a component inline on a write path declares
+  efficiency, a component with human users declares usability
+- A motivation gives a fact and the consequence that follows from it —
+  a bare fact does not justify a priority
+- §10 quality-tree branches are falsifiable — a branch naming module
+  counts, file layout, or bind addresses describes what was built and
+  cannot fail
+- Adding or renaming a quality updates four places: the §1 goal table,
+  the §4 quality-approach table, the §10 tree, and the §10 scenario
+  table
+
 ### Concept sections
 
 - Describe the idea in prose, then give a `Concept | Implementation`
   table mapping it to concrete identifiers — rather than inlining
   identifiers throughout the prose
-- A glossary entry is a **bold term** followed by plain text — no
-  inline-code monospacing of the term
+
+### Glossary
+
+- Every glossary term is bold — `**term**`, never inline-code
+  monospaced, and never left as plain text. Applies to identifiers
+  (table names, routes, service names) as much as to prose terms
+- The definition following the term is plain text
 
 ## Docs-as-code
 


### PR DESCRIPTION
Closes #983.

Five changes to `templates/base/core/docs.md` under `[ID: docs-arc42]`:

1. **New `### Requirement and goal content`** — nine rules for what
   makes a requirement or goal good, each with its diagnostic tell. The
   section previously covered ID form and naming only.
2. **ISO 25010 list widened** — the old parenthetical omitted Security
   and Performance Efficiency, both top-level characteristics. Now names
   all eight plus Correctness, Functional Completeness, and Availability.
3. **Glossary rule moved** out of `### Concept sections` into its own
   `### Glossary` subsection, with both halves stated: bold, never
   monospaced, never plain.
4. **§10 quality tree dropped** — see below.
5. **`QG0n` named as the join key** across §1, §4 and §10 — see below.

Changes 4 and 5 extend the original scope of #983, because two rules
this PR added describe the tree and are now false, and because the
register defined an id without saying what it is for.

## Why the tree goes (change 4)

The first draft of this PR added two rules that assumed a §10 quality
tree beside the scenario table. Applying the whole `[ID: docs-arc42]`
rule set across 19 arc42 doc sets showed the tree does not earn its
place:

- **390 tree leaves against 281 scenarios**, and **28% of the
  assertions existed only in the tree** — with no stimulus, response, or
  priority written for them
- **no repository where the two agreed**; the tree and the table drift
  apart because nothing forces them together
- rendered at up to **3015 × 4455 px**, unreadable in a wiki and gone on
  paper
- the tree's only unique content is grouping plus which qualities are
  §1 goals, which is two table columns

arc42 upstream reached the same conclusion independently: [Tip
10-2](https://docs.arc42.org/tips/10-2/) is marked deprecated ("we
favor a simple table instead of the graphics") and [FAQ
C-10-3](https://faq.arc42.org/questions/C-10-3/) states the maintenance
criticism directly.

So the two tree rules are replaced by four:

- §10 scenarios are falsifiable (was: tree branches are falsifiable)
- §10 is one table, not a table plus a tree — carry the ISO 25010
  sub-characteristic and the `QG0n` id as columns instead
- a scenario known not to hold today says so and cites its §11 entry —
  a scenario stating only the target reads as an aspiration
- adding or renaming a quality updates three places, not four

## Why the join key (change 5)

The register defines `QG0n` and the content rules say a quality change
touches three tables, but nothing said the id is what joins them.
Without it the three sections are matched by reading, and drift
silently: a goal renamed in §1 leaves a stale §4 approach row, or §10
grows a scenario for a quality §1 never claimed. Naming the join key
makes the three checkable by script.

## Checks

Both gates pass, and the staleness this branch carried since `0602189`
is fixed:

| Check | Before | After |
| --- | --- | --- |
| `py tools/sync.py --check` | exit 1, 17 stale chains | exit 0 |
| `py tests/run_smoke.py` | not run | 23/23 pass |

Verified against `2.7 Template authoring rules`: all lines under 80
chars, no HTML, matching the local declarative style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
