### PR TITLE
feat(templates): govern examples in the Go and Node library stacks (#991)

### DIFF
--- a/generated/stack-go-echo.md
+++ b/generated/stack-go-echo.md
@@ -2967,9 +2967,133 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
+
+
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by
@@ -3039,6 +3163,25 @@ no HTTP layer.
 - Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
   e.g. `TestParseConfig_MissingField_ReturnsError`
 - Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Examples
+[ID: go-lib-examples]
+[EXTEND: base-examples]
+
+- Prefer `Example` functions in `_test.go` with an `// Output:` comment.
+  `go test` compares the comment against what the function prints, so
+  the real-output rule is machine-checked rather than reviewed, and the
+  example cannot rot silently
+- Reach for a standalone `examples/` directory only for what an
+  `Example` function cannot carry — a multi-file program, a CLI
+  invocation, a flag-driven journey
+- Each program under `examples/` MUST be `package main`, so it cannot
+  be imported as library API and cannot widen the module's surface
+- Smoke check: `go vet ./... && go test ./...` covers the `Example`
+  functions; `go run ./examples/<name>` covers the directory. Pass
+  condition — every program exits zero
 
 ---
 

--- a/generated/stack-go-lib.md
+++ b/generated/stack-go-lib.md
@@ -2967,9 +2967,133 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
+
+
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by
@@ -3039,6 +3163,25 @@ no HTTP layer.
 - Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
   e.g. `TestParseConfig_MissingField_ReturnsError`
 - Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Examples
+[ID: go-lib-examples]
+[EXTEND: base-examples]
+
+- Prefer `Example` functions in `_test.go` with an `// Output:` comment.
+  `go test` compares the comment against what the function prints, so
+  the real-output rule is machine-checked rather than reviewed, and the
+  example cannot rot silently
+- Reach for a standalone `examples/` directory only for what an
+  `Example` function cannot carry — a multi-file program, a CLI
+  invocation, a flag-driven journey
+- Each program under `examples/` MUST be `package main`, so it cannot
+  be imported as library API and cannot widen the module's surface
+- Smoke check: `go vet ./... && go test ./...` covers the `Example`
+  functions; `go run ./examples/<name>` covers the directory. Pass
+  condition — every program exits zero
 
 ---
 

--- a/generated/stack-go-service.md
+++ b/generated/stack-go-service.md
@@ -2967,9 +2967,133 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
+
+
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by
@@ -3039,6 +3163,25 @@ no HTTP layer.
 - Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
   e.g. `TestParseConfig_MissingField_ReturnsError`
 - Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Examples
+[ID: go-lib-examples]
+[EXTEND: base-examples]
+
+- Prefer `Example` functions in `_test.go` with an `// Output:` comment.
+  `go test` compares the comment against what the function prints, so
+  the real-output rule is machine-checked rather than reviewed, and the
+  example cannot rot silently
+- Reach for a standalone `examples/` directory only for what an
+  `Example` function cannot carry — a multi-file program, a CLI
+  invocation, a flag-driven journey
+- Each program under `examples/` MUST be `package main`, so it cannot
+  be imported as library API and cannot widen the module's surface
+- Smoke check: `go vet ./... && go test ./...` covers the `Example`
+  functions; `go run ./examples/<name>` covers the directory. Pass
+  condition — every program exits zero
 
 ---
 

--- a/generated/stack-grpc-go.md
+++ b/generated/stack-grpc-go.md
@@ -2967,9 +2967,133 @@ scheduled whole-tree sweep, not a per-change gate.
 - Platform templates define the CI integration and SAST tool
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
+
+
 <!-- templates/stack/go-lib.md -->
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by
@@ -3039,6 +3163,25 @@ no HTTP layer.
 - Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
   e.g. `TestParseConfig_MissingField_ReturnsError`
 - Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Examples
+[ID: go-lib-examples]
+[EXTEND: base-examples]
+
+- Prefer `Example` functions in `_test.go` with an `// Output:` comment.
+  `go test` compares the comment against what the function prints, so
+  the real-output rule is machine-checked rather than reviewed, and the
+  example cannot rot silently
+- Reach for a standalone `examples/` directory only for what an
+  `Example` function cannot carry — a multi-file program, a CLI
+  invocation, a flag-driven journey
+- Each program under `examples/` MUST be `package main`, so it cannot
+  be imported as library API and cannot widen the module's surface
+- Smoke check: `go vet ./... && go test ./...` covers the `Example`
+  functions; `go run ./examples/<name>` covers the directory. Pass
+  condition — every program exits zero
 
 ---
 

--- a/generated/stack-nodejs-lib.md
+++ b/generated/stack-nodejs-lib.md
@@ -2325,9 +2325,133 @@ answer for the wrong reason is the same failure in a cheaper form.
   smell that can silently break sorting, filtering, and UI logic
 
 
+<!-- templates/base/core/examples.md -->
+# Base — Examples
+[ID: base-examples]
+
+Rules for a project that ships an `examples/` directory. An examples
+directory is a try-it-now surface, not a folder of sample inputs: every
+file in it is runnable, maintained, and executed by CI against the
+project it documents.
+
+Applies only where the directory exists. A project without one inherits
+nothing from this template.
+
+---
+
+## Contents
+[ID: base-examples-scope]
+
+- One file per pattern or user journey — not one per API surface, and
+  not one per feature listed in the README. Split on the seams a
+  consumer meets, not on the table of contents
+- `examples/` is maintained; `scripts/` is throwaway probes and
+  benchmarks and is not shipped. A file nobody would run twice belongs
+  in `scripts/`
+- Examples MUST be excluded from the built artifact, the same way tests
+  are
+- A design document references an example rather than duplicating its
+  code — two copies of a snippet drift, and the copy in prose is the
+  one nothing executes
+
+---
+
+## The index
+[ID: base-examples-index]
+
+- The directory MUST carry its own `README.md` indexing every example
+  as an exact command paired with the output it produces. A bare folder
+  of sample inputs under-delivers and reads as broken data
+- Output MUST be real or a reproducible dry run — never fabricated
+  numbers. Where the true output needs an engine or service the reader
+  may not have, show the dry run, which conveys the shape and runs
+  anywhere
+- A sample input that is incomplete on purpose (an optional field left
+  blank) MUST say so next to the command, not leave the reader to
+  reverse-engineer the intent
+- The index is the one document whose body is machine-generated prose,
+  and the secret scanner reads it like source. Where an example prints
+  a derived identifier — a hash, a cache key, a request id — label it
+  with a word the scanner does not treat as a credential keyword. A
+  keyword followed by a high-entropy token is a generic-api-key match
+- Fix the label, never the scanner. A fingerprint-scoped allowlist
+  entry dies at squash-merge and leaves dead config behind; a
+  path-scoped one permanently exempts the one file whose whole purpose
+  is pasting program output
+- The scan reads commit history, not the working tree — a follow-up
+  commit does not clear a finding, the branch has to stop containing it
+
+---
+
+## Offline
+[ID: base-examples-offline]
+
+- Offline means no dependency on a host outside the project. A process
+  the example starts itself, a container the project's own compose file
+  brings up, and a bundled fixture are all offline; a third-party
+  endpoint is not, whoever operates it. Sockets are not the test —
+  reproducibility for a reader who has the repository and nothing else
+  is
+- Examples MUST run offline in that sense, against the data and
+  services the project already carries
+- Where the behaviour being demonstrated inherently needs an outside
+  host, the example drives the project's own seam — the fake, the
+  fixture, the recorded capture — never the live client
+- The rule MUST name the concrete type an example may not construct.
+  A soft "avoid the network" invites an example that builds the real
+  client and points it at a host that obviously resolves, which is
+  offline until the day it is not; a named constructor is a line the
+  reader can check and CI can enforce
+- A project whose subject matter is I/O MUST accept that its central
+  capability may not be demonstrable by any example, and MUST carry it
+  where that capability is documented rather than reaching for the
+  network to cover it
+
+### Exception
+[ID: base-examples-offline-exception]
+
+An example MAY depend on an outside host where the capability cannot be
+sealed behind a seam and building one would cost more than the example
+is worth. Prefer the seam wherever a seam is cheap — this is an
+exception, not a second style. An example taking it MUST:
+
+- name, in its index entry, the external service it requires
+- state in that entry why no seam was built — one sentence
+- carry its pasted output with the date it was captured, never
+  presented as reproducible
+- run in a CI leg that does not gate merges
+
+A project whose examples all take the exception has not found the
+exception, it has skipped the seam.
+
+---
+
+## The smoke job
+[ID: base-examples-smoke]
+
+- Every example MUST be executed by CI against the project, so it
+  cannot rot
+- The job MUST install the project the way a consumer does — no dev,
+  test, or optional extras. Reusing the test job proves only that the
+  examples run beside the test tooling, which no reader has
+- The job MUST glob the directory rather than listing files, so a new
+  example is covered without editing CI. A listed job silently stops
+  covering the file someone forgot to register
+- The job MUST run on the lowest runtime version the project claims to
+  support, so an example cannot depend on syntax that version lacks
+- An example taking `base-examples-offline-exception` MUST run in a
+  separate leg that does not gate merges — a third-party endpoint MUST
+  NOT be able to block a merge by being slow or down
+- That leg MUST still be watched. A non-blocking leg left permanently
+  red is a deleted example with extra steps
+- Check: install the project alone, then execute every file under
+  `examples/`. Pass condition — the gating leg covers at least one file
+  and every file it runs exits zero
+
+
 <!-- templates/stack/nodejs-lib.md -->
 # Stack — Node.js Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/core/examples.md]
 
 A Node.js library or CLI tool written in TypeScript. Intended to be
 published to npm or used as a shared internal package. No web server,
@@ -2361,6 +2485,9 @@ src/
   types.ts                   # shared TypeScript types and interfaces
 tests/
   [module].test.ts
+examples/
+  README.md                  # index — command and real output per example
+  [pattern].mjs              # runnable against the built package
 dist/                        # build output — gitignored
 tsconfig.json
 tsconfig.build.json          # excludes tests from the build output
@@ -2444,6 +2571,26 @@ CLAUDE.md
 - Component test naming: `<function>_<state>_<expected>`
   e.g. `parseConfig_missingRequiredField_throwsValidationError`
 - Run before every commit: `npm test && tsc --noEmit`
+
+---
+
+## Examples
+[ID: nodejs-lib-examples]
+[EXTEND: base-examples]
+
+- Examples MUST run against the built package, not raw TypeScript. A
+  consumer who installed from npm has no `tsx` or `ts-node`, so an
+  example written in `.ts` is unrunnable for the reader it is written
+  for. Ship `.mjs` importing the package by name, or compile the
+  examples in the smoke job before running them
+- `examples/` MUST be excluded from the published package. The `files`
+  field in `package.json` is an allowlist — a directory absent from it
+  is already excluded, and `npm pack --dry-run` lists what would ship
+- Smoke check: pack and install the tarball into a clean directory —
+  `npm pack`, then `npm install <tarball>` — and run each example
+  against it. Installing the workspace with `--omit=dev` is the weaker
+  form: it proves the example runs beside the source tree, not against
+  what npm serves
 
 ---
 

--- a/templates/manifest.yaml
+++ b/templates/manifest.yaml
@@ -311,6 +311,7 @@ stacks:
       - base-quality
       - base-testing
       - base-quality-gates
+      - base-examples
 
   - id: stack-go-service
     file: templates/stack/go-service.md
@@ -422,6 +423,7 @@ stacks:
       - base-docs
       - base-quality
       - base-typescript
+      - base-examples
 
   - id: stack-c-embedded
     file: templates/stack/c-embedded.md

--- a/templates/stack/go-lib.md
+++ b/templates/stack/go-lib.md
@@ -1,5 +1,5 @@
 # Stack — Go Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/core/testing.md, templates/base/workflow/quality-gates.md, templates/base/core/examples.md]
 
 Base Go conventions for any Go module — library, CLI tool, or service.
 Never used directly for services — always extended by
@@ -69,6 +69,25 @@ no HTTP layer.
 - Component test naming: `Test<UnitOfWork>_<State>_<Expected>`
   e.g. `TestParseConfig_MissingField_ReturnsError`
 - Run before every commit: `go test ./... && go vet ./...`
+
+---
+
+## Examples
+[ID: go-lib-examples]
+[EXTEND: base-examples]
+
+- Prefer `Example` functions in `_test.go` with an `// Output:` comment.
+  `go test` compares the comment against what the function prints, so
+  the real-output rule is machine-checked rather than reviewed, and the
+  example cannot rot silently
+- Reach for a standalone `examples/` directory only for what an
+  `Example` function cannot carry — a multi-file program, a CLI
+  invocation, a flag-driven journey
+- Each program under `examples/` MUST be `package main`, so it cannot
+  be imported as library API and cannot widen the module's surface
+- Smoke check: `go vet ./... && go test ./...` covers the `Example`
+  functions; `go run ./examples/<name>` covers the directory. Pass
+  condition — every program exits zero
 
 ---
 

--- a/templates/stack/nodejs-lib.md
+++ b/templates/stack/nodejs-lib.md
@@ -1,5 +1,5 @@
 # Stack — Node.js Library / CLI
-[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md]
+[DEPENDS ON: templates/base/core/git.md, templates/base/core/docs.md, templates/base/core/quality.md, templates/base/language/typescript.md, templates/base/core/examples.md]
 
 A Node.js library or CLI tool written in TypeScript. Intended to be
 published to npm or used as a shared internal package. No web server,
@@ -33,6 +33,9 @@ src/
   types.ts                   # shared TypeScript types and interfaces
 tests/
   [module].test.ts
+examples/
+  README.md                  # index — command and real output per example
+  [pattern].mjs              # runnable against the built package
 dist/                        # build output — gitignored
 tsconfig.json
 tsconfig.build.json          # excludes tests from the build output
@@ -116,6 +119,26 @@ CLAUDE.md
 - Component test naming: `<function>_<state>_<expected>`
   e.g. `parseConfig_missingRequiredField_throwsValidationError`
 - Run before every commit: `npm test && tsc --noEmit`
+
+---
+
+## Examples
+[ID: nodejs-lib-examples]
+[EXTEND: base-examples]
+
+- Examples MUST run against the built package, not raw TypeScript. A
+  consumer who installed from npm has no `tsx` or `ts-node`, so an
+  example written in `.ts` is unrunnable for the reader it is written
+  for. Ship `.mjs` importing the package by name, or compile the
+  examples in the smoke job before running them
+- `examples/` MUST be excluded from the published package. The `files`
+  field in `package.json` is an allowlist — a directory absent from it
+  is already excluded, and `npm pack --dry-run` lists what would ship
+- Smoke check: pack and install the tarball into a clean directory —
+  `npm pack`, then `npm install <tarball>` — and run each example
+  against it. Installing the workspace with `--omit=dev` is the weaker
+  form: it proves the example runs beside the source tree, not against
+  what npm serves
 
 ---
 


### PR DESCRIPTION
## Why

`base-examples` landed in #990 with only `stack-python-lib` declaring it.
The other two library-layer stacks were left ungoverned — the half-governed
state ADR-025 names in its Context and defers to follow-up.

## What changed

- `stack/go-lib.md` — `[ID: go-lib-examples]`, `[EXTEND: base-examples]`
- `stack/nodejs-lib.md` — `[ID: nodejs-lib-examples]`,
  `[EXTEND: base-examples]`, plus `examples/` in the structure tree
- `[DEPENDS ON: ...]` headers and `templates/manifest.yaml` `depends_on`
  for both, kept in step (SYS-04)
- `docs/SPEC.md` and 17 `generated/*.md` — `py tools/sync.py`

No new ADR: ADR-025 already decided the mechanism and recorded this
adoption as follow-up.

### Language residue, not a copy of the base rules

**Go** — `Example` functions in `_test.go` with an `// Output:` comment are
the idiomatic form, and `go test` compares the comment against what the
function prints. That machine-checks the real-output rule instead of leaving
it to review, which is stronger than anything the base template can require.
A standalone `examples/` directory is for what an `Example` function cannot
carry, and each program in it MUST be `package main` so it cannot widen the
module's importable surface.

**Node** — an example MUST run against the built package. A consumer who
installed from npm has no `tsx` or `ts-node`, so an example written in `.ts`
is unrunnable for exactly the reader it is written for. Exclusion from the
published package is the `files` allowlist in `package.json`, not a wheel
exclude, and `npm pack --dry-run` is what shows the truth. The smoke check
packs and installs the tarball; installing the workspace with `--omit=dev`
is named as the weaker form and why.

## Reach — worth a reviewer's attention

Service stacks inherit from library stacks (`stack-python-service` →
`stack-python-lib`, `stack-go-service` → `stack-go-lib`), so this
propagates further than the two files it edits:

| Stack | Resolves `base-examples` | Source |
| -- | -- | -- |
| python-lib, python-service, flask, fastapi, django, grpc-python | yes | #990, via the `stack-python-lib` edge |
| go-lib, go-service, go-echo, grpc-go, nodejs-lib | yes | this PR |
| node-express, node-nestjs, htmx, static-site-astro, static-site-tutorial, c-embedded | no | — |

11 of 17 stacks, 6 of which predate this PR — the python-service edge carried
`base-examples` to the Python web stacks the moment #990 merged, which was
not called out at the time.

That reach is safe by construction, and the second commit of #990 is why:

- The rules apply only where an `examples/` directory exists. A stack
  declaring `base-examples` mandates nothing on a project that ships none
- `base-examples-offline` means *no host outside the project* — a service's
  examples running against its own localhost or its own compose stack comply
  as written
- `base-examples-offline-exception` covers the case where a third-party
  service genuinely cannot be sealed behind a seam

Had this landed against the first draft's absolute no-network reading, the
same propagation would have handed every FastAPI and Go service project an
unsatisfiable rule.

## Verification

```
py tools/sync.py --check               All files in sync.
py tools/audit_redundancy.py --check   OK: no new exact in-chain duplicates
py tests/run_smoke.py                  23 checks — 23 passed  0 failed  0 errors
py tools/resolve.py stack-go-lib       base/core/examples.md in the chain
py tools/resolve.py stack-nodejs-lib   base/core/examples.md in the chain
```

SYS-04 (headers match manifest) and the EXTEND-target reachability checks
both pass — `[EXTEND: base-examples]` resolves in each chain only because the
`depends_on` edge was added alongside it.

## Issues

Closes #991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
