### PR TITLE
feat(templates): give examples/ its own base template (#987, #988)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -58,6 +58,7 @@ base/
 │   ├── agents.md       # Output structure, models (inline/reference/hybrid), formatting rules
 │   ├── skills.md       # Skill authoring — when to write one, frontmatter, triggering, structure, scripts
 │   ├── readme.md       # README structure, badges, quick start, contribution guide
+│   ├── examples.md     # Examples directory — contents, index, offline rule, smoke job
 │   └── oop.md          # SOLID, OOP, GoF design patterns, AOP guidance
 ├── security/
 │   ├── devsecops.md    # SAST, SCA, SBOM, secret detection, license compliance

--- a/docs/decisions/025-examples-get-their-own-template.md
+++ b/docs/decisions/025-examples-get-their-own-template.md
@@ -1,0 +1,125 @@
+---
+id: "025"
+status: Accepted
+date: 2026-08-05
+category: templates
+supersedes: []
+superseded_by: []
+---
+
+# ADR-025: Examples get their own template
+
+## Context
+
+Governance of an `examples/` directory is split across two templates,
+and neither half knows about the other.
+
+`stack/python-lib.md` (`[ID: python-lib-structure]`) prescribes the
+directory: one file per pattern, smoke-tested in CI, excluded from the
+wheel, distinct from `scripts/`. `base/core/readme.md` prescribes its
+contents: the index, the offline rule, output that is real and never
+fabricated. The bridge between them is a single conditional bullet
+under the README's Project structure section — a rule about how example
+code *runs*, reached through the template that governs README prose,
+because the index happens to be a README.
+
+Three consequences follow from that split.
+
+`base/core/readme.md` carries one file-level `[ID: base-readme]` and no
+section IDs. The offline rule is therefore not addressable: a project
+that needs to extend or override it has to replace the entire README
+contract to reach it.
+
+`base-readme` is in the core tier, so every project inherits the index
+and offline rules. `python-lib` is the only one of seventeen stacks
+that prescribes the directory. A Go or Node library shipping
+`examples/` is governed on content and ungoverned on structure, layout,
+and CI.
+
+Two gaps sat in the seam between the halves and were found downstream
+in `braboj/page-fetcher`. "Smoke-tested in CI" never says how the
+package is installed for that job, and the cheapest reading — reuse the
+test job — proves the examples run beside the test tooling rather than
+against the published surface (#988). And the index is the one document
+whose body is machine-generated program output, which the secret
+scanner reads like source; a printed cache key matched
+`generic-api-key` and failed the scan on a file containing no secret
+(#987). Both are template gaps, not project mistakes, and neither owner
+was the obvious place to fix them.
+
+## Decision
+
+1. **A dedicated template** — `templates/base/core/examples.md`
+   (`[ID: base-examples]`) holds every rule governing an `examples/`
+   directory: contents, index, offline execution, smoke job. Sections
+   carry their own IDs so a project can extend one rule without
+   replacing a neighbouring contract.
+
+2. **Reached by `depends_on`, not the core tier** — a stack that
+   prescribes an examples directory declares `base-examples`. The core
+   tier is the set that applies to every project, and most projects
+   ship no examples directory; a conditional concern does not belong
+   there.
+
+3. **README keeps the pointer only** — `base-readme` MUST state that
+   the directory carries its own `README.md`, because the index is a
+   README and that template owns READMEs. It MUST NOT restate what the
+   index contains.
+
+4. **Stack templates keep only what is language-specific** —
+   packaging exclusion, install command, file extension, position
+   relative to the source layout. Everything a second language would
+   copy verbatim belongs in `base-examples`.
+
+5. **The new template holds what neither owner did** — the smoke job
+   MUST install the project the way a consumer does and MUST glob the
+   directory rather than list files; the index MUST label a printed
+   derived identifier with a word the secret scanner does not treat as
+   a credential keyword, and MUST fix the label rather than the
+   scanner.
+
+## Alternatives considered
+
+- **Patch the two gaps in place** — rejected; it leaves the rules
+  unaddressable behind a single file-level ID and leaves every
+  non-Python library governed on content but not structure.
+- **Move the index rules into `stack/python-lib.md`** — rejected; the
+  rules are language-agnostic, so every library stack that later adopts
+  an examples directory copies them, and the copies drift.
+- **Add `base-examples` to the core tier** — rejected; it would apply
+  a conditional concern to every project and grow the core six for a
+  directory most projects do not have.
+- **Make it an orthogonal extra, like the platform templates** —
+  rejected; an examples directory is a property of the stack, not a
+  project-level choice made independently of it.
+- **Leave the offline rule as guidance rather than a named ban** —
+  rejected; "avoid the network" is satisfiable by an example that
+  constructs the real client against a host that obviously resolves,
+  which is offline until the day it is not.
+
+## Consequences
+
+- `base/core/readme.md` §5 reduces to one pointer bullet; the index,
+  offline and fabricated-output rules move out.
+- `stack/python-lib.md` keeps the wheel exclusion, the flat-layout
+  caveat and the install command, and gains `base-examples` in its
+  `[DEPENDS ON: ...]` header and manifest `depends_on` — both, since
+  headers MUST match the manifest (SYS-04).
+- `templates/manifest.yaml` gains the `base-examples` entry;
+  `py tools/sync.py` regenerates SPEC.md, README.md, INTERVIEW.md and
+  `generated/`.
+- #987 and #988 are answered by `base-examples-index` and
+  `base-examples-smoke`. #987's second request — repeating the
+  commit-history point wherever the secret scan is described — is
+  platform-template scope and stays open there.
+- `go-lib` and `nodejs-lib` prescribe no examples directory today.
+  Adopting one is a `depends_on` line plus a structure entry, and is
+  not done here.
+- The redundancy audit stays clean: the rules move, they do not
+  duplicate.
+
+## Related
+
+- `templates/base/core/examples.md` — the new template
+- `templates/base/core/readme.md` — the pointer that remains
+- `templates/stack/python-lib.md` — the first consumer

--- a/docs/decisions/025-examples-get-their-own-template.md
+++ b/docs/decisions/025-examples-get-their-own-template.md
@@ -78,6 +78,15 @@ was the obvious place to fix them.
    a credential keyword, and MUST fix the label rather than the
    scanner.
 
+6. **Offline is bounded, and has one exception** — offline means no
+   dependency on a host outside the project, not the absence of
+   sockets; a process the example starts, a container the project
+   brings up, and a bundled fixture all qualify. An example MAY depend
+   on an outside host where the capability cannot be sealed behind a
+   seam and building one would cost more than the example is worth,
+   provided it names the service, states why no seam was built, dates
+   its pasted output, and runs in a CI leg that does not gate merges.
+
 ## Alternatives considered
 
 - **Patch the two gaps in place** — rejected; it leaves the rules
@@ -96,6 +105,18 @@ was the obvious place to fix them.
   rejected; "avoid the network" is satisfiable by an example that
   constructs the real client against a host that obviously resolves,
   which is offline until the day it is not.
+- **An absolute offline rule with no exception** — rejected; it reads
+  as "build a fake of your vendor's API before you may ship an
+  example", which charges a documentation rule for an architectural
+  seam. Where no seam exists the alternative to a dated example is no
+  example, and the portfolio contains products whose entire surface is
+  someone else's service. A rule routinely overridden is a rule stated
+  wrongly.
+- **Define offline as "no sockets"** — rejected; it would ban an
+  example that starts the project's own service on localhost or brings
+  up its own container, both of which are reproducible forever for a
+  reader who has the repository. The property that matters is
+  reproducibility, not socket abstinence.
 
 ## Consequences
 
@@ -117,6 +138,14 @@ was the obvious place to fix them.
   not done here.
 - The redundancy audit stays clean: the rules move, they do not
   duplicate.
+- A project whose examples need an outside host declares the exception
+  per example rather than overriding `base-examples-offline` wholesale,
+  so the preference for a seam survives in the projects that deviate
+  from it.
+- A stack adopting `base-examples` gains a second CI leg where its
+  examples take the exception. The gating leg's pass condition covers
+  only what it runs, so a quarantined example cannot be counted as
+  passing by a job that never executed it.
 
 ## Related
 

--- a/generated/stack-astro.md
+++ b/generated/stack-astro.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-c-embedded.md
+++ b/generated/stack-c-embedded.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4586,9 +4577,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -4629,12 +4715,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-django.md
+++ b/generated/stack-django.md
@@ -4638,10 +4638,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -4651,6 +4658,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -4667,9 +4691,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-express.md
+++ b/generated/stack-express.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4586,9 +4577,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -4629,12 +4715,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-fastapi.md
+++ b/generated/stack-fastapi.md
@@ -4638,10 +4638,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -4651,6 +4658,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -4667,9 +4691,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4586,9 +4577,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -4629,12 +4715,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-flask.md
+++ b/generated/stack-flask.md
@@ -4638,10 +4638,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -4651,6 +4658,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -4667,9 +4691,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -3750,9 +3741,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -3793,12 +3879,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-grpc-python.md
+++ b/generated/stack-grpc-python.md
@@ -3802,10 +3802,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -3815,6 +3822,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -3831,9 +3855,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-htmx.md
+++ b/generated/stack-htmx.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-nestjs.md
+++ b/generated/stack-nestjs.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -3028,10 +3028,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -3041,6 +3048,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -3057,9 +3081,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-python-lib.md
+++ b/generated/stack-python-lib.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -2976,9 +2967,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -3019,12 +3105,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the
@@ -4586,9 +4577,104 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero
+
+
 <!-- templates/stack/python-lib.md -->
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -4629,12 +4715,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package

--- a/generated/stack-python-service.md
+++ b/generated/stack-python-service.md
@@ -4638,10 +4638,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -4651,6 +4658,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -4667,9 +4691,14 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
 
 
 <!-- templates/stack/python-lib.md -->

--- a/generated/stack-tutorial.md
+++ b/generated/stack-tutorial.md
@@ -1442,18 +1442,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/templates/base/core/examples.md
+++ b/templates/base/core/examples.md
@@ -1,0 +1,92 @@
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Examples MUST run offline against data the project already bundles
+- Where the behaviour being demonstrated inherently needs a network, a
+  service, or a device, the example drives the project's own seam — the
+  fake, the fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the run covers at least one file and
+  every file exits zero

--- a/templates/base/core/examples.md
+++ b/templates/base/core/examples.md
@@ -58,10 +58,17 @@ nothing from this template.
 ## Offline
 [ID: base-examples-offline]
 
-- Examples MUST run offline against data the project already bundles
-- Where the behaviour being demonstrated inherently needs a network, a
-  service, or a device, the example drives the project's own seam — the
-  fake, the fixture, the recorded capture — never the live client
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
 - The rule MUST name the concrete type an example may not construct.
   A soft "avoid the network" invites an example that builds the real
   client and points it at a host that obviously resolves, which is
@@ -71,6 +78,23 @@ nothing from this template.
   capability may not be demonstrable by any example, and MUST carry it
   where that capability is documented rather than reaching for the
   network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
 
 ---
 
@@ -87,6 +111,11 @@ nothing from this template.
   covering the file someone forgot to register
 - The job MUST run on the lowest runtime version the project claims to
   support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
 - Check: install the project alone, then execute every file under
-  `examples/`. Pass condition — the run covers at least one file and
-  every file exits zero
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero

--- a/templates/base/core/readme.md
+++ b/templates/base/core/readme.md
@@ -68,18 +68,9 @@ Every README MUST contain the following sections, in this order:
   and structurally enforces the one-line-description rule
 - Generated directories (`dist/`, `__pycache__/`, `.venv/`) MUST be omitted
 - When the project ships an `examples/` directory, that directory MUST
-  carry its own `README.md` indexing each example as an exact command
-  paired with the output it produces. A bare folder of sample inputs
-  under-delivers and reads as broken data; the index turns it into a
-  try-it-now surface
-  - Examples MUST run offline against data the project already bundles
-  - Output MUST be real or a reproducible dry run — never fabricated
-    numbers. Where the true output needs an engine or service the
-    reader may not have, show the dry run, which conveys the shape and
-    runs anywhere
-  - A sample input that looks incomplete on purpose (an optional field
-    left blank) MUST say so next to the command, not leave the reader
-    to reverse-engineer the intent
+  carry its own `README.md`, because the index is a README and this
+  template owns those. What the index and the examples themselves MUST
+  contain is `base-examples`, and MUST NOT be restated here
 
 ### 6. Development setup
 - MUST cover: cloning, installing dependencies, running tests, running the

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -55,6 +55,9 @@ base:
   - id: base-readme
     file: templates/base/core/readme.md
     description: README structure, badges, quick start, contribution guide
+  - id: base-examples
+    file: templates/base/core/examples.md
+    description: Examples directory — contents, index, offline rule, smoke job
   - id: base-deployment
     file: templates/base/infra/deployment.md
     description: Deployment targets (cloud/hybrid/offline), certs, LB, registries, secrets
@@ -247,6 +250,7 @@ stacks:
       - base-docs
       - base-quality
       - base-quality-gates
+      - base-examples
 
   - id: stack-python-service
     file: templates/stack/python-service.md

--- a/templates/stack/python-lib.md
+++ b/templates/stack/python-lib.md
@@ -1,5 +1,5 @@
 # Stack — Python Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 A Python library, CLI tool, or shared package intended to be imported or
 installed. No web server, no frontend. May be published to PyPI.
@@ -40,12 +40,11 @@ CLAUDE.md
 
 - Source layout (`src/`) — prevents accidental imports of the uninstalled
   package
-- `examples/` holds runnable, maintained usage patterns — one file per
-  pattern or user journey, smoke-tested in CI against the library so
-  they cannot rot, and excluded from the built wheel like `tests/`.
-  Distinct from `scripts/`, which is throwaway probes and benchmarks
-  and is not shipped. A design document references an example rather
-  than duplicating its code
+- `examples/` holds runnable usage patterns, governed by
+  `base-examples`. Python specifics: under `src/` the directory cannot
+  reach the wheel and needs no exclude — a flat layout MUST exclude it
+  explicitly, like `tests/`; the smoke job installs with
+  `pip install -e .` and no extra
 - When adopting `src/` or adding a sub-package, audit every path-based
   exclude in tool configs (bandit `exclude_dirs`, coverage `omit`,
   ruff `extend-exclude`) for patterns that now match new package


### PR DESCRIPTION
## Why

Governance of an `examples/` directory is split across two templates, and
neither half knows about the other:

| Concern | Lives in | Applies to |
| -- | -- | -- |
| Directory exists, one file per pattern, smoke-tested, excluded from the wheel | `stack/python-lib.md` | python-lib only |
| The index, the offline rule, real output | `base/core/readme.md` §5 | every project (core tier) |

The bridge is one conditional bullet under the README's Project structure
section — a rule about how example *code runs*, reached through the template
that governs README prose, because the index happens to be a README.

Three things follow:

- `base/core/readme.md` carries one file-level `[ID: base-readme]` and no
  section IDs, so the offline rule is not addressable — extending it means
  replacing the entire README contract
- `base-readme` is core tier, `python-lib` is the only one of seventeen
  stacks that prescribes the directory. A Go or Node library shipping
  `examples/` is governed on content and ungoverned on structure and CI
- Two gaps sat in the seam and were found downstream in `braboj/page-fetcher`
  — the smoke job's install method (#988) and the secret scanner reading the
  index like source (#987). Both are template gaps, and neither owner was the
  obvious place to fix them

## What changed

- **New** `templates/base/core/examples.md` `[ID: base-examples]` — four
  addressable sections: `-scope`, `-index`, `-offline` (with
  `-offline-exception`), `-smoke`
- **New** `docs/decisions/025-examples-get-their-own-template.md`
- `base/core/readme.md` §5 — the examples block reduces to a pointer; it
  keeps "the directory carries its own README" because this template owns
  READMEs, and forbids restating the content rules
- `stack/python-lib.md` — keeps the Python residue only (wheel exclusion,
  flat-layout caveat, `pip install -e .`), gains `base-examples` in
  `[DEPENDS ON: ...]`
- `templates/manifest.yaml` — `base-examples` registered under `base:`, added
  to `stack-python-lib.depends_on`
- `docs/SPEC.md` and 17 `generated/*.md` — `py tools/sync.py`. Every stack
  churns because `base-readme` is core tier

## What "offline" means here

The first draft of this PR said only "examples MUST run offline", which is
two things wrong at once, both fixed in the second commit:

- **It was undefined**, and the natural reading is "no sockets". That bans an
  example that starts the project's own service on localhost or brings up its
  own container — both reproducible forever for a reader holding the
  repository. Offline is now defined as *no dependency on a host outside the
  project*. Reproducibility is the property; socket abstinence is not.
- **It had no exception**, which charged a documentation rule for an
  architectural seam. A product whose entire surface is a vendor's API was
  told to build a fake before it could ship an example — and where no seam
  exists, the alternative to a dated example is no example.
  `base-examples-offline-exception` allows the outside host when the
  capability cannot be sealed, provided the entry names the service, says why
  no seam was built, dates its pasted output, and runs in a CI leg that does
  not gate merges.

The preference is unchanged: seam where a seam is cheap. A project whose
examples all take the exception has skipped the seam, not found the
exception.

## Judgment calls worth review

- **Opt-in tier, not core** — a conditional concern does not belong in the
  six that apply to every project. Only `stack-python-lib` declares it today;
  `go-lib` and `nodejs-lib` prescribe no examples directory, and adopting is
  one `depends_on` line each, left as follow-up
- **The offline rule names a type** — `base-examples-offline` requires naming
  the concrete type an example may not construct, rather than a soft "avoid
  the network". The downstream case that motivated it named `NetworkFetcher`;
  the reasoning generalizes, the name does not
- **The exception is per example, not per project** — deviating does not
  override `base-examples-offline` wholesale, so the preference for a seam
  survives inside the projects that deviate from it

## Verification

```
py tools/sync.py --check               All files in sync.
py tools/audit_redundancy.py --check   OK: no new exact in-chain duplicates
py tests/run_smoke.py                  23 checks — 23 passed  0 failed  0 errors
py tools/resolve.py stack-python-lib   base/core/examples.md resolves into the chain
```

SYS-04 (headers match manifest) and ADR-01 (ADR format) both pass. The
redundancy audit staying at zero is the check that matters here — it confirms
the rules moved rather than got copied.

## Issues

Closes #988.

Refs #987 — the index half is answered by `base-examples-index`, including
the commit-history point. The second request in that issue, repeating the
note wherever the secret scan is described, is platform-template scope and
stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
